### PR TITLE
Combines the selection functionality of build 1302 with the flip functionality that existed prior.

### DIFF
--- a/src/main/java/com/sk89q/worldedit/CuboidClipboard.java
+++ b/src/main/java/com/sk89q/worldedit/CuboidClipboard.java
@@ -195,7 +195,7 @@ public class CuboidClipboard {
         final int height = getHeight();
 
         switch (dir) {
-        case NORTH_SOUTH:
+        case WEST_EAST:
             final int wid = (int) Math.ceil(width / 2.0f);
             for (int xs = 0; xs < wid; ++xs) {
                 for (int z = 0; z < length; ++z) {
@@ -214,7 +214,7 @@ public class CuboidClipboard {
 
             break;
 
-        case WEST_EAST:
+        case NORTH_SOUTH:
             final int len = (int) Math.ceil(length / 2.0f);
             for (int zs = 0; zs < len; ++zs) {
                 for (int x = 0; x < width; ++x) {


### PR DESCRIPTION
Necessary because selection is the most basic part of the plugin and should be the first thing to work as expected. If I say expand North, the selection should expand to the North. If I say move left, the selection contents should move to my left. If I say stack without giving a direction, the selection should be stacked in the direction I'm looking.
