### PR TITLE
Fixed using zip file snapshots for some cases

### DIFF
--- a/src/main/java/com/sk89q/worldedit/data/TrueZipMcRegionChunkStore.java
+++ b/src/main/java/com/sk89q/worldedit/data/TrueZipMcRegionChunkStore.java
@@ -97,20 +97,14 @@ public class TrueZipMcRegionChunkStore extends McRegionChunkStore {
                 name = folder + "/" + name;
             }
         } else {
-            Pattern pattern = Pattern.compile(".*\\.mcr$");
-            // World pattern
-            Pattern worldPattern = Pattern.compile(worldname + "\\$");
+            Pattern pattern = Pattern.compile("^" + worldname + "/region/.*\\.mcr$");
             for (Enumeration<? extends ZipEntry> e = zip.entries();
                     e.hasMoreElements();) {
                 ZipEntry testEntry = (ZipEntry) e.nextElement();
-                // Check for world
-                if (worldPattern.matcher(worldname).matches()) {
-                    // Check for file
-                    if (pattern.matcher(testEntry.getName()).matches()) {
-                        folder = testEntry.getName().substring(0, testEntry.getName().lastIndexOf("/"));
-                        name = folder + "/" + name;
-                        break;
-                    }
+                if (pattern.matcher(testEntry.getName()).matches()) {
+                    folder = testEntry.getName().substring(0, testEntry.getName().lastIndexOf("/"));
+                    name = folder + "/" + name;
+                    break;
                 }
             }
 

--- a/src/main/java/com/sk89q/worldedit/data/ZippedMcRegionChunkStore.java
+++ b/src/main/java/com/sk89q/worldedit/data/ZippedMcRegionChunkStore.java
@@ -94,18 +94,14 @@ public class ZippedMcRegionChunkStore extends McRegionChunkStore {
                 name = folder + "/" + name;
             }
         } else {
-            Pattern pattern = Pattern.compile(".*\\.mcr$");
+            Pattern pattern = Pattern.compile("^" + worldname + "/region/.*\\.mcr$");
             for (Enumeration<? extends ZipEntry> e = zip.entries();
                     e.hasMoreElements();) {
                 ZipEntry testEntry = (ZipEntry) e.nextElement();
-                // Check for world
-                if (testEntry.getName().startsWith(worldname + "/")) {
-                    if (pattern.matcher(testEntry.getName()).matches()) {
-                        folder = testEntry.getName().substring(0, testEntry.getName().lastIndexOf("/"));
-                        name = folder + "/" + name;
-                        break;
-                    }
-                    
+                if (pattern.matcher(testEntry.getName()).matches()) {
+                    folder = testEntry.getName().substring(0, testEntry.getName().lastIndexOf("/"));
+                    name = folder + "/" + name;
+                    break;
                 }
             }
             


### PR DESCRIPTION
If you had some <date>.zip/<world>/DIM-#/r.(…).mcr files within your
backup, worldedit found this folder as chunk folder first, saving it
and using it for all its restore attempts - which then failed for
sure...
