### PR TITLE
Fix to replace() call in StringUtil.lookup()

### DIFF
--- a/src/main/java/com/sk89q/util/StringUtil.java
+++ b/src/main/java/com/sk89q/util/StringUtil.java
@@ -273,7 +273,7 @@ public class StringUtil {
     }
 
     public static <T extends Enum<?>> T lookup(Map<String, T> lookup, String name, boolean fuzzy) {
-        String testName = name.replace("[ _]", "").toLowerCase();
+        String testName = name.replaceAll("[ _]", "").toLowerCase();
 
         T type = lookup.get(testName);
         if (type != null) {


### PR DESCRIPTION
Feel free to shoot this down, but it looks like the replace() call in StringUtil.lookup() should really be replaceAll(). "[ _]" looks like a regular expression to me, and one that makes sense.
