### PR TITLE
Remove artifical 20 points limit from polygonal selection

### DIFF
--- a/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegionSelector.java
+++ b/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegionSelector.java
@@ -107,10 +107,6 @@ public class Polygonal2DRegionSelector implements RegionSelector, CUIRegion {
             if (lastPoint.getBlockX() == pos.getBlockX() && lastPoint.getBlockZ() == pos.getBlockZ()) {
                 return false;
             }
-
-            if (points.size() >= 20) {
-                return false;
-            }
         }
 
         region.addPoint(pos);


### PR DESCRIPTION
After removing the limit, regions with more than 20 points seem to work fine, and nothing bad happens to the server.
