### PR TITLE
Add missing spout WorldEditPlugin edit session factory call

### DIFF
--- a/src/spout/java/com/sk89q/worldedit/spout/WorldEditPlugin.java
+++ b/src/spout/java/com/sk89q/worldedit/spout/WorldEditPlugin.java
@@ -209,8 +209,8 @@ public class WorldEditPlugin extends CommonPlugin {
         LocalSession session = controller.getSession(wePlayer);
         BlockBag blockBag = session.getBlockBag(wePlayer);
 
-        EditSession editSession =
-                new EditSession(wePlayer.getWorld(), session.getBlockChangeLimit(), blockBag);
+        EditSession editSession = WorldEdit.getInstance().getEditSessionFactory()
+                .getEditSession(wePlayer.getWorld(), session.getBlockChangeLimit(), blockBag);
         editSession.enableQueue();
 
         return editSession;


### PR DESCRIPTION
Looks like I missed this due to the way spout was refactored to a different source folder
