### PR TITLE
[WEPIF] Use equalsIgnoreCase for plugin name checks, and check for GroupManager

### DIFF
--- a/src/main/java/com/sk89q/wepif/PermissionsResolverManager.java
+++ b/src/main/java/com/sk89q/wepif/PermissionsResolverManager.java
@@ -273,8 +273,8 @@ public class PermissionsResolverManager implements PermissionsResolver {
             String name = plugin.getDescription().getName();
             if (plugin instanceof PermissionsProvider) {
                 setPluginPermissionsResolver(plugin);
-            } else if ("Permissions".equals(name) || "PermissionsEx".equals(name)
-                    || "bPermissions".equals(name)) {
+            } else if ("permissions".equalsIgnoreCase(name) || "permissionsex".equalsIgnoreCase(name)
+                    || "bpermissions".equalsIgnoreCase(name) || "groupmanager".equalsIgnoreCase(name)) {
                 load();
             }
         }
@@ -284,8 +284,8 @@ public class PermissionsResolverManager implements PermissionsResolver {
             String name = event.getPlugin().getDescription().getName();
 
             if (event.getPlugin() instanceof PermissionsProvider
-                    || "Permissions".equals(name) || "PermissionsEx".equals(name)
-                    || "bPermissions".equals(name)) {
+                    || "permissions".equalsIgnoreCase(name) || "permissionsex".equalsIgnoreCase(name)
+                    || "bpermissions".equalsIgnoreCase(name) || "groupmanager".equalsIgnoreCase(name)) {
                 load();
             }
         }


### PR DESCRIPTION
Using equalsIgnoreCase fixes a few weird issues with bPerms, and adding GroupManager fixes a metric tonne of issues with GroupManager.. Like it being randomly disabled, it not working, etc.
