### PR TITLE
added //schematic delete

### DIFF
--- a/src/main/java/com/sk89q/worldedit/commands/SchematicCommands.java
+++ b/src/main/java/com/sk89q/worldedit/commands/SchematicCommands.java
@@ -199,12 +199,13 @@ public class SchematicCommands {
         if (!f.exists()) {
             player.printError("Schematic " + fileName + " does not exist!");
             return;
-        } else if (!f.delete()) {
+        }
+
+        if (!f.delete()) {
             player.printError("Schematic " + fileName + " cannot be deleted!");
             return;
-        } else {
-            player.print(fileName + " has been deleted.");
         }
+        player.print(fileName + " has been deleted.");
     }
 
     @Command(


### PR DESCRIPTION
Updated from previous pull.

Deletes a schematic permanently from the schematics folder.
The idea is that you should not need ftp/shell access to delete worldedit generated schematics.
