### PR TITLE
Fix bounds error when loading negative block IDs

### DIFF
--- a/src/main/java/com/sk89q/worldedit/blocks/BaseBlock.java
+++ b/src/main/java/com/sk89q/worldedit/blocks/BaseBlock.java
@@ -52,8 +52,8 @@ public class BaseBlock {
      * @param data
      */
     public BaseBlock(int type, int data) {
-        this.type = (short) type;
-        this.data = (byte) data;
+        setType(type);
+        setData(data);
     }
 
     /**
@@ -67,6 +67,10 @@ public class BaseBlock {
      * @param type the type to set
      */
     public void setType(int type) {
+        if (type < 0) {
+            type += 256;
+        }
+
         this.type = (short) type;
     }
 


### PR DESCRIPTION
Fixes the error when pasting schematics with large block IDs which which wrap around and cause this out of bounds error:

```
19:01:33 [SEVERE] java.lang.ArrayIndexOutOfBoundsException: -28
19:01:33 [SEVERE]   at org.bukkit.Material.getMaterial(Material.java:438)
19:01:33 [SEVERE]   at com.sk89q.worldedit.bukkit.BukkitWorld.isValidBlockType(BukkitWorld.java:844)
19:01:33 [SEVERE]   at com.sk89q.worldedit.EditSession.rawSetBlock(EditSession.java:178)
19:01:33 [SEVERE]   at com.sk89q.worldedit.EditSession.flushQueue(EditSession.java:731)
19:01:33 [SEVERE]   at com.sk89q.worldedit.WorldEdit.handleCommand(WorldEdit.java:1265)
19:01:33 [SEVERE]   at com.sk89q.worldedit.bukkit.WorldEditPlugin.onCommand(WorldEditPlugin.java:204)
19:01:33 [SEVERE]   at com.sk89q.bukkit.util.DynamicPluginCommand.execute(DynamicPluginCommand.java:44)
19:01:33 [SEVERE]   at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:166)
19:01:33 [SEVERE]   at org.bukkit.craftbukkit.CraftServer.dispatchCommand(CraftServer.java:469)
19:01:33 [SEVERE]   at net.minecraft.server.NetServerHandler.handleCommand(NetServerHandler.java:914)
19:01:33 [SEVERE]   at net.minecraft.server.NetServerHandler.chat(NetServerHandler.java:874)
19:01:33 [SEVERE]   at net.minecraft.server.NetServerHandler.a(NetServerHandler.java:857)
19:01:33 [SEVERE]   at net.minecraft.server.Packet3Chat.handle(Packet3Chat.java:33)
19:01:33 [SEVERE]   at net.minecraft.server.NetworkManager.b(NetworkManager.java:234)
19:01:33 [SEVERE]   at net.minecraft.server.NetServerHandler.a(NetServerHandler.java:118)
19:01:33 [SEVERE]   at net.minecraft.server.NetworkListenThread.a(NetworkListenThread.java:78)
19:01:33 [SEVERE]   at net.minecraft.server.MinecraftServer.w(MinecraftServer.java:557)
19:01:33 [SEVERE]   at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:455)
19:01:33 [SEVERE]   at net.minecraft.server.ThreadServerApplication.run(SourceFile:490)
```

To reproduce:
1. Install MCPC 1.2.3 with IndustrialCraft^2 from http://www.mcportcentral.co.za/index.php?topic=1692.0
2. Load an MCEdit schematic containing machine block IDs , example: http://dl.dropbox.com/u/65303659/Schematics.zip
3. //schem load XPHCFactory
4. //paste

Without the patch, the above error occurs, and the IC2 machines and cables are missing. With the patch, they're pasted successfully.
