### PR TITLE
Add biome support

### DIFF
--- a/src/main/java/com/sk89q/worldedit/BiomeType.java
+++ b/src/main/java/com/sk89q/worldedit/BiomeType.java
@@ -1,0 +1,43 @@
+package com.sk89q.worldedit;
+
+public class BiomeType {
+
+    private String name;
+
+    public BiomeType(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Get the name of the player.
+     *
+     * @return String
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Gets the hash code.
+     *
+     * @return hash code
+     */
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+
+    /**
+     * Returns true if equal.
+     *
+     * @param other
+     * @return whether the other object is equivalent
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof BiomeType) {
+            return ((BiomeType) obj).name.equals(name);
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/sk89q/worldedit/BiomeTypes.java
+++ b/src/main/java/com/sk89q/worldedit/BiomeTypes.java
@@ -1,0 +1,28 @@
+package com.sk89q.worldedit;
+
+import java.util.List;
+
+public interface BiomeTypes {
+
+    /**
+     * Returns if a biome with the given name is available.
+     *
+     * @param name
+     * @return
+     */
+    boolean has(String name);
+
+    /**
+     * Returns the biome type for the given name
+     *
+     * @return
+     */
+    BiomeType get(String name) throws UnknownBiomeTypeException;
+
+    /**
+     * Returns a list of all available biome types.
+     *
+     * @return
+     */
+    List<BiomeType> all();
+}

--- a/src/main/java/com/sk89q/worldedit/LocalWorld.java
+++ b/src/main/java/com/sk89q/worldedit/LocalWorld.java
@@ -103,6 +103,14 @@ public abstract class LocalWorld {
     public abstract void setBlockDataFast(Vector pt, int data);
 
     /**
+     * Get biome type
+     *
+     * @param pt
+     * @return
+     */
+    public abstract BiomeType getBiome(Vector2D pt);
+
+    /**
      * set block type & data
      * @param pt
      * @param type

--- a/src/main/java/com/sk89q/worldedit/ServerInterface.java
+++ b/src/main/java/com/sk89q/worldedit/ServerInterface.java
@@ -52,6 +52,13 @@ public abstract class ServerInterface {
     public abstract void reload();
 
     /**
+     * Returns all available biomes.
+     *
+     * @return
+     */
+    public abstract BiomeTypes getBiomes();
+
+    /**
      * Schedules the given <code>task</code> to be invoked once every <code>period</code> ticks
      * after an initial delay of <code>delay</code> ticks.
      *

--- a/src/main/java/com/sk89q/worldedit/UnknownBiomeTypeException.java
+++ b/src/main/java/com/sk89q/worldedit/UnknownBiomeTypeException.java
@@ -1,0 +1,17 @@
+package com.sk89q.worldedit;
+
+public class UnknownBiomeTypeException extends WorldEditException {
+    private static final long serialVersionUID = -6239229394330814896L;
+
+    private String typeName;
+
+    public UnknownBiomeTypeException(String typeName) {
+        super("Unknown " + typeName + " biome type.");
+        this.typeName = typeName;
+    }
+
+    public String getTypeName() {
+        return typeName;
+    }
+
+}

--- a/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -185,6 +185,7 @@ public class WorldEdit {
 
         commands.setInjector(new SimpleInjector(this));
 
+        server.onCommandRegistration(commands.registerAndReturn(BiomeCommands.class), commands);
         server.onCommandRegistration(commands.registerAndReturn(ChunkCommands.class), commands);
         server.onCommandRegistration(commands.registerAndReturn(ClipboardCommands.class), commands);
         server.onCommandRegistration(commands.registerAndReturn(GeneralCommands.class), commands);
@@ -589,7 +590,7 @@ public class WorldEdit {
         }
     }
 
-    private Mask getBlockMaskComponent(LocalPlayer player, LocalSession session, List<Mask> masks, String component) throws IncompleteRegionException, UnknownItemException, DisallowedItemException {
+    private Mask getBlockMaskComponent(LocalPlayer player, LocalSession session, List<Mask> masks, String component) throws WorldEditException {
         final char firstChar = component.charAt(0);
         switch (firstChar) {
         case '#':
@@ -630,6 +631,15 @@ public class WorldEdit {
             }
 
             return new UnderOverlayMask(ids, over);
+
+        case '$':
+            Set<BiomeType> biomes = new HashSet<BiomeType>();
+            String[] biomesList = component.substring(1).split(",");
+            for (String biomeName : biomesList) {
+                BiomeType biome = server.getBiomes().get(biomeName);
+                biomes.add(biome);
+            }
+            return new BiomeTypeMask(biomes);
 
         case '!':
             if (component.length() > 1) {

--- a/src/main/java/com/sk89q/worldedit/bukkit/BukkitBiomeTypes.java
+++ b/src/main/java/com/sk89q/worldedit/bukkit/BukkitBiomeTypes.java
@@ -1,0 +1,47 @@
+package com.sk89q.worldedit.bukkit;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import org.bukkit.block.Biome;
+
+import com.sk89q.worldedit.BiomeType;
+import com.sk89q.worldedit.BiomeTypes;
+import com.sk89q.worldedit.UnknownBiomeTypeException;
+
+public class BukkitBiomeTypes implements BiomeTypes {
+
+    public BukkitBiomeTypes() {
+    }
+
+    @Override
+    public boolean has(String name) {
+        try {
+            Biome.valueOf(name.toUpperCase(Locale.ENGLISH));
+            return true;
+        } catch (IllegalArgumentException exc) {
+            return false;
+        }
+    }
+
+    @Override
+    public BiomeType get(String name) throws UnknownBiomeTypeException {
+        try {
+            Biome biome = Biome.valueOf(name.toUpperCase(Locale.ENGLISH));
+            return new BiomeType(biome.name());
+        } catch (IllegalArgumentException exc) {
+            throw new UnknownBiomeTypeException(name);
+        }
+    }
+
+    @Override
+    public List<BiomeType> all() {
+        List<BiomeType> biomes = new ArrayList<BiomeType>();
+        for (Biome biome : Biome.values()) {
+            biomes.add(new BiomeType(biome.name()));
+        }
+        return biomes;
+    }
+
+}

--- a/src/main/java/com/sk89q/worldedit/bukkit/BukkitServerInterface.java
+++ b/src/main/java/com/sk89q/worldedit/bukkit/BukkitServerInterface.java
@@ -36,6 +36,7 @@ import org.bukkit.Server;
 import org.bukkit.World;
 import org.bukkit.entity.EntityType;
 
+import com.sk89q.worldedit.BiomeTypes;
 import com.sk89q.worldedit.LocalWorld;
 import com.sk89q.worldedit.ServerInterface;
 
@@ -43,10 +44,12 @@ public class BukkitServerInterface extends ServerInterface {
     public Server server;
     public WorldEditPlugin plugin;
     private CommandRegistration dynamicCommands;
+    private BukkitBiomeTypes biomes;
 
     public BukkitServerInterface(WorldEditPlugin plugin, Server server) {
         this.plugin = plugin;
         this.server = server;
+        this.biomes = new BukkitBiomeTypes();
         dynamicCommands = new CommandRegistration(plugin);
     }
 
@@ -65,6 +68,11 @@ public class BukkitServerInterface extends ServerInterface {
     @Override
     public void reload() {
         plugin.loadConfiguration();
+    }
+
+    @Override
+    public BiomeTypes getBiomes() {
+        return biomes;
     }
 
     @Override

--- a/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
+++ b/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.util.TreeGenerator;
+import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Furnace;
@@ -52,6 +53,7 @@ import org.bukkit.Material;
 import org.bukkit.TreeType;
 import org.bukkit.World;
 
+import com.sk89q.worldedit.BiomeType;
 import com.sk89q.worldedit.BlockVector2D;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.LocalWorld;
@@ -192,6 +194,17 @@ public class BukkitWorld extends LocalWorld {
     @Override
     public int getBlockLightLevel(Vector pt) {
         return world.getBlockAt(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ()).getLightLevel();
+    }
+
+    /**
+     * Get biome type
+     *
+     * @param pt
+     * @return
+     */
+    public BiomeType getBiome(Vector2D pt) {
+        Biome bukkitBiome = world.getBiome(pt.getBlockX(), pt.getBlockZ());
+        return new BiomeType(bukkitBiome.name());
     }
 
     /**

--- a/src/main/java/com/sk89q/worldedit/commands/BiomeCommands.java
+++ b/src/main/java/com/sk89q/worldedit/commands/BiomeCommands.java
@@ -1,0 +1,119 @@
+package com.sk89q.worldedit.commands;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.sk89q.minecraft.util.commands.Command;
+import com.sk89q.minecraft.util.commands.CommandContext;
+import com.sk89q.minecraft.util.commands.CommandPermissions;
+import com.sk89q.worldedit.BiomeType;
+import com.sk89q.worldedit.EditSession;
+import com.sk89q.worldedit.LocalPlayer;
+import com.sk89q.worldedit.LocalSession;
+import com.sk89q.worldedit.LocalWorld;
+import com.sk89q.worldedit.Vector;
+import com.sk89q.worldedit.Vector2D;
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.WorldEditException;
+import com.sk89q.worldedit.regions.FlatRegion;
+import com.sk89q.worldedit.regions.Region;
+
+public class BiomeCommands {
+
+    private WorldEdit we;
+
+    public BiomeCommands(WorldEdit we) {
+        this.we = we;
+    }
+
+    @Command(
+        aliases = { "biomelist", "biomels" },
+        usage = "[page]",
+        desc = "Gets all biomes available.",
+        min = 0,
+        max = 1
+    )
+    @CommandPermissions("worldedit.biome.list")
+    public void biomeList(CommandContext args, LocalSession session, LocalPlayer player,
+            EditSession editSession) throws WorldEditException {
+
+        int page;
+        int offset;
+        int count = 0;
+
+        if (args.argsLength() == 0 || (page = args.getInteger(0)) < 2) {
+            page = 1;
+            offset = 0;
+        } else {
+            offset = (page - 1) * 19;
+        }
+
+        List<BiomeType> biomes = we.getServer().getBiomes().all();
+        int totalPages = biomes.size() / 19 + 1;
+        player.print("Available Biomes (page " + page + "/" + totalPages + ") :");
+        for (BiomeType biome : biomes) {
+            if (offset > 0) {
+                offset--;
+            } else {
+                player.print(" " + biome.getName());
+                if (++count == 19) {
+                    break;
+                }
+            }
+        }
+    }
+
+    @Command(
+        aliases = { "biomeinfo" },
+        usage = "",
+        flags = "ts",
+        desc = "Get the biome of the targeted block.",
+        help =
+            "Get the biome of the block.\n" +
+            "By default use the block you are currently in.\n" +
+            "-t use the block you are looking at.\n" +
+            "-s use all the blocks contained in your selection",
+        min = 0,
+        max = 0
+    )
+    @CommandPermissions("worldedit.biome.info")
+    public void biomeInfo(CommandContext args, LocalSession session, LocalPlayer player,
+            EditSession editSession) throws WorldEditException {
+
+        if (args.hasFlag('s')) {
+            LocalWorld world = player.getWorld();
+            Region region = session.getSelection(world);
+            Set<BiomeType> biomes = new HashSet<BiomeType>();
+
+            if (region instanceof FlatRegion) {
+                for (Vector2D pt : ((FlatRegion) region).asFlatRegion()) {
+                    biomes.add(world.getBiome(pt));
+                }
+            } else {
+                for (Vector pt : region) {
+                    biomes.add(world.getBiome(pt.toVector2D()));
+                }
+            }
+
+            player.print("Biomes:");
+            for (BiomeType biome : biomes) {
+                player.print(" " + biome.getName());
+            }
+        } else {
+            Vector2D pos;
+            if (args.hasFlag('t')) {
+                Vector blockPosition = player.getBlockTrace(300);
+                if (blockPosition == null) {
+                    player.printError("No block in sight!");
+                    return;
+                }
+                pos = blockPosition.toVector2D();
+            } else {
+                pos = player.getPosition().toVector2D();
+            }
+            BiomeType biome = player.getWorld().getBiome(pos);
+            player.print("Biome: " + biome.getName());
+        }
+    }
+}

--- a/src/main/java/com/sk89q/worldedit/masks/BiomeTypeMask.java
+++ b/src/main/java/com/sk89q/worldedit/masks/BiomeTypeMask.java
@@ -1,0 +1,27 @@
+package com.sk89q.worldedit.masks;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.sk89q.worldedit.BiomeType;
+import com.sk89q.worldedit.EditSession;
+import com.sk89q.worldedit.Vector;
+
+public class BiomeTypeMask implements Mask {
+
+    private Set<BiomeType> biomes;
+
+    public BiomeTypeMask() {
+        this(new HashSet<BiomeType>());
+    }
+
+    public BiomeTypeMask(Set<BiomeType> biomes) {
+        this.biomes = biomes;
+    }
+
+    public boolean matches(EditSession editSession, Vector pos) {
+        BiomeType biome = editSession.getWorld().getBiome(pos.toVector2D());
+        return biomes.contains(biome);
+    }
+
+}

--- a/src/main/java/com/sk89q/worldedit/spout/SpoutBiomeTypes.java
+++ b/src/main/java/com/sk89q/worldedit/spout/SpoutBiomeTypes.java
@@ -1,0 +1,26 @@
+package com.sk89q.worldedit.spout;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.sk89q.worldedit.BiomeType;
+import com.sk89q.worldedit.BiomeTypes;
+import com.sk89q.worldedit.UnknownBiomeTypeException;
+
+public class SpoutBiomeTypes implements BiomeTypes {
+
+    @Override
+    public boolean has(String name) {
+        return false;
+    }
+
+    @Override
+    public BiomeType get(String name) throws UnknownBiomeTypeException {
+        throw new UnknownBiomeTypeException(name);
+    }
+
+    @Override
+    public List<BiomeType> all() {
+        return Collections.<BiomeType>emptyList();
+    }
+}

--- a/src/main/java/com/sk89q/worldedit/spout/SpoutServerInterface.java
+++ b/src/main/java/com/sk89q/worldedit/spout/SpoutServerInterface.java
@@ -23,6 +23,7 @@ import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandPermissions;
 import com.sk89q.minecraft.util.commands.CommandsManager;
 import com.sk89q.worldedit.LocalPlayer;
+import com.sk89q.worldedit.BiomeTypes;
 import com.sk89q.worldedit.LocalWorld;
 import com.sk89q.worldedit.ServerInterface;
 import org.spout.api.Game;
@@ -40,10 +41,12 @@ public class SpoutServerInterface extends ServerInterface {
     public Game game;
     public WorldEditPlugin plugin;
     private final SpoutRawCommandExecutor executor;
+    private SpoutBiomeTypes biomes;
 
     public SpoutServerInterface(WorldEditPlugin plugin, Game game) {
         this.plugin = plugin;
         this.game = game;
+        this.biomes = new SpoutBiomeTypes(); 
         this.executor = new SpoutRawCommandExecutor(plugin);
     }
 
@@ -62,6 +65,11 @@ public class SpoutServerInterface extends ServerInterface {
     @Override
     public void reload() {
         plugin.loadConfiguration();
+    }
+
+    @Override
+    public BiomeTypes getBiomes() {
+        return biomes;
     }
 
     @Override

--- a/src/main/java/com/sk89q/worldedit/spout/SpoutWorld.java
+++ b/src/main/java/com/sk89q/worldedit/spout/SpoutWorld.java
@@ -19,12 +19,14 @@
 
 package com.sk89q.worldedit.spout;
 
+import com.sk89q.worldedit.BiomeType;
 import com.sk89q.worldedit.BlockVector2D;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.EntityType;
 import com.sk89q.worldedit.LocalWorld;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.Vector;
+import com.sk89q.worldedit.Vector2D;
 import com.sk89q.worldedit.blocks.BaseBlock;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.regions.Region;
@@ -165,6 +167,16 @@ public class SpoutWorld extends LocalWorld {
     @Override
     public int getBlockLightLevel(Vector pt) {
         return world.getBlockMaterial(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ()).getLightLevel();
+    }
+
+    /**
+     * Get biome type
+     *
+     * @param pt
+     * @return
+     */
+    public BiomeType getBiome(Vector2D pt) {
+        return new BiomeType("Unknown");
     }
 
     /**


### PR DESCRIPTION
This add some features related to biomes, a /biomeinfo command and a BiomeTypeMask (prefixed by $).
It's fully compatible with older versions of Bukkit (it only uses org.bukkit.World#getBiome() which have been added a long time ago.)
