### PR TITLE
Add missing break when writing IntArrayTag.

### DIFF
--- a/src/main/java/com/sk89q/jnbt/NBTOutputStream.java
+++ b/src/main/java/com/sk89q/jnbt/NBTOutputStream.java
@@ -159,6 +159,7 @@ public final class NBTOutputStream implements Closeable {
             break;
         case NBTConstants.TYPE_INT_ARRAY:
             writeIntArrayTagPayload((IntArrayTag) tag);
+            break;
         default:
             throw new IOException("Invalid tag type: " + type + ".");
         }


### PR DESCRIPTION
This cause an error during saving schematic using IntArrayTag.
