### PR TITLE
Fixes missing blocks along some polygonal edges

### DIFF
--- a/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegion.java
+++ b/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegion.java
@@ -327,7 +327,8 @@ public class Polygonal2DRegion implements Region {
                 z2 = zOld;
             }
             if (x1 <= targetX && targetX <= x2) {
-                crossproduct = ((long) targetZ - (long) z1) * (long) (x2 - x1) - ((long) z2 - (long) z1) * (long) (targetX - x1);
+                crossproduct = ((long) targetZ - (long) z1) * (long) (x2 - x1)
+                    - ((long) z2 - (long) z1) * (long) (targetX - x1);
                 if (crossproduct == 0) {
                     if ((z1 <= targetZ) == (targetZ <= z2)) return true; //on edge
                 } else if (crossproduct < 0 && (x1 != targetX)) {


### PR DESCRIPTION
In cases where our polygon edge runs exactly horizontal, vertical or perfectly diagonal (1:1); the selection will be missing some blocks along the north (-X) or east (-Z) edge.

This occurs when the cross-product (already computed) is exactly 0. We have to do an extra check to make sure the point is within the bounds of the line on both axis.

The code will work exactly the same for WorldGuard's region protection.
