### PR TITLE
Fixed SPC 2.10_2 compatibility

### DIFF
--- a/src/main/java/com/sk89q/worldedit/LocalWorld.java
+++ b/src/main/java/com/sk89q/worldedit/LocalWorld.java
@@ -94,7 +94,11 @@ public abstract class LocalWorld {
      * @param data
      * @return
      */
-    public abstract boolean setTypeIdAndData(Vector pt, int type, int data);
+    public boolean setTypeIdAndData(Vector pt, int type, int data) {
+        boolean ret = setBlockType(pt, type);
+        setBlockData(pt, data);
+        return ret;
+    }
     
     /**
      * set block type & data
@@ -103,7 +107,11 @@ public abstract class LocalWorld {
      * @param data
      * @return 
      */
-    public abstract boolean setTypeIdAndDataFast(Vector pt, int type, int data);
+    public boolean setTypeIdAndDataFast(Vector pt, int type, int data) {
+        boolean ret = setBlockTypeFast(pt, type);
+        setBlockDataFast(pt, data);
+        return ret;
+    }
     
     /**
      * Get block data.


### PR DESCRIPTION
setTypeIdAndData in LocalWorld is no longer abstract - it now defaults to calling setBlockType and setBlockData. Restores compatibility with SinglePlayerCommands 2.10_2.

This may not be the only change needed for complete compatibility, but most functionality now seems to be restored.

Bukkit should not be affected, as the changed methods are overridden in BukkitWorld anyway.
