### PR TITLE
Added support for clientside WorldEdit

### DIFF
--- a/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -19,8 +19,11 @@
 
 package com.sk89q.worldedit;
 
+import java.io.DataInputStream;
+import java.io.IOException;
 import java.util.Calendar;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.TimeZone;
@@ -637,6 +640,69 @@ public class LocalSession {
     public void setCUIVersion(int CUIVersion) {
         this.cuiVersion = CUIVersion;
     }
+
+	/**
+	 * Executed on an incoming WorldEdit packet (Packet250CustomPayload for default in Minecraft)
+	 */
+	int packetsLeft = 0;
+	byte packetCode = 0;
+	HashSet<?> packetCache;
+
+	class BlockLocation {
+		public final Vector pos;
+		public final int id;
+		public final int data;
+		public BlockLocation(int x, int y, int z, int id, int data) {
+			this.pos = new Vector(x, y, z);
+			this.id = id;
+			this.data = data;
+		}
+	}
+	public void worldEditPacketReceived(LocalPlayer player, DataInputStream packetStream) throws IOException {
+		if(packetsLeft <= 0) {
+			packetCode = packetStream.readByte();
+			packetsLeft = packetStream.readInt();
+			switch (packetCode) {
+				case 'S':
+					if(!player.hasPermission("worldedit.packet.multiset")) {
+						packetsLeft = 0;
+						packetCode = ' ';
+					}
+					packetCache = new HashSet<BlockLocation>();
+					break;
+				default:
+					packetsLeft = 0;
+			}
+			return;
+		}
+
+		packetsLeft--;
+
+		switch (packetCode) {
+			case 'S': //Set multiple blocks
+				int x = packetStream.readInt();
+				int y = packetStream.readShort();
+				int z = packetStream.readInt();
+				int id = packetStream.readShort();
+				int data = packetStream.readShort();
+				((HashSet<BlockLocation>)packetCache).add(new BlockLocation(x, y, z, id, data));
+				break;
+		}
+
+		if(packetsLeft <= 0) {
+			switch(packetCode) {
+				case 'S':
+					if(!player.hasPermission("worldedit.packet.multiset")) return;
+					HashSet<BlockLocation> blocks = (HashSet<BlockLocation>)packetCache;
+					LocalWorld world = player.getWorld();
+					for(BlockLocation block : blocks) {
+						world.setTypeIdAndDataFast(block.pos, block.id, block.data);
+					}
+					packetCache = null;
+					break;
+			}
+		}
+	}
 
     /**
      * Detect date from a user's input.

--- a/src/main/java/com/sk89q/worldedit/bukkit/WorldEditChannelListener.java
+++ b/src/main/java/com/sk89q/worldedit/bukkit/WorldEditChannelListener.java
@@ -1,0 +1,53 @@
+/*
+ * WorldEdit
+ * Copyright (C) 2012 sk89q <http://www.sk89q.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.bukkit;
+
+import com.sk89q.worldedit.LocalPlayer;
+import com.sk89q.worldedit.LocalSession;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.messaging.PluginMessageListener;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.nio.charset.Charset;
+
+/**
+ * Handles incoming WorldEdit modifier message
+ * @author Doridian
+ */
+public class WorldEditChannelListener implements PluginMessageListener {
+	public static final Charset UTF_8_CHARSET = Charset.forName("UTF-8");
+	private final WorldEditPlugin plugin;
+
+	public WorldEditChannelListener(WorldEditPlugin plugin) {
+		this.plugin = plugin;
+	}
+
+	@Override
+	public void onPluginMessageReceived(String channel, Player player, byte[] message) {
+		LocalSession localSession = plugin.getSession(player);
+		LocalPlayer localPlayer = plugin.wrapPlayer(player);
+
+		try {
+			localSession.worldEditPacketReceived(localPlayer, new DataInputStream(new ByteArrayInputStream(message)));
+		} catch(Exception e) {
+			e.printStackTrace();
+		}
+	}
+}

--- a/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -52,6 +52,8 @@ public class WorldEditPlugin extends JavaPlugin {
      */
     public static final String CUI_PLUGIN_CHANNEL = "WECUI";
 
+	public static final String WORLDEDIT_PLUGIN_CHANNEL = "WorldEdit";
+
     /**
      * The server interface that all server-related API goes through.
      */
@@ -106,6 +108,9 @@ public class WorldEditPlugin extends JavaPlugin {
         api = new WorldEditAPI(this);
         getServer().getMessenger().registerIncomingPluginChannel(this, CUI_PLUGIN_CHANNEL, new CUIChannelListener(this));
         getServer().getMessenger().registerOutgoingPluginChannel(this, CUI_PLUGIN_CHANNEL);
+
+	    getServer().getMessenger().registerIncomingPluginChannel(this, WORLDEDIT_PLUGIN_CHANNEL, new WorldEditChannelListener(this));
+	    //getServer().getMessenger().registerOutgoingPluginChannel(this, WORLDEDIT_PLUGIN_CHANNEL); //No outgoing messages exist yet!
 
         // Now we can register events!
         getServer().getPluginManager().registerEvents(new WorldEditListener(this), this);


### PR DESCRIPTION
Introduces permission worldedit.packet.multiset
Introduced Packet250 listener so that a client-side worldedit can push changes.

Note by TomyLobo:
Doridian added support for a client-side preview+commit editing mode to <a href="http://github.com/Doridian/Yiffcraft">Yiffcraft</a>
