### PR TITLE
Fix loading schematic files with block data values >127

### DIFF
--- a/src/main/java/com/sk89q/worldedit/schematic/MCEditSchematicFormat.java
+++ b/src/main/java/com/sk89q/worldedit/schematic/MCEditSchematicFormat.java
@@ -121,7 +121,7 @@ public class MCEditSchematicFormat extends SchematicFormat {
             }
         } else {
             for (int i = 0; i < rawBlocks.length; ++i) {
-                blocks[i] = rawBlocks[i];
+                blocks[i] = (short) (rawBlocks[i] & 0xFF);
             }
         }
 


### PR DESCRIPTION
Minecraft 1.3 introduces several blocks with data values
over 127, such as sandstone stairs (128).  Since byte
is signed, implicit conversion to short results in
negative block data values that cause later IndexOutOfBounds
exceptions.  This change explicitly masks off the extended
sign bits so the result is positive.
