### PR TITLE
Add SSL to GitHub URL and new forum link

### DIFF
--- a/craftscripts/SUBMITTING.txt
+++ b/craftscripts/SUBMITTING.txt
@@ -1,5 +1,5 @@
 Write a cool script? Send it to sk89q (somehow) or you can submit a pull
-request on http://github.com/sk89q/worldedit. He will consider your script
+request on https://github.com/sk89q/worldedit. He will consider your script
 for inclusion in WorldEdit releases. Please license your script with a
 permissive open source license such as GPLv2, MIT, BSD, WTFPL, etc.
 
@@ -7,4 +7,4 @@ Note: Legally you should not release things to the public domain as not
 all countries have the concept of public domain in their copyright law.
 
 You can also post your scripts here:
-http://forum.sk89q.com/viewforum.php?f=11
+http://forum.sk89q.com/forums/craftscripts.6/


### PR DESCRIPTION
Minor edits to [craftscripts/SUBMITTING.txt](https://github.com/sk89q/worldedit/blob/master/craftscripts/SUBMITTING.txt)

Forum thread at the bottom is outdated, so I updated it to the [subforum](http://forum.sk89q.com/forums/craftscripts.6/). Also, I changed the repository URL to use HTTPS (I know GitHub uses it at all times anyways).
