### PR TITLE
Utilize worldguard to check permissions to edit in the worlds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,18 @@
       <artifactId>vanilla</artifactId>
       <version>1.2.5-SNAPSHOT</version>
     </dependency>
+    <dependency>
+	<groupId>com.sk89q</groupId>
+	<artifactId>worldguard</artifactId>
+	<version>5.4</version>
+	<exclusions>
+	<!-- We don't want to depend upon our self -->
+	<exclusion>
+	<groupId>com.sk89q</groupId>
+	<artifactId>worldedit</artifactId>
+	</exclusion>
+	</exclusions>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/sk89q/worldedit/ArbitraryShape.java
+++ b/src/main/java/com/sk89q/worldedit/ArbitraryShape.java
@@ -141,8 +141,9 @@ public abstract class ArbitraryShape {
      * @param hollow Specifies whether to generate a hollow shape.
      * @return number of affected blocks.
      * @throws MaxChangedBlocksException
+     * @throws WorldGuardMissingPermissionException
      */
-    public int generate(EditSession editSession, Pattern pattern, boolean hollow) throws MaxChangedBlocksException {
+    public int generate(EditSession editSession, Pattern pattern, boolean hollow) throws MaxChangedBlocksException, WorldGuardMissingPermissionException {
         int affected = 0;
 
         for (BlockVector position : getExtent()) {

--- a/src/main/java/com/sk89q/worldedit/CuboidClipboard.java
+++ b/src/main/java/com/sk89q/worldedit/CuboidClipboard.java
@@ -268,7 +268,7 @@ public class CuboidClipboard {
     }
 
     public void paste(EditSession editSession, Vector newOrigin, boolean noAir)
-            throws MaxChangedBlocksException {
+            throws MaxChangedBlocksException, WorldGuardMissingPermissionException {
         paste(editSession, newOrigin, noAir, false);
     }
 
@@ -279,9 +279,10 @@ public class CuboidClipboard {
      * @param newOrigin Position to paste it from
      * @param noAir True to not paste air
      * @throws MaxChangedBlocksException
+     * @throws WorldGuardMissingPermissionException
      */
     public void paste(EditSession editSession, Vector newOrigin, boolean noAir, boolean entities)
-            throws MaxChangedBlocksException {
+            throws MaxChangedBlocksException, WorldGuardMissingPermissionException {
         place(editSession, newOrigin.add(offset), noAir);
         if (entities) {
             pasteEntities(newOrigin.add(offset));
@@ -295,8 +296,9 @@ public class CuboidClipboard {
      * @param pos
      * @param noAir
      * @throws MaxChangedBlocksException
+     * @throws WorldGuardMissingPermissionException
      */
-    public void place(EditSession editSession, Vector pos, boolean noAir) throws MaxChangedBlocksException {
+    public void place(EditSession editSession, Vector pos, boolean noAir) throws MaxChangedBlocksException, WorldGuardMissingPermissionException {
         for (int x = 0; x < size.getBlockX(); ++x) {
             for (int y = 0; y < size.getBlockY(); ++y) {
                 for (int z = 0; z < size.getBlockZ(); ++z) {

--- a/src/main/java/com/sk89q/worldedit/HeightMap.java
+++ b/src/main/java/com/sk89q/worldedit/HeightMap.java
@@ -84,9 +84,10 @@ public class HeightMap {
      * @param iterations
      * @return number of blocks affected
      * @throws MaxChangedBlocksException
+     * @throws WorldGuardMissingPermissionException
      */
 
-    public int applyFilter(HeightMapFilter filter, int iterations) throws MaxChangedBlocksException {
+    public int applyFilter(HeightMapFilter filter, int iterations) throws MaxChangedBlocksException, WorldGuardMissingPermissionException {
         int[] newData = new int[data.length];
         System.arraycopy(data, 0, newData, 0, data.length);
 
@@ -103,9 +104,10 @@ public class HeightMap {
      * @param data
      * @return number of blocks affected
      * @throws MaxChangedBlocksException
+     * @throws WorldGuardMissingPermissionException
      */
 
-    public int apply(int[] data) throws MaxChangedBlocksException {
+    public int apply(int[] data) throws MaxChangedBlocksException, WorldGuardMissingPermissionException {
         Vector minY = region.getMinimumPoint();
         int originX = minY.getBlockX();
         int originY = minY.getBlockY();

--- a/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -143,7 +143,7 @@ public class LocalSession {
         if (historyPointer >= 0) {
             EditSession editSession = history.get(historyPointer);
             EditSession newEditSession =
-                    new EditSession(editSession.getWorld(), -1, newBlockBag);
+                    new EditSession(editSession.getWorld(), -1, newBlockBag,editSession.getPlayer());
             newEditSession.enableQueue();
             newEditSession.setFastMode(fastMode);
             editSession.undo(newEditSession);
@@ -164,7 +164,7 @@ public class LocalSession {
         if (historyPointer < history.size()) {
             EditSession editSession = history.get(historyPointer);
             EditSession newEditSession =
-                    new EditSession(editSession.getWorld(), -1, newBlockBag);
+                    new EditSession(editSession.getWorld(), -1, newBlockBag, editSession.getPlayer());
             newEditSession.enableQueue();
             newEditSession.setFastMode(fastMode);
             editSession.redo(newEditSession);
@@ -684,7 +684,7 @@ public class LocalSession {
         // Create an edit session
         EditSession editSession =
                 new EditSession(player.isPlayer() ? player.getWorld() : null,
-                        getBlockChangeLimit(), blockBag);
+                        getBlockChangeLimit(), blockBag, player);
         editSession.setFastMode(fastMode);
         if (mask != null) {
             mask.prepare(this, player, null);

--- a/src/main/java/com/sk89q/worldedit/WorldGuardMissingPermissionException.java
+++ b/src/main/java/com/sk89q/worldedit/WorldGuardMissingPermissionException.java
@@ -1,0 +1,19 @@
+package com.sk89q.worldedit;
+
+import org.bukkit.Location;
+
+public class WorldGuardMissingPermissionException extends WorldEditException {
+
+
+	private static final long serialVersionUID = -7222415044987581773L;
+
+	public WorldGuardMissingPermissionException() {
+		// TODO Auto-generated constructor stub
+	}
+
+	public WorldGuardMissingPermissionException(Location location) {
+		super("Permission denied to edit on location " + location);
+		// TODO Auto-generated constructor stub
+	}
+
+}

--- a/src/main/java/com/sk89q/worldedit/WorldGuardNotLoadedException.java
+++ b/src/main/java/com/sk89q/worldedit/WorldGuardNotLoadedException.java
@@ -1,0 +1,6 @@
+package com.sk89q.worldedit;
+
+public class WorldGuardNotLoadedException extends WorldEditException {
+
+	private static final long serialVersionUID = 2229997393155681743L;
+}

--- a/src/main/java/com/sk89q/worldedit/bukkit/EditSessionBlockChangeDelegate.java
+++ b/src/main/java/com/sk89q/worldedit/bukkit/EditSessionBlockChangeDelegate.java
@@ -24,6 +24,7 @@ import org.bukkit.BlockChangeDelegate;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.Vector;
 import com.sk89q.worldedit.MaxChangedBlocksException;
+import com.sk89q.worldedit.WorldGuardMissingPermissionException;
 import com.sk89q.worldedit.blocks.BaseBlock;
 
 /**
@@ -43,7 +44,9 @@ public class EditSessionBlockChangeDelegate implements BlockChangeDelegate {
             return editSession.setBlock(new Vector(x, y, z), new BaseBlock(typeId));
         } catch (MaxChangedBlocksException ex) {
             return false;
-        }
+        } catch (WorldGuardMissingPermissionException e) {
+		return false;
+		}
     }
 
     public boolean setRawTypeIdAndData(int x, int y, int z, int typeId, int data) {
@@ -51,7 +54,9 @@ public class EditSessionBlockChangeDelegate implements BlockChangeDelegate {
             return editSession.setBlock(new Vector(x, y, z), new BaseBlock(typeId, data));
         } catch (MaxChangedBlocksException ex) {
             return false;
-        }
+        } catch (WorldGuardMissingPermissionException e) {
+		return false;
+		}
     }
 
     public boolean setTypeId(int x, int y, int z, int typeId) {

--- a/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -228,7 +228,8 @@ public class WorldEditPlugin extends JavaPlugin {
         BlockBag blockBag = session.getBlockBag(wePlayer);
 
         EditSession editSession =
-                new EditSession(wePlayer.getWorld(), session.getBlockChangeLimit(), blockBag);
+                new EditSession(wePlayer.getWorld(), session.getBlockChangeLimit(), blockBag, wePlayer);
+
         editSession.enableQueue();
 
         return editSession;

--- a/src/main/java/com/sk89q/worldedit/scripting/CraftScriptContext.java
+++ b/src/main/java/com/sk89q/worldedit/scripting/CraftScriptContext.java
@@ -62,7 +62,7 @@ public class CraftScriptContext extends CraftScriptEnvironment {
     public EditSession remember() {
         EditSession editSession =
                 new EditSession(player.getWorld(),
-                        session.getBlockChangeLimit(), session.getBlockBag(player));
+                        session.getBlockChangeLimit(), session.getBlockBag(player), player);
         editSession.enableQueue();
         editSessions.add(editSession);
         return editSession;

--- a/src/main/java/com/sk89q/worldedit/snapshots/SnapshotRestore.java
+++ b/src/main/java/com/sk89q/worldedit/snapshots/SnapshotRestore.java
@@ -30,6 +30,7 @@ import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.Vector;
 import com.sk89q.worldedit.Vector2D;
+import com.sk89q.worldedit.WorldGuardMissingPermissionException;
 import com.sk89q.worldedit.blocks.BaseBlock;
 import com.sk89q.worldedit.data.Chunk;
 import com.sk89q.worldedit.data.ChunkStore;
@@ -144,9 +145,10 @@ public class SnapshotRestore {
      *
      * @param editSession
      * @throws MaxChangedBlocksException
+     * @throws WorldGuardMissingPermissionException
      */
     public void restore(EditSession editSession)
-            throws MaxChangedBlocksException {
+            throws MaxChangedBlocksException, WorldGuardMissingPermissionException {
 
         missingChunks = new ArrayList<Vector2D>();
         errorChunks = new ArrayList<Vector2D>();

--- a/src/main/java/com/sk89q/worldedit/spout/WorldEditPlugin.java
+++ b/src/main/java/com/sk89q/worldedit/spout/WorldEditPlugin.java
@@ -202,7 +202,7 @@ public class WorldEditPlugin extends CommonPlugin {
         BlockBag blockBag = session.getBlockBag(wePlayer);
 
         EditSession editSession =
-                new EditSession(wePlayer.getWorld(), session.getBlockChangeLimit(), blockBag);
+                new EditSession(wePlayer.getWorld(), session.getBlockChangeLimit(), blockBag, wePlayer);
         editSession.enableQueue();
 
         return editSession;

--- a/src/main/java/com/sk89q/worldedit/tools/AreaPickaxe.java
+++ b/src/main/java/com/sk89q/worldedit/tools/AreaPickaxe.java
@@ -78,7 +78,9 @@ public class AreaPickaxe implements BlockTool {
             }
         } catch (MaxChangedBlocksException e) {
             player.printError("Max blocks change limit reached.");
-        } finally {
+        } catch (WorldGuardMissingPermissionException e) {
+		player.printError("Permission denied to edit here.");
+		} finally {
             session.remember(editSession);
         }
 

--- a/src/main/java/com/sk89q/worldedit/tools/BlockReplacer.java
+++ b/src/main/java/com/sk89q/worldedit/tools/BlockReplacer.java
@@ -46,12 +46,13 @@ public class BlockReplacer implements DoubleActionBlockTool {
         BlockBag bag = session.getBlockBag(player);
 
         LocalWorld world = clicked.getWorld();
-        EditSession editSession = new EditSession(world, -1, bag);
+        EditSession editSession = new EditSession(world, -1, bag, player);
 
         try {
             editSession.setBlock(clicked, targetBlock);
         } catch (MaxChangedBlocksException e) {
-        } finally {
+        } catch (WorldGuardMissingPermissionException e) {
+		} finally {
             if (bag != null) {
                 bag.flushChanges();
             }
@@ -66,7 +67,7 @@ public class BlockReplacer implements DoubleActionBlockTool {
             LocalSession session, WorldVector clicked) {
 
         LocalWorld world = clicked.getWorld();
-        targetBlock = (new EditSession(world, -1)).getBlock(clicked);
+        targetBlock = (new EditSession(world, -1, player)).getBlock(clicked);
         BlockType type = BlockType.fromID(targetBlock.getType());
 
         if (type != null) {

--- a/src/main/java/com/sk89q/worldedit/tools/BrushTool.java
+++ b/src/main/java/com/sk89q/worldedit/tools/BrushTool.java
@@ -195,7 +195,9 @@ public class BrushTool implements TraceTool {
             brush.build(editSession, target, material, size);
         } catch (MaxChangedBlocksException e) {
             player.printError("Max blocks change limit reached.");
-        } finally {
+        } catch (WorldGuardMissingPermissionException e) {
+            player.printError("Permission denied to edit.");
+		} finally {
             if (bag != null) {
                 bag.flushChanges();
             }

--- a/src/main/java/com/sk89q/worldedit/tools/FloatingTreeRemover.java
+++ b/src/main/java/com/sk89q/worldedit/tools/FloatingTreeRemover.java
@@ -84,7 +84,9 @@ public class FloatingTreeRemover implements BlockTool {
             }
         } catch (MaxChangedBlocksException e) {
             player.printError("Max blocks change limit reached.");
-        } finally {
+        } catch (WorldGuardMissingPermissionException e) {
+		player.printError("Permission denied to edit.");
+		} finally {
             session.remember(editSession);
         }
 

--- a/src/main/java/com/sk89q/worldedit/tools/FloodFillTool.java
+++ b/src/main/java/com/sk89q/worldedit/tools/FloodFillTool.java
@@ -64,7 +64,9 @@ public class FloodFillTool implements BlockTool {
                     clicked, range, initialType, new HashSet<BlockVector>());
         } catch (MaxChangedBlocksException e) {
             player.printError("Max blocks change limit reached.");
-        } finally {
+        } catch (WorldGuardMissingPermissionException e) {
+		player.printError("Permission denied to edit");
+		} finally {
             session.remember(editSession);
         }
 
@@ -82,12 +84,13 @@ public class FloodFillTool implements BlockTool {
      * @param size
      * @param initialType
      * @param visited
+     * @throws WorldGuardMissingPermissionException
      */
     private void recurse(ServerInterface server, EditSession editSession,
             LocalWorld world, BlockVector pos,
             Vector origin, int size, int initialType,
             Set<BlockVector> visited)
-            throws MaxChangedBlocksException {
+            throws MaxChangedBlocksException, WorldGuardMissingPermissionException {
 
         if (origin.distance(pos) > size || visited.contains(pos)) {
             return;

--- a/src/main/java/com/sk89q/worldedit/tools/LongRangeBuildTool.java
+++ b/src/main/java/com/sk89q/worldedit/tools/LongRangeBuildTool.java
@@ -59,7 +59,9 @@ public class LongRangeBuildTool extends BrushTool implements DoubleActionTraceTo
             return true;
         } catch (MaxChangedBlocksException e) {
             // one block? eat it
-        }
+        } catch (WorldGuardMissingPermissionException e) {
+		// same!
+		}
         return false;
 
     }
@@ -80,7 +82,9 @@ public class LongRangeBuildTool extends BrushTool implements DoubleActionTraceTo
             return true;
         } catch (MaxChangedBlocksException e) {
             // one block? eat it
-        }
+        } catch (WorldGuardMissingPermissionException e) {
+		// same!
+		}
         return false;
     }
 

--- a/src/main/java/com/sk89q/worldedit/tools/QueryTool.java
+++ b/src/main/java/com/sk89q/worldedit/tools/QueryTool.java
@@ -37,7 +37,7 @@ public class QueryTool implements BlockTool {
             LocalPlayer player, LocalSession session, WorldVector clicked) {
 
         LocalWorld world = clicked.getWorld();
-        BaseBlock block = (new EditSession(world, 0)).rawGetBlock(clicked);
+        BaseBlock block = (new EditSession(world, 0, player)).rawGetBlock(clicked);
         BlockType type = BlockType.fromID(block.getType());
 
         player.print("\u00A79@" + clicked + ": " + "\u00A7e"

--- a/src/main/java/com/sk89q/worldedit/tools/RecursivePickaxe.java
+++ b/src/main/java/com/sk89q/worldedit/tools/RecursivePickaxe.java
@@ -66,7 +66,9 @@ public class RecursivePickaxe implements BlockTool {
                     config.superPickaxeManyDrop);
         } catch (MaxChangedBlocksException e) {
             player.printError("Max blocks change limit reached.");
-        } finally {
+        } catch (WorldGuardMissingPermissionException e) {
+            player.printError("Permission denied to edit.");
+		} finally {
             session.remember(editSession);
         }
 
@@ -84,12 +86,13 @@ public class RecursivePickaxe implements BlockTool {
      * @param size
      * @param initialType
      * @param visited
+     * @throws WorldGuardMissingPermissionException
      */
     private static void recurse(ServerInterface server, EditSession editSession,
             LocalWorld world, BlockVector pos,
             Vector origin, double size, int initialType,
             Set<BlockVector> visited, boolean drop)
-            throws MaxChangedBlocksException {
+            throws MaxChangedBlocksException, WorldGuardMissingPermissionException {
 
         final double distanceSq = origin.distanceSq(pos);
         if (distanceSq > size*size || visited.contains(pos)) {

--- a/src/main/java/com/sk89q/worldedit/tools/TreePlanter.java
+++ b/src/main/java/com/sk89q/worldedit/tools/TreePlanter.java
@@ -58,7 +58,9 @@ public class TreePlanter implements BlockTool {
             }
         } catch (MaxChangedBlocksException e) {
             player.printError("Max. blocks changed reached.");
-        } finally {
+        } catch (WorldGuardMissingPermissionException e) {
+		player.printError("Permission denied to edit.");
+		} finally {
             session.remember(editSession);
         }
 

--- a/src/main/java/com/sk89q/worldedit/tools/brushes/Brush.java
+++ b/src/main/java/com/sk89q/worldedit/tools/brushes/Brush.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit.tools.brushes;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.Vector;
+import com.sk89q.worldedit.WorldGuardMissingPermissionException;
 import com.sk89q.worldedit.patterns.Pattern;
 
 /**
@@ -38,7 +39,8 @@ public interface Brush {
      * @param mat
      * @param size
      * @throws MaxChangedBlocksException 
+     * @throws WorldGuardMissingPermissionException
      */
     public void build(EditSession editSession, Vector pos, Pattern mat, double size)
-            throws MaxChangedBlocksException;
+            throws MaxChangedBlocksException, WorldGuardMissingPermissionException;
 }

--- a/src/main/java/com/sk89q/worldedit/tools/brushes/ClipboardBrush.java
+++ b/src/main/java/com/sk89q/worldedit/tools/brushes/ClipboardBrush.java
@@ -23,6 +23,7 @@ import com.sk89q.worldedit.CuboidClipboard;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.Vector;
+import com.sk89q.worldedit.WorldGuardMissingPermissionException;
 import com.sk89q.worldedit.patterns.Pattern;
 
 public class ClipboardBrush implements Brush {
@@ -35,7 +36,7 @@ public class ClipboardBrush implements Brush {
     }
 
     public void build(EditSession editSession, Vector pos, Pattern mat, double size)
-            throws MaxChangedBlocksException {
+            throws MaxChangedBlocksException, WorldGuardMissingPermissionException {
         clipboard.place(editSession, pos.subtract(clipboard.getSize().divide(2)), noAir);
     }
 }

--- a/src/main/java/com/sk89q/worldedit/tools/brushes/CylinderBrush.java
+++ b/src/main/java/com/sk89q/worldedit/tools/brushes/CylinderBrush.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit.tools.brushes;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.Vector;
+import com.sk89q.worldedit.WorldGuardMissingPermissionException;
 import com.sk89q.worldedit.patterns.Pattern;
 
 public class CylinderBrush implements Brush {
@@ -32,7 +33,7 @@ public class CylinderBrush implements Brush {
     }
 
     public void build(EditSession editSession, Vector pos, Pattern mat, double size)
-            throws MaxChangedBlocksException {
+            throws MaxChangedBlocksException, WorldGuardMissingPermissionException {
         editSession.makeCylinder(pos, mat, size, size, height, true);
     }
 }

--- a/src/main/java/com/sk89q/worldedit/tools/brushes/GravityBrush.java
+++ b/src/main/java/com/sk89q/worldedit/tools/brushes/GravityBrush.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit.tools.brushes;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.Vector;
+import com.sk89q.worldedit.WorldGuardMissingPermissionException;
 import com.sk89q.worldedit.blocks.BaseBlock;
 import com.sk89q.worldedit.blocks.BlockID;
 import com.sk89q.worldedit.patterns.Pattern;
@@ -39,7 +40,7 @@ public class GravityBrush implements Brush {
     }
 
     @Override
-    public void build(EditSession editSession, Vector pos, Pattern mat, double size) throws MaxChangedBlocksException {
+    public void build(EditSession editSession, Vector pos, Pattern mat, double size) throws MaxChangedBlocksException, WorldGuardMissingPermissionException {
         final BaseBlock air = new BaseBlock(BlockID.AIR, 0);
         final double startY = fullHeight ? editSession.getWorld().getMaxY() : pos.getBlockY() + size;
         for (double x = pos.getBlockX() + size; x > pos.getBlockX() - size; --x) {

--- a/src/main/java/com/sk89q/worldedit/tools/brushes/HollowCylinderBrush.java
+++ b/src/main/java/com/sk89q/worldedit/tools/brushes/HollowCylinderBrush.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit.tools.brushes;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.Vector;
+import com.sk89q.worldedit.WorldGuardMissingPermissionException;
 import com.sk89q.worldedit.patterns.Pattern;
 
 public class HollowCylinderBrush implements Brush {
@@ -32,7 +33,7 @@ public class HollowCylinderBrush implements Brush {
     }
 
     public void build(EditSession editSession, Vector pos, Pattern mat, double size)
-            throws MaxChangedBlocksException {
+            throws MaxChangedBlocksException, WorldGuardMissingPermissionException {
         editSession.makeCylinder(pos, mat, size, size, height, false);
     }
 }

--- a/src/main/java/com/sk89q/worldedit/tools/brushes/HollowSphereBrush.java
+++ b/src/main/java/com/sk89q/worldedit/tools/brushes/HollowSphereBrush.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit.tools.brushes;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.Vector;
+import com.sk89q.worldedit.WorldGuardMissingPermissionException;
 import com.sk89q.worldedit.patterns.Pattern;
 
 public class HollowSphereBrush implements Brush {
@@ -29,7 +30,7 @@ public class HollowSphereBrush implements Brush {
     }
 
     public void build(EditSession editSession, Vector pos, Pattern mat, double size)
-            throws MaxChangedBlocksException {
+            throws MaxChangedBlocksException, WorldGuardMissingPermissionException {
         editSession.makeSphere(pos, mat, size, size, size, false);
     }
 }

--- a/src/main/java/com/sk89q/worldedit/tools/brushes/SmoothBrush.java
+++ b/src/main/java/com/sk89q/worldedit/tools/brushes/SmoothBrush.java
@@ -23,6 +23,7 @@ import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.HeightMap;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.Vector;
+import com.sk89q.worldedit.WorldGuardMissingPermissionException;
 import com.sk89q.worldedit.WorldVector;
 import com.sk89q.worldedit.filtering.GaussianKernel;
 import com.sk89q.worldedit.filtering.HeightMapFilter;
@@ -44,7 +45,7 @@ public class SmoothBrush implements Brush {
     }
 
     public void build(EditSession editSession, Vector pos, Pattern mat, double size)
-            throws MaxChangedBlocksException {
+            throws MaxChangedBlocksException, WorldGuardMissingPermissionException {
         double rad = size;
         WorldVector min = new WorldVector(editSession.getWorld(), pos.subtract(rad, rad, rad));
         Vector max = pos.add(rad, rad + 10, rad);

--- a/src/main/java/com/sk89q/worldedit/tools/brushes/SphereBrush.java
+++ b/src/main/java/com/sk89q/worldedit/tools/brushes/SphereBrush.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit.tools.brushes;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.Vector;
+import com.sk89q.worldedit.WorldGuardMissingPermissionException;
 import com.sk89q.worldedit.patterns.Pattern;
 
 public class SphereBrush implements Brush {
@@ -29,7 +30,7 @@ public class SphereBrush implements Brush {
     }
 
     public void build(EditSession editSession, Vector pos, Pattern mat, double size)
-            throws MaxChangedBlocksException {
+            throws MaxChangedBlocksException, WorldGuardMissingPermissionException {
         editSession.makeSphere(pos, mat, size, size, size, true);
     }
 }

--- a/src/main/java/com/sk89q/worldedit/util/TreeGenerator.java
+++ b/src/main/java/com/sk89q/worldedit/util/TreeGenerator.java
@@ -26,6 +26,7 @@ import java.util.Random;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.Vector;
+import com.sk89q.worldedit.WorldGuardMissingPermissionException;
 import com.sk89q.worldedit.blocks.BaseBlock;
 import com.sk89q.worldedit.blocks.BlockID;
 
@@ -42,13 +43,13 @@ public class TreeGenerator {
         TALL_REDWOOD("Tall redwood", "tallredwood", "tallsequoia", "tallsequoioideae"),
         BIRCH("Birch", "birch", "white", "whitebark"),
         PINE("Pine", "pine") {
-            public boolean generate(EditSession editSession, Vector pos) throws MaxChangedBlocksException {
+            public boolean generate(EditSession editSession, Vector pos) throws MaxChangedBlocksException, WorldGuardMissingPermissionException {
                 makePineTree(editSession, pos);
                 return true;
             }
         },
         RANDOM_REDWOOD("Random redwood",  "randredwood", "randomredwood", "anyredwood" ) {
-            public boolean generate(EditSession editSession, Vector pos) throws MaxChangedBlocksException {
+            public boolean generate(EditSession editSession, Vector pos) throws MaxChangedBlocksException, WorldGuardMissingPermissionException {
                 TreeType[] choices = new TreeType[] {
                         TreeType.REDWOOD, TreeType.TALL_REDWOOD
                 };
@@ -62,7 +63,7 @@ public class TreeGenerator {
         BROWN_MUSHROOM("Brown Mushroom", "brownmushroom", "browngiantmushroom"),
         SWAMP("Swamp", "swamp", "swamptree"),
         RANDOM("Random", "rand", "random" ) {
-            public boolean generate(EditSession editSession, Vector pos) throws MaxChangedBlocksException {
+            public boolean generate(EditSession editSession, Vector pos) throws MaxChangedBlocksException, WorldGuardMissingPermissionException {
                 TreeType[] choices = new TreeType[] {
                         TreeType.TREE, TreeType.BIG_TREE, TreeType.BIRCH,
                         TreeType.REDWOOD, TreeType.TALL_REDWOOD, TreeType.PINE
@@ -92,7 +93,7 @@ public class TreeGenerator {
             this.lookupKeys = lookupKeys;
         }
 
-        public boolean generate(EditSession editSession, Vector pos) throws MaxChangedBlocksException {
+        public boolean generate(EditSession editSession, Vector pos) throws MaxChangedBlocksException, WorldGuardMissingPermissionException {
             return editSession.getWorld().generateTree(this, editSession, pos);
         }
 
@@ -137,9 +138,10 @@ public class TreeGenerator {
      * @param pos
      * @return
      * @throws MaxChangedBlocksException
+     * @throws WorldGuardMissingPermissionException
      */
     public boolean generate(EditSession editSession, Vector pos)
-            throws MaxChangedBlocksException {
+            throws MaxChangedBlocksException, WorldGuardMissingPermissionException {
         return type.generate(editSession, pos);
     }
 
@@ -147,9 +149,10 @@ public class TreeGenerator {
      * Makes a terrible looking pine tree.
      *
      * @param basePos
+     * @throws WorldGuardMissingPermissionException
      */
     private static void makePineTree(EditSession editSession, Vector basePos)
-            throws MaxChangedBlocksException {
+            throws MaxChangedBlocksException, WorldGuardMissingPermissionException {
         int trunkHeight = (int) Math.floor(Math.random() * 2) + 3;
         int height = (int) Math.floor(Math.random() * 5) + 8;
 


### PR DESCRIPTION
While worldedit and worldguard is created from the same source, there
has never been a way to prevent people from using worldedit in regions
where they do not have any permissions to work in.
