### PR TITLE
Adding support for natural directions

### DIFF
--- a/src/main/java/com/sk89q/worldedit/LocalConfiguration.java
+++ b/src/main/java/com/sk89q/worldedit/LocalConfiguration.java
@@ -101,6 +101,7 @@ public abstract class LocalConfiguration {
     public String saveDir = "schematics";
     public String scriptsDir = "craftscripts";
     public boolean showFirstUseVersion = true;
+    public boolean naturalDirections = false;
 
     /**
      * Loads the configuration.

--- a/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -74,7 +74,7 @@ public class LocalSession {
     private boolean fastMode = false;
     private Mask mask;
     private TimeZone timezone = TimeZone.getDefault();
-
+    
     /**
      * Construct the object.
      *
@@ -664,6 +664,24 @@ public class LocalSession {
      */
     public void setFastMode(boolean fastMode) {
         this.fastMode = fastMode;
+    }
+    
+    /**
+     * Checks if the session has natural directions enabled.
+     * 
+     * @return
+     */
+    public boolean hasNaturalDirections() {
+    	return config.naturalDirections;
+    }
+    
+    /** 
+     * Set direction mode
+     * 
+     * @param naturalDirections
+     */
+    public void setNaturalDirections(boolean naturalDirections) {
+    	config.naturalDirections = naturalDirections;
     }
 
     /**

--- a/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -820,10 +820,34 @@ public class WorldEdit {
         }
     }
 
+    private char getActualDirection(char direction) {
+    	if (!config.naturalDirections) return direction;
+    	char newDirection;
+    	switch (direction) {
+    	case 'n':
+    		newDirection = 'e';
+    		break;
+    	case 'w':
+    		newDirection = 'n';
+    		break;
+    	case 's':
+    		newDirection = 'w';
+    		break;
+    	case 'e':
+    		newDirection = 's';
+    		break;
+    	default:
+    		newDirection = direction;
+    	}
+    	return newDirection;
+    }
+    
     private PlayerDirection getPlayerDirection(LocalPlayer player, String dirStr) throws UnknownDirectionException {
         final PlayerDirection dir;
-
-        switch (dirStr.charAt(0)) {
+        
+        char direction = getActualDirection(dirStr.charAt(0));
+        
+        switch (direction) {
         case 'w':
             dir = PlayerDirection.WEST;
             break;

--- a/src/main/java/com/sk89q/worldedit/bukkit/BukkitConfiguration.java
+++ b/src/main/java/com/sk89q/worldedit/bukkit/BukkitConfiguration.java
@@ -88,6 +88,8 @@ public class BukkitConfiguration extends LocalConfiguration {
         allowedDataCycleBlocks = new HashSet<Integer>(config.getIntList("limits.allowed-data-cycle-blocks", null));
 
         noOpPermissions = config.getBoolean("no-op-permissions", false);
+        naturalDirections = config.getBoolean("natural-directions", naturalDirections);
+
 
         LocalSession.MAX_HISTORY_SIZE = Math.max(0, config.getInt("history.size", 15));
         LocalSession.EXPIRATION_GRACE = config.getInt("history.expiration", 10) * 60 * 1000;

--- a/src/main/java/com/sk89q/worldedit/commands/GeneralCommands.java
+++ b/src/main/java/com/sk89q/worldedit/commands/GeneralCommands.java
@@ -226,4 +226,35 @@ public class GeneralCommands {
     public void we(CommandContext args, LocalSession session, LocalPlayer player,
             EditSession editSession) throws WorldEditException {
     }
+    
+    @Command(
+            aliases = { "/ndirections" },
+            usage = "[on|off]",
+            desc = "Toggle natural directions (sun rises in the east)",
+            min = 0,
+            max = 1
+        )
+    @CommandPermissions("worldedit.ndirections")
+    public void ndirections(CommandContext args, LocalSession session, LocalPlayer player,
+            EditSession editSession) throws WorldEditException {
+
+    	String newState = args.getString(0, null);
+        if (session.hasNaturalDirections()) {
+            if ("on".equals(newState)) {
+                player.printError("Natural directions already enabled.");
+                return;
+            }
+
+            session.setNaturalDirections(false);
+            player.print("Natural directions disabled.");
+        } else {
+            if ("off".equals(newState)) {
+                player.printError("Natural directions already disabled.");
+                return;
+            }
+
+            session.setNaturalDirections(true);
+            player.print("Natural directions enabled. The sun now rises in the East and sets in the West.");
+        }
+    }
 }

--- a/src/main/java/com/sk89q/worldedit/util/PropertiesConfiguration.java
+++ b/src/main/java/com/sk89q/worldedit/util/PropertiesConfiguration.java
@@ -89,6 +89,7 @@ public class PropertiesConfiguration extends LocalConfiguration {
         navigationWand = getInt("nav-wand-item", navigationWand);
         navigationWandMaxDistance = getInt("nav-wand-distance", navigationWandMaxDistance);
         scriptTimeout = getInt("scripting-timeout", scriptTimeout);
+        naturalDirections = getBool("natural-directions", naturalDirections);
 
         LocalSession.MAX_HISTORY_SIZE = Math.max(15, getInt("history-size", 15));
 


### PR DESCRIPTION
Hey guys,

I noticed when playing with WorldEdit and Rei's MiniMap that the directions didn't line up, that WorldEdit is using the pre-Beta 1.9 prerelease 4 behavior of the sun rising in the North. Personally I wanted to see the `//expand` and similar commands work with the minimap, so I implemented a "Natural Directions" command in WorldEdit to toggle between the classic behavior and the more natural behavior. I default it to off so when adding the command the users should (hopefully) not see any difference unless they do a `//ndirections on` or set `natural-directions=true` in the `worldedit.properties` file.

I'm not super familiar with the Bukkit/WorldEdit code bases yet so I may have missed something, but from my testing in single player mode it works like a champ. Feel free to merge it, steal it, or ignore it at your leisure.

Happy coding,

bratta
