### PR TITLE
Fix data of blocks when doing negative rotations

### DIFF
--- a/src/main/java/com/sk89q/worldedit/CuboidClipboard.java
+++ b/src/main/java/com/sk89q/worldedit/CuboidClipboard.java
@@ -126,7 +126,7 @@ public class CuboidClipboard {
             return;
         }
         boolean reverse = angle < 0;
-        int numRotations = (int)Math.floor(angle / 90.0);
+        int numRotations = Math.abs((int)Math.floor(angle / 90.0));
 
         int width = getWidth();
         int length = getLength();


### PR DESCRIPTION
Negative angles will return negative number of rotations thus never looping the rotation.
