### PR TITLE
When copying a region, take the real region into account

### DIFF
--- a/src/main/java/com/sk89q/worldedit/CuboidClipboard.java
+++ b/src/main/java/com/sk89q/worldedit/CuboidClipboard.java
@@ -22,6 +22,8 @@ package com.sk89q.worldedit;
 import com.sk89q.jnbt.*;
 import com.sk89q.worldedit.blocks.*;
 import com.sk89q.worldedit.data.*;
+import com.sk89q.worldedit.regions.Region;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -257,8 +259,10 @@ public class CuboidClipboard {
      * Copy to the clipboard.
      *
      * @param editSession
+     *
+     * @deprecated As of release 5.3, replaced with {@link #copy(EditSession, Region)}
      */
-    public void copy(EditSession editSession) {
+    @Deprecated public void copy(EditSession editSession) {
         for (int x = 0; x < size.getBlockX(); ++x) {
             for (int y = 0; y < size.getBlockY(); ++y) {
                 for (int z = 0; z < size.getBlockZ(); ++z) {
@@ -269,6 +273,26 @@ public class CuboidClipboard {
         }
     }
 
+    /**
+     * Copy to the clipboard without blocks outside the region
+     *
+     * @param editSession
+     * @param region
+     */
+	public void copy(EditSession editSession, Region region) {
+		for (int x = 0; x < size.getBlockX(); ++x) {
+			for (int y = 0; y < size.getBlockY(); ++y) {
+				for (int z = 0; z < size.getBlockZ(); ++z) {
+					Vector pt = new Vector(x, y, z).add(getOrigin());
+					if (region.contains(pt)) {
+						data[x][y][z] = editSession.getBlock(pt);
+					} else {
+						data[x][y][x] = new BaseBlock(BlockID.AIR);
+					}
+				}
+			}
+		}
+	}
     /**
      * Paste from the clipboard.
      *

--- a/src/main/java/com/sk89q/worldedit/commands/ClipboardCommands.java
+++ b/src/main/java/com/sk89q/worldedit/commands/ClipboardCommands.java
@@ -63,7 +63,7 @@ public class ClipboardCommands {
         CuboidClipboard clipboard = new CuboidClipboard(
                 max.subtract(min).add(new Vector(1, 1, 1)),
                 min, min.subtract(pos));
-        clipboard.copy(editSession);
+        clipboard.copy(editSession, region);
         session.setClipboard(clipboard);
 
         player.print("Block(s) copied.");
@@ -95,7 +95,7 @@ public class ClipboardCommands {
         CuboidClipboard clipboard = new CuboidClipboard(
                 max.subtract(min).add(new Vector(1, 1, 1)),
                 min, min.subtract(pos));
-        clipboard.copy(editSession);
+        clipboard.copy(editSession, region);
         session.setClipboard(clipboard);
 
         editSession.setBlocks(session.getSelection(player.getWorld()), block);


### PR DESCRIPTION
Currently when copying a region, it will transform any type of region
into a plain cuboid. When using region like poly, this is mostly not
what people actually want. Thus we when copying the region, replace all
block outside the defined region with air, which can later be masked out
when pasting.
