### PR TITLE
Make region selection require permissions

### DIFF
--- a/src/main/java/com/sk89q/worldedit/commands/SelectionCommands.java
+++ b/src/main/java/com/sk89q/worldedit/commands/SelectionCommands.java
@@ -680,6 +680,7 @@ public class SelectionCommands {
         min = 0,
         max = 1
     )
+    @CommandPermissions("worldedit.selection.select")
     public void select(CommandContext args, LocalSession session, LocalPlayer player,
             EditSession editSession) throws WorldEditException {
 


### PR DESCRIPTION
There are a few other changes, no idea why, but I was using GH's built in editor. I don't really want people on my server typing `//desel`.
