### PR TITLE
May the "hand" be a BlockType

### DIFF
--- a/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -39,6 +39,8 @@ import java.util.regex.Matcher;
 
 import javax.script.ScriptException;
 
+import org.bukkit.inventory.ItemStack;
+
 import com.sk89q.minecraft.util.commands.CommandException;
 import com.sk89q.minecraft.util.commands.CommandPermissionsException;
 import com.sk89q.minecraft.util.commands.CommandUsageException;
@@ -60,6 +62,7 @@ import com.sk89q.worldedit.blocks.MobSpawnerBlock;
 import com.sk89q.worldedit.blocks.NoteBlock;
 import com.sk89q.worldedit.blocks.SignBlock;
 import com.sk89q.worldedit.blocks.SkullBlock;
+import com.sk89q.worldedit.bukkit.BukkitPlayer;
 import com.sk89q.worldedit.commands.BiomeCommands;
 import com.sk89q.worldedit.commands.ChunkCommands;
 import com.sk89q.worldedit.commands.ClipboardCommands;
@@ -396,7 +399,13 @@ public class WorldEdit {
         if (testID.equalsIgnoreCase("hand")) {
         	int handBlockId = player.getItemInHand();
         	if (player.getWorld().isValidBlockType(handBlockId)) {
-        		blockId = handBlockId;
+        		if (player instanceof BukkitPlayer) {
+	        		ItemStack itemStack = ((BukkitPlayer) player).getPlayer().getItemInHand();
+	        		blockId = itemStack.getTypeId();
+	        		data = itemStack.getData().getData();
+        		} else {
+        			blockId = handBlockId;        			
+        		}
         	} else {
         		throw new UnknownItemException(ItemType.fromID(handBlockId).getName());
         	}


### PR DESCRIPTION
This allows to use word "hand" where blockName or blockId should be otherwise:

//replace stone hand - will replace stone with block in hand
//set hand - will set selection to block in hand

and so on..
