### PR TITLE
Various Spout fixes

### DIFF
--- a/src/main/java/com/sk89q/worldedit/spout/SpoutPlayer.java
+++ b/src/main/java/com/sk89q/worldedit/spout/SpoutPlayer.java
@@ -34,8 +34,9 @@ import org.spout.api.chat.style.ChatStyle;
 import org.spout.api.entity.Entity;
 import org.spout.api.geo.discrete.Point;
 import org.spout.api.inventory.ItemStack;
-import org.spout.api.material.MaterialRegistry;
 import org.spout.api.player.Player;
+import org.spout.vanilla.material.VanillaMaterial;
+import org.spout.vanilla.material.VanillaMaterials;
 import org.spout.vanilla.controller.living.player.VanillaPlayer;
 
 public class SpoutPlayer extends LocalPlayer {
@@ -53,7 +54,7 @@ public class SpoutPlayer extends LocalPlayer {
     public int getItemInHand() {
         VanillaPlayer vanillaPlayer = (VanillaPlayer) player.getEntity().getController();
         ItemStack itemStack = vanillaPlayer.getInventory().getQuickbar().getCurrentItem();
-        return itemStack != null ? itemStack.getMaterial().getId() : 0;
+        return itemStack != null ? ((VanillaMaterial) itemStack.getMaterial()).getMinecraftId() : 0;
     }
 
     @Override
@@ -81,7 +82,7 @@ public class SpoutPlayer extends LocalPlayer {
     @Override
     public void giveItem(int type, int amt) {
         VanillaPlayer vanillaPlayer = (VanillaPlayer) player.getEntity().getController();
-        vanillaPlayer.getInventory().addItem(new ItemStack(MaterialRegistry.get((short) type), amt), false);
+        vanillaPlayer.getInventory().addItem(new ItemStack(VanillaMaterials.getMaterial((short) type), amt), false);
     }
 
     @Override

--- a/src/main/java/com/sk89q/worldedit/spout/SpoutPlayerBlockBag.java
+++ b/src/main/java/com/sk89q/worldedit/spout/SpoutPlayerBlockBag.java
@@ -32,8 +32,8 @@ import com.sk89q.worldedit.blocks.BlockID;
 import org.spout.api.inventory.InventoryBase;
 import org.spout.api.inventory.ItemStack;
 import org.spout.api.material.Material;
-import org.spout.api.material.MaterialRegistry;
 import org.spout.api.player.Player;
+import org.spout.vanilla.material.VanillaMaterials;
 import org.spout.vanilla.util.VanillaPlayerUtil;
 
 public class SpoutPlayerBlockBag extends BlockBag {
@@ -84,7 +84,7 @@ public class SpoutPlayerBlockBag extends BlockBag {
         final short damage = item.getDamage();
         int amount = (item instanceof BaseItemStack) ? ((BaseItemStack) item).getAmount() : 1;
         assert(amount == 1);
-        Material mat = MaterialRegistry.get(id);
+        Material mat = VanillaMaterials.getMaterial(id);
         if (mat.hasSubMaterials()) {
             mat = mat.getSubMaterial(damage);
         }
@@ -98,25 +98,25 @@ public class SpoutPlayerBlockBag extends BlockBag {
         boolean found = false;
 
         for (int slot = 0; slot < items.length; ++slot) {
-            ItemStack bukkitItem = items[slot];
+            ItemStack spoutItem = items[slot];
 
-            if (bukkitItem == null) {
+            if (spoutItem == null) {
                 continue;
             }
 
-            if (!bukkitItem.getMaterial().equals(mat)) {
+            if (!spoutItem.getMaterial().equals(mat)) {
                 // Type id or damage value doesn't fit
                 continue;
             }
 
-            int currentAmount = bukkitItem.getAmount();
+            int currentAmount = spoutItem.getAmount();
             if (currentAmount < 0) {
                 // Unlimited
                 return;
             }
 
             if (currentAmount > 1) {
-                bukkitItem.setAmount(currentAmount - 1);
+                spoutItem.setAmount(currentAmount - 1);
                 found = true;
             } else {
                 items[slot] = null;
@@ -140,7 +140,7 @@ public class SpoutPlayerBlockBag extends BlockBag {
     public void storeItem(BaseItem item) throws BlockBagException {
         final short id = (short) item.getType();
         final short damage = item.getDamage();
-        Material mat = MaterialRegistry.get(id);
+        Material mat = VanillaMaterials.getMaterial(id);
         if (mat.hasSubMaterials()) {
             mat = mat.getSubMaterial(damage);
         }
@@ -156,9 +156,9 @@ public class SpoutPlayerBlockBag extends BlockBag {
         int freeSlot = -1;
 
         for (int slot = 0; slot < items.length; ++slot) {
-            ItemStack bukkitItem = items[slot];
+            ItemStack spoutItem = items[slot];
 
-            if (bukkitItem == null) {
+            if (spoutItem == null) {
                 // Delay using up a free slot until we know there are no stacks
                 // of this item to merge into
 
@@ -168,12 +168,12 @@ public class SpoutPlayerBlockBag extends BlockBag {
                 continue;
             }
 
-            if (!bukkitItem.getMaterial().equals(mat)) {
+            if (!spoutItem.getMaterial().equals(mat)) {
                 // Type id or damage value doesn't fit
                 continue;
             }
 
-            int currentAmount = bukkitItem.getAmount();
+            int currentAmount = spoutItem.getAmount();
             if (currentAmount < 0) {
                 // Unlimited
                 return;
@@ -185,11 +185,11 @@ public class SpoutPlayerBlockBag extends BlockBag {
 
             int spaceLeft = mat.getMaxStackSize() - currentAmount;
             if (spaceLeft >= amount) {
-                bukkitItem.setAmount(currentAmount + amount);
+                spoutItem.setAmount(currentAmount + amount);
                 return;
             }
 
-            bukkitItem.setAmount(mat.getMaxStackSize());
+            spoutItem.setAmount(mat.getMaxStackSize());
             amount -= spaceLeft;
         }
 

--- a/src/main/java/com/sk89q/worldedit/spout/SpoutServerInterface.java
+++ b/src/main/java/com/sk89q/worldedit/spout/SpoutServerInterface.java
@@ -32,6 +32,7 @@ import org.spout.api.geo.World;
 import org.spout.api.material.Material;
 import org.spout.api.material.MaterialRegistry;
 import org.spout.api.scheduler.TaskPriority;
+import org.spout.vanilla.material.VanillaMaterial;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -54,7 +55,7 @@ public class SpoutServerInterface extends ServerInterface {
     @Override
     public int resolveItem(String name) {
         Material mat = MaterialRegistry.get(name);
-        return mat == null ? 0 : mat.getId();
+        return mat == null || !(mat instanceof VanillaMaterial) ? 0 : ((VanillaMaterial) mat).getMinecraftId();
     }
 
     @Override

--- a/src/main/java/com/sk89q/worldedit/spout/SpoutWorld.java
+++ b/src/main/java/com/sk89q/worldedit/spout/SpoutWorld.java
@@ -43,13 +43,16 @@ import org.spout.api.geo.cuboid.Chunk;
 import org.spout.api.inventory.ItemStack;
 import org.spout.api.material.BlockMaterial;
 import org.spout.api.material.Material;
-import org.spout.api.material.MaterialRegistry;
 import org.spout.api.math.Vector3;
 import org.spout.vanilla.controller.object.moving.Item;
 import org.spout.vanilla.controller.object.moving.PrimedTnt;
 import org.spout.vanilla.controller.object.projectile.Arrow;
 import org.spout.vanilla.controller.object.vehicle.Boat;
 import org.spout.vanilla.controller.object.vehicle.Minecart;
+import org.spout.vanilla.material.VanillaMaterial;
+import org.spout.vanilla.material.VanillaMaterials;
+import org.spout.vanilla.world.generator.normal.object.tree.TreeObject;
+import org.spout.vanilla.world.generator.normal.object.tree.SmallTreeObject;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -93,7 +96,7 @@ public class SpoutWorld extends LocalWorld {
      */
     @Override
     public boolean setBlockType(Vector pt, int type) {
-        Material mat = MaterialRegistry.get((short) type);
+        Material mat = VanillaMaterials.getMaterial((short) type);
         if (mat != null && mat instanceof BlockMaterial) {
             return world.setBlockMaterial(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ(), (BlockMaterial) mat, (short)0, WorldEditPlugin.getInstance());
         }
@@ -121,7 +124,7 @@ public class SpoutWorld extends LocalWorld {
      */
     @Override
     public boolean setTypeIdAndData(Vector pt, int type, int data) {
-        Material mat = MaterialRegistry.get((short) type);
+        Material mat = VanillaMaterials.getMaterial((short) type);
         if (mat != null && mat instanceof BlockMaterial) {
             return world.setBlockMaterial(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ(), (BlockMaterial) mat, (short)data, WorldEditPlugin.getInstance());
         }
@@ -149,7 +152,8 @@ public class SpoutWorld extends LocalWorld {
      */
     @Override
     public int getBlockType(Vector pt) {
-        return world.getBlockMaterial(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ()).getId();
+        Material mat = world.getBlockMaterial(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ());
+        return mat instanceof VanillaMaterial? ((VanillaMaterial) mat).getMinecraftId() : 0;
     }
 
     /**
@@ -422,7 +426,12 @@ public class SpoutWorld extends LocalWorld {
     @Override
     public boolean generateTree(TreeGenerator.TreeType type, EditSession editSession, Vector pt)
             throws MaxChangedBlocksException {
-        throw new UnsupportedOperationException("Not supported yet.");
+        TreeObject tree = new SmallTreeObject(); //TODO: properly check for tree type
+        if (!tree.canPlaceObject(world, pt.getBlockX(), pt.getBlockY(), pt.getBlockZ())) {
+            return false;
+        }
+        tree.placeObject(world, pt.getBlockX(), pt.getBlockY(), pt.getBlockZ());
+        return true;
     }
 
     /**
@@ -433,12 +442,12 @@ public class SpoutWorld extends LocalWorld {
      */
     @Override
     public void dropItem(Vector pt, BaseItemStack item) {
-        Material mat = MaterialRegistry.get((short) item.getType());
+        Material mat = VanillaMaterials.getMaterial((short) item.getType());
         if (mat.hasSubMaterials()) {
             mat = mat.getSubMaterial(item.getDamage());
         }
-        ItemStack bukkitItem = new ItemStack(mat, item.getDamage(), item.getAmount());
-        world.createAndSpawnEntity(SpoutUtil.toPoint(world, pt), new Item(bukkitItem, new Vector3(pt.getX(), pt.getY(), pt.getZ())));
+        ItemStack spoutItem = new ItemStack(mat, item.getDamage(), item.getAmount());
+        world.createAndSpawnEntity(SpoutUtil.toPoint(world, pt), new Item(spoutItem, new Vector3(pt.getX(), pt.getY(), pt.getZ())));
     }
 
     /**
@@ -685,7 +694,7 @@ public class SpoutWorld extends LocalWorld {
      */
     @Override
     public boolean isValidBlockType(int type) {
-        return MaterialRegistry.get((short)type) instanceof BlockMaterial;
+        return VanillaMaterials.getMaterial((short)type) instanceof BlockMaterial;
     }
 
     @Override

--- a/src/main/java/com/sk89q/worldedit/spout/WorldEditListener.java
+++ b/src/main/java/com/sk89q/worldedit/spout/WorldEditListener.java
@@ -138,8 +138,8 @@ public class WorldEditListener implements Listener {
 
             if (!event.isAir()) {
                 final Point clickedBlock = event.getInteractedPoint();
-                final WorldVector pos = new WorldVector(world, clickedBlock.getX(),
-                        clickedBlock.getY(), clickedBlock.getZ());
+                final WorldVector pos = new WorldVector(world, clickedBlock.getBlockX(),
+                        clickedBlock.getBlockY(), clickedBlock.getBlockZ());
 
 
                 if (we.handleBlockLeftClick(player, pos)) {
@@ -165,8 +165,8 @@ public class WorldEditListener implements Listener {
         } else if (action == Action.RIGHT_CLICK) {
             if (!event.isAir()) {
                 final Point clickedBlock = event.getInteractedPoint();
-                final WorldVector pos = new WorldVector(world, clickedBlock.getX(),
-                        clickedBlock.getY(), clickedBlock.getZ());
+                final WorldVector pos = new WorldVector(world, clickedBlock.getBlockX(),
+                        clickedBlock.getBlockY(), clickedBlock.getBlockZ());
 
                 if (we.handleBlockRightClick(player, pos)) {
                     event.setCancelled(true);


### PR DESCRIPTION
- use the Minecraft Block ID obtained from VanillaMaterial.getMinecraftId() instead of the Spout ID, as the two no longer seems to match
- switched to VanillaMaterials from MaterialRegistry for the same reason
- use the block coordinates from a Point to fix blocks' coordinates being off by 1
- added a very rudimentary implementation of the tree generator; only standard small trees are generated
- fixed some variables' names beginning with bukkit instead of spout
