### PR TITLE
Fix dinnerperms wildcard matching & group enumeration.

### DIFF
--- a/src/main/java/com/sk89q/bukkit/migration/DinnerPermsResolver.java
+++ b/src/main/java/com/sk89q/bukkit/migration/DinnerPermsResolver.java
@@ -26,16 +26,11 @@ public class DinnerPermsResolver implements PermissionsResolver {
             return false; // Permissions are only registered for online players
         if ( player.hasPermission("*")  || player.hasPermission(permission))
             return true;
-        int i = 0;
-        while (i <= permission.length() + 1) {
-            int dotPos = permission.indexOf(".", i);
-            if (dotPos > -1) {
-                if (player.hasPermission(permission.substring(0, dotPos + 1) + "*"))
-                    return true;
-                i += dotPos;
-            } else {
-                break;
-            }
+        int dotPos = permission.lastIndexOf(".");
+        while (dotPos > -1) {
+            if (player.hasPermission(permission.substring(0, dotPos + 1) + "*"))
+                return true;
+            dotPos = permission.lastIndexOf(".", dotPos - 1);
         }
         return false;
     }
@@ -58,7 +53,7 @@ public class DinnerPermsResolver implements PermissionsResolver {
         List<String> groupNames = new ArrayList<String>();
         for (PermissionAttachmentInfo permAttach : player.getEffectivePermissions()) {
             String perm = permAttach.getPermission();
-            if (!perm.startsWith(GROUP_PREFIX))
+            if (!perm.startsWith(GROUP_PREFIX) || !permAttach.getValue())
                 continue;
             groupNames.add(perm.substring(GROUP_PREFIX.length(), perm.length()));
         }


### PR DESCRIPTION
Given a permission such as "worldguard.region.select.own.myregion," the code would only check the following (Bukkit) permissions:
- worldguard.*
- worldguard.*
- worldguard.region.select.*

I fixed it up so it will now check (in this order):
- worldguard.region.select.own.*
- worldguard.region.select.*
- worldguard.region.*
- worldguard.*

Also, I added a check in getGroups() to make sure the "group.&lt;groupname>" permission was actually true. Not sure if something like that is actually needed, but I guess it would be nice to negate inherited groups now and then.
