### PR TITLE
Improve zip file recognition.

### DIFF
--- a/src/main/java/com/sk89q/worldedit/snapshots/Snapshot.java
+++ b/src/main/java/com/sk89q/worldedit/snapshots/Snapshot.java
@@ -131,7 +131,7 @@ public class Snapshot implements Comparable<Snapshot> {
         try {
             if (file.getName().toLowerCase().endsWith(".zip")) {
                 ZipFile entry = new ZipFile(file);
-                return entry.getEntry(worldname) != null;
+                return entry.getEntry(worldname + "/level.dat") != null;
             } else if (file.getName().toLowerCase().endsWith(".tar.bz2")
                     || file.getName().toLowerCase().endsWith(".tar.gz")
                     || file.getName().toLowerCase().endsWith(".tar")) {


### PR DESCRIPTION
Look for world/level.dat because some zip file generators do not include
entries for directories by themselves.
