### PR TITLE
Fixed ContainerBlocks spilling items when edited

### DIFF
--- a/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -194,7 +194,7 @@ public class EditSession {
         final int existing = world.getBlockType(pt);
 
         // Clear the container block so that it doesn't drop items
-        if (BlockType.isContainerBlock(existing) && blockBag == null) {
+        if (BlockType.isContainerBlock(existing)) {
             world.clearContainerBlockContents(pt);
             // Ice turns until water so this has to be done first
         } else if (existing == BlockID.ICE) {


### PR DESCRIPTION
Fixed ContainerBlocks spilling items when edited, which caused an Item Duplication Exploit.

http://youtrack.sk89q.com/issue/WORLDEDIT-2381 - [Now Resolved]
