### PR TITLE
Pass LocalPlayers to the EditSession getters for easy external access

### DIFF
--- a/src/main/java/com/sk89q/worldedit/EditSessionFactory.java
+++ b/src/main/java/com/sk89q/worldedit/EditSessionFactory.java
@@ -3,7 +3,7 @@ package com.sk89q.worldedit;
 import com.sk89q.worldedit.bags.BlockBag;
 
 public class EditSessionFactory {
-    
+
     /**
      * Construct an edit session with a maximum number of blocks.
      *
@@ -13,7 +13,18 @@ public class EditSessionFactory {
     public EditSession getEditSession(LocalWorld world, int maxBlocks) {
         return new EditSession(world, maxBlocks);
     }
-    
+
+    /**
+     * Construct an edit session with a maximum number of blocks.
+     *
+     * @param world
+     * @param maxBlocks
+     * @param player
+     */
+    public EditSession getEditSession(LocalWorld world, int maxBlocks, LocalPlayer player) {
+        return this.getEditSession(world, maxBlocks);
+    }
+
     /**
      * Construct an edit session with a maximum number of blocks and a block bag.
      *
@@ -23,6 +34,18 @@ public class EditSessionFactory {
      */
     public EditSession getEditSession(LocalWorld world, int maxBlocks, BlockBag blockBag) {
         return new EditSession(world, maxBlocks, blockBag);
+    }
+
+    /**
+     * Construct an edit session with a maximum number of blocks and a block bag.
+     *
+     * @param world
+     * @param maxBlocks
+     * @param blockBag
+     * @param player
+     */
+    public EditSession getEditSession(LocalWorld world, int maxBlocks, BlockBag blockBag, LocalPlayer player) {
+        return this.getEditSession(world, maxBlocks, blockBag);
     }
 
 }

--- a/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -136,14 +136,15 @@ public class LocalSession {
      * Performs an undo.
      *
      * @param newBlockBag
+     * @param player
      * @return whether anything was undone
      */
-    public EditSession undo(BlockBag newBlockBag) {
+    public EditSession undo(BlockBag newBlockBag, LocalPlayer player) {
         --historyPointer;
         if (historyPointer >= 0) {
             EditSession editSession = history.get(historyPointer);
             EditSession newEditSession = WorldEdit.getInstance().getEditSessionFactory()
-                    .getEditSession(editSession.getWorld(), -1, newBlockBag);
+                    .getEditSession(editSession.getWorld(), -1, newBlockBag, player);
             newEditSession.enableQueue();
             newEditSession.setFastMode(fastMode);
             editSession.undo(newEditSession);
@@ -158,13 +159,14 @@ public class LocalSession {
      * Performs a redo
      *
      * @param newBlockBag
+     * @param player
      * @return whether anything was redone
      */
-    public EditSession redo(BlockBag newBlockBag) {
+    public EditSession redo(BlockBag newBlockBag, LocalPlayer player) {
         if (historyPointer < history.size()) {
             EditSession editSession = history.get(historyPointer);
             EditSession newEditSession = WorldEdit.getInstance().getEditSessionFactory()
-                    .getEditSession(editSession.getWorld(), -1, newBlockBag);
+                    .getEditSession(editSession.getWorld(), -1, newBlockBag, player);
             newEditSession.enableQueue();
             newEditSession.setFastMode(fastMode);
             editSession.redo(newEditSession);
@@ -700,7 +702,7 @@ public class LocalSession {
         // Create an edit session
         EditSession editSession = WorldEdit.getInstance().getEditSessionFactory()
                 .getEditSession(player.isPlayer() ? player.getWorld() : null,
-                        getBlockChangeLimit(), blockBag);
+                        getBlockChangeLimit(), blockBag, player);
         editSession.setFastMode(fastMode);
         if (mask != null) {
             mask.prepare(this, player, null);

--- a/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -221,7 +221,7 @@ public class WorldEditPlugin extends JavaPlugin {
         BlockBag blockBag = session.getBlockBag(wePlayer);
 
         EditSession editSession = controller.getEditSessionFactory()
-                .getEditSession(wePlayer.getWorld(), session.getBlockChangeLimit(), blockBag);
+                .getEditSession(wePlayer.getWorld(), session.getBlockChangeLimit(), blockBag, wePlayer);
         editSession.enableQueue();
 
         return editSession;

--- a/src/main/java/com/sk89q/worldedit/commands/HistoryCommands.java
+++ b/src/main/java/com/sk89q/worldedit/commands/HistoryCommands.java
@@ -56,7 +56,7 @@ public class HistoryCommands {
         for (int i = 0; i < times; ++i) {
             EditSession undone;
             if (args.argsLength() < 2) {
-                undone = session.undo(session.getBlockBag(player));
+                undone = session.undo(session.getBlockBag(player), player);
             } else {
                 player.checkPermission("worldedit.history.undo.other");
                 LocalSession sess = we.getSession(args.getString(1));
@@ -64,7 +64,7 @@ public class HistoryCommands {
                     player.printError("Unable to find session for " + args.getString(1));
                     break;
                 }
-                undone = sess.undo(session.getBlockBag(player));
+                undone = sess.undo(session.getBlockBag(player), player);
             }
 
             if (undone != null) {
@@ -98,7 +98,7 @@ public class HistoryCommands {
         for (int i = 0; i < times; ++i) {
             EditSession redone;
             if (args.argsLength() < 2) {
-                redone = session.redo(session.getBlockBag(player));
+                redone = session.redo(session.getBlockBag(player), player);
             } else {
                 player.checkPermission("worldedit.history.redo.other");
                 LocalSession sess = we.getSession(args.getString(1));
@@ -106,7 +106,7 @@ public class HistoryCommands {
                     player.printError("Unable to find session for " + args.getString(1));
                     break;
                 }
-                redone = sess.redo(session.getBlockBag(player));
+                redone = sess.redo(session.getBlockBag(player), player);
             }
 
             if (redone != null) {

--- a/src/main/java/com/sk89q/worldedit/scripting/CraftScriptContext.java
+++ b/src/main/java/com/sk89q/worldedit/scripting/CraftScriptContext.java
@@ -62,7 +62,7 @@ public class CraftScriptContext extends CraftScriptEnvironment {
     public EditSession remember() {
         EditSession editSession = controller.getEditSessionFactory()
                 .getEditSession(player.getWorld(),
-                        session.getBlockChangeLimit(), session.getBlockBag(player));
+                        session.getBlockChangeLimit(), session.getBlockBag(player), player);
         editSession.enableQueue();
         editSessions.add(editSession);
         return editSession;

--- a/src/main/java/com/sk89q/worldedit/tools/BlockReplacer.java
+++ b/src/main/java/com/sk89q/worldedit/tools/BlockReplacer.java
@@ -46,7 +46,7 @@ public class BlockReplacer implements DoubleActionBlockTool {
         BlockBag bag = session.getBlockBag(player);
 
         LocalWorld world = clicked.getWorld();
-        EditSession editSession = WorldEdit.getInstance().getEditSessionFactory().getEditSession(world, -1, bag);
+        EditSession editSession = WorldEdit.getInstance().getEditSessionFactory().getEditSession(world, -1, bag, player);
 
         try {
             editSession.setBlock(clicked, targetBlock);
@@ -66,7 +66,7 @@ public class BlockReplacer implements DoubleActionBlockTool {
             LocalSession session, WorldVector clicked) {
 
         LocalWorld world = clicked.getWorld();
-        EditSession editSession = WorldEdit.getInstance().getEditSessionFactory().getEditSession(world, -1);
+        EditSession editSession = WorldEdit.getInstance().getEditSessionFactory().getEditSession(world, -1, player);
         targetBlock = (editSession).getBlock(clicked);
         BlockType type = BlockType.fromID(targetBlock.getType());
 

--- a/src/main/java/com/sk89q/worldedit/tools/QueryTool.java
+++ b/src/main/java/com/sk89q/worldedit/tools/QueryTool.java
@@ -37,7 +37,7 @@ public class QueryTool implements BlockTool {
             LocalPlayer player, LocalSession session, WorldVector clicked) {
 
         LocalWorld world = clicked.getWorld();
-        EditSession editSession = WorldEdit.getInstance().getEditSessionFactory().getEditSession(world, 0);
+        EditSession editSession = WorldEdit.getInstance().getEditSessionFactory().getEditSession(world, 0, player);
         BaseBlock block = (editSession).rawGetBlock(clicked);
         BlockType type = BlockType.fromID(block.getType());
 

--- a/src/spout/java/com/sk89q/worldedit/spout/WorldEditPlugin.java
+++ b/src/spout/java/com/sk89q/worldedit/spout/WorldEditPlugin.java
@@ -215,7 +215,7 @@ public class WorldEditPlugin extends CommonPlugin {
         BlockBag blockBag = session.getBlockBag(wePlayer);
 
         EditSession editSession = WorldEdit.getInstance().getEditSessionFactory()
-                .getEditSession(wePlayer.getWorld(), session.getBlockChangeLimit(), blockBag);
+                .getEditSession(wePlayer.getWorld(), session.getBlockChangeLimit(), blockBag, wePlayer);
         editSession.enableQueue();
 
         return editSession;


### PR DESCRIPTION
Note that the LocalPlayer isn't used in the default EditSessionFactory's getter/constructors, its merely to allow developers extending it to resolve the player who the EditSession is being constructed for.
