### PR TITLE
Access to CommandManager registration with parent

### DIFF
--- a/src/main/java/com/sk89q/minecraft/util/commands/CommandsManager.java
+++ b/src/main/java/com/sk89q/minecraft/util/commands/CommandsManager.java
@@ -135,7 +135,7 @@ public abstract class CommandsManager<T> {
      * @param parent
      * @return Commands Registered
      */
-    private List<Command> registerMethods(Class<?> cls, Method parent) {
+    public List<Command> registerMethods(Class<?> cls, Method parent) {
         try {
             if (getInjector() == null) {
                 return registerMethods(cls, parent, null);


### PR DESCRIPTION
Made CommandManager registration with parent public so hooks can be made to existing commands

Making this change would make it possible for other plugins to use existing WorldEdit commands. (example: Someone wants to add a custom brush or tool but want to use the same familiar syntax as worldedit)

Woohoo for 1 word change.
