### PR TITLE
Allow conversion from an old region to ellipsoid when using //sel.

### DIFF
--- a/src/main/java/com/sk89q/worldedit/regions/EllipsoidRegionSelector.java
+++ b/src/main/java/com/sk89q/worldedit/regions/EllipsoidRegionSelector.java
@@ -53,20 +53,21 @@ public class EllipsoidRegionSelector implements RegionSelector, CUIRegion {
             final EllipsoidRegionSelector ellipsoidRegionSelector = (EllipsoidRegionSelector) oldSelector;
 
             region = new EllipsoidRegion(ellipsoidRegionSelector.getIncompleteRegion());
-        }/* else {
-            final Region oldRegion;
+        } else {
+            Region oldRegion = null;
             try {
                 oldRegion = oldSelector.getRegion();
             } catch (IncompleteRegionException e) {
                 return;
             }
 
-            pos1 = oldRegion.getMinimumPoint().toBlockVector();
-            pos2 = oldRegion.getMaximumPoint().toBlockVector();
+            BlockVector pos1 = oldRegion.getMinimumPoint().toBlockVector();
+            BlockVector pos2 = oldRegion.getMaximumPoint().toBlockVector();
+            
+            Vector center = pos1.add(pos2).divide(2).floor();
+            region.setCenter(center);
+            region.setRadius(pos2.subtract(center));
         }
-
-        region.setPos1(pos1);
-        region.setPos2(pos2);*/
     }
 
     public boolean selectPrimary(Vector pos) {


### PR DESCRIPTION
This converts a cuboid, poly, etc region to an ellipsoid when you use //sel ellipsoid. If you have a cuboid region for example, and you so //sel ellipsoid, it will make an ellipsoid that fits inside that region. Questions? Ask in #sk-dev.
