### PR TITLE
HorizontalRegion

### DIFF
--- a/src/main/java/com/sk89q/worldedit/regions/CuboidRegion.java
+++ b/src/main/java/com/sk89q/worldedit/regions/CuboidRegion.java
@@ -32,7 +32,7 @@ import java.util.HashSet;
  *
  * @author sk89q
  */
-public class CuboidRegion extends AbstractRegion {
+public class CuboidRegion extends AbstractRegion implements FlatRegion {
     /**
      * Store the first point.
      */
@@ -367,6 +367,16 @@ public class CuboidRegion extends AbstractRegion {
 
             public void remove() {
                 throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    @Override
+    public Iterable<Vector2D> asFlatRegion() {
+        return new Iterable<Vector2D>() {
+            @Override
+            public Iterator<Vector2D> iterator() {
+                return new FlatRegionIterator(CuboidRegion.this);
             }
         };
     }

--- a/src/main/java/com/sk89q/worldedit/regions/CylinderRegion.java
+++ b/src/main/java/com/sk89q/worldedit/regions/CylinderRegion.java
@@ -20,6 +20,7 @@
 package com.sk89q.worldedit.regions;
 
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
 import com.sk89q.worldedit.LocalWorld;
 import com.sk89q.worldedit.Vector;
@@ -31,7 +32,7 @@ import com.sk89q.worldedit.data.ChunkStore;
  *
  * @author yetanotherx
  */
-public class CylinderRegion extends AbstractRegion {
+public class CylinderRegion extends AbstractRegion implements FlatRegion {
     private Vector center;
     private Vector2D center2D;
     private Vector2D radius;
@@ -340,6 +341,16 @@ public class CylinderRegion extends AbstractRegion {
         }
 
         return false;
+    }
+
+    @Override
+    public Iterable<Vector2D> asFlatRegion() {
+        return new Iterable<Vector2D>() {
+            @Override
+            public Iterator<Vector2D> iterator() {
+                return new FlatRegionIterator(CylinderRegion.this);
+            }
+        };
     }
 
     /**

--- a/src/main/java/com/sk89q/worldedit/regions/FlatRegion.java
+++ b/src/main/java/com/sk89q/worldedit/regions/FlatRegion.java
@@ -1,0 +1,27 @@
+// $Id$
+/*
+ * WorldEdit
+ * Copyright (C) 2010, 2011 sk89q <http://www.sk89q.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.sk89q.worldedit.regions;
+
+import com.sk89q.worldedit.Vector2D;
+
+public interface FlatRegion extends Region {
+
+    public Iterable<Vector2D> asFlatRegion();
+}

--- a/src/main/java/com/sk89q/worldedit/regions/FlatRegionIterator.java
+++ b/src/main/java/com/sk89q/worldedit/regions/FlatRegionIterator.java
@@ -1,0 +1,97 @@
+// $Id$
+/*
+ * WorldEdit
+ * Copyright (C) 2010, 2011 sk89q <http://www.sk89q.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.sk89q.worldedit.regions;
+
+import java.util.Iterator;
+
+import com.sk89q.worldedit.Vector;
+import com.sk89q.worldedit.Vector2D;
+
+public class FlatRegionIterator implements Iterator<Vector2D>  {
+
+    private Region region;
+    private int y;
+    private int minX;
+    private int nextX;
+    private int nextZ;
+    private int maxX;
+    private int maxZ;
+
+    public FlatRegionIterator(Region region) {
+        this.region = region;
+
+        Vector min = region.getMinimumPoint();
+        Vector max = region.getMaximumPoint();
+
+        this.y = min.getBlockY();
+
+        this.minX = min.getBlockX();
+
+        this.nextX = minX;
+        this.nextZ = min.getBlockZ();
+
+        this.maxX = max.getBlockX();
+        this.maxZ = max.getBlockZ();
+
+        forward();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return nextX != Integer.MIN_VALUE;
+    }
+
+    private void forward() {
+        while (hasNext() && !region.contains(new Vector(nextX, y, nextZ))) {
+            forwardOne();
+        }
+    }
+
+    @Override
+    public Vector2D next() {
+        if (!hasNext()) {
+            throw new java.util.NoSuchElementException();
+        }
+
+        Vector2D answer = new Vector2D(nextX, nextZ);
+
+        forwardOne();
+        forward();
+
+        return answer;
+    }
+
+    private void forwardOne() {
+        if (++nextX <= maxX) {
+            return;
+        }
+        nextX = minX;
+
+        if (++nextZ <= maxZ) {
+            return;
+        }
+        nextX = Integer.MIN_VALUE;
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegion.java
+++ b/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegion.java
@@ -37,7 +37,7 @@ import com.sk89q.worldedit.data.ChunkStore;
  *
  * @author sk89q
  */
-public class Polygonal2DRegion extends AbstractRegion {
+public class Polygonal2DRegion extends AbstractRegion implements FlatRegion {
     private List<BlockVector2D> points;
     private BlockVector min;
     private BlockVector max;
@@ -467,6 +467,16 @@ public class Polygonal2DRegion extends AbstractRegion {
     @Override
     public Iterator<BlockVector> iterator() {
         return new RegionIterator(this);
+    }
+
+    @Override
+    public Iterable<Vector2D> asFlatRegion() {
+        return new Iterable<Vector2D>() {
+            @Override
+            public Iterator<Vector2D> iterator() {
+                return new FlatRegionIterator(Polygonal2DRegion.this);
+            }
+        };
     }
 
     /**


### PR DESCRIPTION
This add a common interface for horizontal region (Cuboid, Polygonal and Cylinder) with an iterator which permits to iterate through all (x, z) couple contained in the region.

It can be useful, for example, for biome manipulation which do not need y position : 
https://github.com/Bukkit/Bukkit/commit/2a310576d179815dbec826f66f548e770d5c01cd

For reference here's the test plugin i've used :
https://github.com/aumgn/WEHorizontalTest/commit/de1a26315f7bf8ceaa03f3db7bf8742d95aa2199
