### PR TITLE
Implement EditSessionFactory

### DIFF
--- a/src/main/java/com/sk89q/worldedit/EditSessionFactory.java
+++ b/src/main/java/com/sk89q/worldedit/EditSessionFactory.java
@@ -1,0 +1,28 @@
+package com.sk89q.worldedit;
+
+import com.sk89q.worldedit.bags.BlockBag;
+
+public class EditSessionFactory {
+    
+    /**
+     * Construct an edit session with a maximum number of blocks.
+     *
+     * @param world
+     * @param maxBlocks
+     */
+    public EditSession getEditSession(LocalWorld world, int maxBlocks) {
+        return new EditSession(world, maxBlocks);
+    }
+    
+    /**
+     * Construct an edit session with a maximum number of blocks and a block bag.
+     *
+     * @param world
+     * @param maxBlocks
+     * @param blockBag
+     */
+    public EditSession getEditSession(LocalWorld world, int maxBlocks, BlockBag blockBag) {
+        return new EditSession(world, maxBlocks, blockBag);
+    }
+
+}

--- a/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -142,8 +142,8 @@ public class LocalSession {
         --historyPointer;
         if (historyPointer >= 0) {
             EditSession editSession = history.get(historyPointer);
-            EditSession newEditSession =
-                    new EditSession(editSession.getWorld(), -1, newBlockBag);
+            EditSession newEditSession = WorldEdit.getInstance().getEditSessionFactory()
+                    .getEditSession(editSession.getWorld(), -1, newBlockBag);
             newEditSession.enableQueue();
             newEditSession.setFastMode(fastMode);
             editSession.undo(newEditSession);
@@ -163,8 +163,8 @@ public class LocalSession {
     public EditSession redo(BlockBag newBlockBag) {
         if (historyPointer < history.size()) {
             EditSession editSession = history.get(historyPointer);
-            EditSession newEditSession =
-                    new EditSession(editSession.getWorld(), -1, newBlockBag);
+            EditSession newEditSession = WorldEdit.getInstance().getEditSessionFactory()
+                    .getEditSession(editSession.getWorld(), -1, newBlockBag);
             newEditSession.enableQueue();
             newEditSession.setFastMode(fastMode);
             editSession.redo(newEditSession);
@@ -698,8 +698,8 @@ public class LocalSession {
         BlockBag blockBag = getBlockBag(player);
 
         // Create an edit session
-        EditSession editSession =
-                new EditSession(player.isPlayer() ? player.getWorld() : null,
+        EditSession editSession = WorldEdit.getInstance().getEditSessionFactory()
+                .getEditSession(player.isPlayer() ? player.getWorld() : null,
                         getBlockChangeLimit(), blockBag);
         editSession.setFastMode(fastMode);
         if (mask != null) {

--- a/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -113,6 +113,11 @@ public class WorldEdit {
     public static final Logger logger = Logger.getLogger("Minecraft.WorldEdit");
 
     /**
+     * Holds the current instance of this class, for static access
+     */
+    private static WorldEdit instance;
+    
+    /**
      * Holds WorldEdit's version.
      */
     private static String version;
@@ -131,6 +136,11 @@ public class WorldEdit {
      * List of commands.
      */
     private final CommandsManager<LocalPlayer> commands;
+    
+    /**
+     * Holds the factory responsible for the creation of edit sessions
+     */
+    private EditSessionFactory editSessionFactory = new EditSessionFactory();
 
     /**
      * Stores a list of WorldEdit sessions, keyed by players' names. Sessions
@@ -155,6 +165,7 @@ public class WorldEdit {
      * @param config
      */
     public WorldEdit(ServerInterface server, final LocalConfiguration config) {
+        instance = this;
         this.server = server;
         this.config = config;
 
@@ -251,6 +262,15 @@ public class WorldEdit {
 
     private void reg(Class<?> clazz) {
         server.onCommandRegistration(commands.registerAndReturn(clazz), commands);
+    }
+
+    /**
+     * Gets the current instance of this class
+     * 
+     * @return
+     */
+    public static WorldEdit getInstance() {
+        return instance;
     }
 
     /**
@@ -1527,6 +1547,28 @@ public class WorldEdit {
      */
     public ServerInterface getServer() {
         return server;
+    }
+
+    /**
+     * Get the edit session factory
+     * 
+     * @return
+     */
+    public EditSessionFactory getEditSessionFactory() {
+        return this.editSessionFactory;
+    }
+
+    /**
+     * Set the edit session factory
+     * 
+     * @param factory
+     */
+    public void setEditSessionFactory(EditSessionFactory factory) {
+        if (factory == null) {
+            throw new IllegalArgumentException("New EditSessionFactory may not be null");
+        }
+        logger.info("Accepted EditSessionFactory of type " + factory.getClass().getName() + " from " + factory.getClass().getPackage().getName());
+        this.editSessionFactory = factory;
     }
 
     /**

--- a/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -220,8 +220,8 @@ public class WorldEditPlugin extends JavaPlugin {
         LocalSession session = controller.getSession(wePlayer);
         BlockBag blockBag = session.getBlockBag(wePlayer);
 
-        EditSession editSession =
-                new EditSession(wePlayer.getWorld(), session.getBlockChangeLimit(), blockBag);
+        EditSession editSession = controller.getEditSessionFactory()
+                .getEditSession(wePlayer.getWorld(), session.getBlockChangeLimit(), blockBag);
         editSession.enableQueue();
 
         return editSession;

--- a/src/main/java/com/sk89q/worldedit/scripting/CraftScriptContext.java
+++ b/src/main/java/com/sk89q/worldedit/scripting/CraftScriptContext.java
@@ -60,8 +60,8 @@ public class CraftScriptContext extends CraftScriptEnvironment {
      * @return
      */
     public EditSession remember() {
-        EditSession editSession =
-                new EditSession(player.getWorld(),
+        EditSession editSession = controller.getEditSessionFactory()
+                .getEditSession(player.getWorld(),
                         session.getBlockChangeLimit(), session.getBlockBag(player));
         editSession.enableQueue();
         editSessions.add(editSession);

--- a/src/main/java/com/sk89q/worldedit/tools/BlockReplacer.java
+++ b/src/main/java/com/sk89q/worldedit/tools/BlockReplacer.java
@@ -46,7 +46,7 @@ public class BlockReplacer implements DoubleActionBlockTool {
         BlockBag bag = session.getBlockBag(player);
 
         LocalWorld world = clicked.getWorld();
-        EditSession editSession = new EditSession(world, -1, bag);
+        EditSession editSession = WorldEdit.getInstance().getEditSessionFactory().getEditSession(world, -1, bag);
 
         try {
             editSession.setBlock(clicked, targetBlock);
@@ -66,7 +66,8 @@ public class BlockReplacer implements DoubleActionBlockTool {
             LocalSession session, WorldVector clicked) {
 
         LocalWorld world = clicked.getWorld();
-        targetBlock = (new EditSession(world, -1)).getBlock(clicked);
+        EditSession editSession = WorldEdit.getInstance().getEditSessionFactory().getEditSession(world, -1);
+        targetBlock = (editSession).getBlock(clicked);
         BlockType type = BlockType.fromID(targetBlock.getType());
 
         if (type != null) {

--- a/src/main/java/com/sk89q/worldedit/tools/QueryTool.java
+++ b/src/main/java/com/sk89q/worldedit/tools/QueryTool.java
@@ -37,7 +37,8 @@ public class QueryTool implements BlockTool {
             LocalPlayer player, LocalSession session, WorldVector clicked) {
 
         LocalWorld world = clicked.getWorld();
-        BaseBlock block = (new EditSession(world, 0)).rawGetBlock(clicked);
+        EditSession editSession = WorldEdit.getInstance().getEditSessionFactory().getEditSession(world, 0);
+        BaseBlock block = (editSession).rawGetBlock(clicked);
         BlockType type = BlockType.fromID(block.getType());
 
         player.print("\u00A79@" + clicked + ": " + "\u00A7e"


### PR DESCRIPTION
Discussed this quite a bit with @TomyLobo. This provides other plugins with the ability to hook into WorldEdit block changing with minimal overheads. By allowing other plugins to extend the factory they can override the getter based constructors and provide an extended version of their own EditSession class where they can override existing methods, do whatever they need to with the data and then simply call super.method() in order to hook into WorldEdit block changing easily and painlessly. My use case for this is implementing a WorldEdit logging feature in LogBlock.
