### PR TITLE
Restore usage of Pre-Anvil chunks.

### DIFF
--- a/src/main/java/com/sk89q/worldedit/data/FileMcRegionChunkStore.java
+++ b/src/main/java/com/sk89q/worldedit/data/FileMcRegionChunkStore.java
@@ -45,12 +45,12 @@ public class FileMcRegionChunkStore extends McRegionChunkStore {
     protected InputStream getInputStream(String name, String world) throws IOException,
             DataException {
         String fileName = "region" + File.separator + name;
-        File file = new File(path, fileName.replace("mcr", "mca")); // TODO: does this need a separate class?
+        File file = new File(path, fileName.replace("mca", "mcr")); // TODO: does this need a separate class?
         if (!file.exists()) {
             file = new File(path, fileName);
         }
         if (!file.exists()) {
-            file = new File(path, "DIM-1" + File.separator + fileName.replace("mcr", "mca")); // TODO: does this need a separate class?
+            file = new File(path, "DIM-1" + File.separator + fileName.replace("mca", "mcr")); // TODO: does this need a separate class?
         }
         if (!file.exists()) {
             file = new File(path, "DIM-1" + File.separator + fileName);


### PR DESCRIPTION
The change of mca -> mcr and mcr -> mca was needed because somewhere along the line the base extension of chunks was changed from mcr to mca which broke this temp-fix for usage of both chunk types.
  This fix is needed to allow people to use their old backups again instead of making them seem corrupted.
