### PR TITLE
Adds possibility to execute method body of a @NestedCommand tagged command

### DIFF
--- a/src/main/java/com/sk89q/minecraft/util/commands/NestedCommand.java
+++ b/src/main/java/com/sk89q/minecraft/util/commands/NestedCommand.java
@@ -38,4 +38,9 @@ public @interface NestedCommand {
      * A list of classes with the child commands.
      */
     Class<?>[] value();
+
+    /**
+     * If set to true it will execute the body of the tagged method.
+     */
+    boolean executeBody() default false;
 }


### PR DESCRIPTION
Hi,

lets try this again without me bitching around and with nice code standards, one commit and a use case ;)

Changes:
- Added boolean executeBody() to @NestedCommand that defaults to false
- Before dispatching the command to the method body it will now check if the command has 0 args and executeBody=true - if so it will execute the body of the tagged method.

Because the executeBody defaults to false it wont do anything anywhere until the param is used. All commands will work like before but new functionality is added to people who might want to use it.

Use Case:
Lets say you have a plugin that has the following command tree:
/myplugin
/myplugin add <args>
/myplugin remove <args>
/myplugin list <flags> <args>
At the moment I could do all of that but dont display information to the player when he only executes /myplugin. It will always display him the following help: /myplugin <add/remove/list>

Now if the base method has executeBody=true it will execute the body of that /myplugin base command and gives you the possibility to display information to the player.
