### PR TITLE
Fix CUI activation after rejoining.

### DIFF
--- a/src/main/java/com/sk89q/worldedit/bukkit/WorldEditListener.java
+++ b/src/main/java/com/sk89q/worldedit/bukkit/WorldEditListener.java
@@ -87,7 +87,6 @@ public class WorldEditListener implements Listener {
     @EventHandler
     public void onPlayerQuit(PlayerQuitEvent event) {
         plugin.getWorldEdit().markExpire(plugin.wrapPlayer(event.getPlayer()));
-        plugin.setPluginChannelCUI(event.getPlayer().getName(), false);
     }
 
     /**


### PR DESCRIPTION
This change allows CUI to work after quitting and rejoining a server. Prior to this
change, quitting a server removes the name from the plugin channel user list. Rejoining
does not add the name back to the list, because CUI has already been initialized, and the
code falls back to chat packets, which recent versions of the mod do not decect anymore.
This causes no regions to be shown, and purple chat messages are shown.
