### PR TITLE
Fix NPE in CylinderRegion

### DIFF
--- a/src/main/java/com/sk89q/worldedit/regions/CylinderRegion.java
+++ b/src/main/java/com/sk89q/worldedit/regions/CylinderRegion.java
@@ -66,7 +66,7 @@ public class CylinderRegion extends AbstractRegion {
      */
     public CylinderRegion(LocalWorld world, Vector center, Vector2D radius, int minY, int maxY) {
         super(world);
-        this.center = center;
+        setCenter(center);
         setRadius(radius);
         this.minY = minY;
         this.maxY = maxY;


### PR DESCRIPTION
The default ctor of CylinderRegion does not initialize the center2D field which can cause NPE exception when using some methods like getMaximumPoint().
