### PR TITLE
Update the Forge implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /dependency-reduced-pom.xml
 /*.iml
 /.idea
+/forge-download

--- a/pom.xml
+++ b/pom.xml
@@ -304,6 +304,39 @@
   </build>
   
   <profiles>
+    <!-- Build WorldEdit for MC-Forge -->
+    <profile>
+      <id>forge</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>1.7</version>
+            <executions>
+              <execution>
+                <phase>compile</phase>
+                <configuration>
+                  <target>
+                    <property name="maven.build.directory"   value="${project.build.directory}"/>
+                    <property name="jchronic.path"           value="${maven.dependency.com.sk89q.jchronic.jar.path}"/>
+                    <property name="truezip.path"            value="${maven.dependency.de.schlichtherle.truezip.jar.path}"/>
+                    <property name="rhino.path"              value="${maven.dependency.rhino.js.jar.path}"/>
+                    <property name="snakeyaml.path"          value="${maven.dependency.org.yaml.snakeyaml.jar.path}"/>
+                    <property name="we.version"              value="${project.version}"/>
+                    <ant antfile="src/forge/ant/build.xml"/>
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <!-- Attach javadocs and source .jars -->
     <profile>
       <id>attach-docs</id>

--- a/src/forge/ant/build.xml
+++ b/src/forge/ant/build.xml
@@ -1,0 +1,150 @@
+<project name="WorldEdit-Forge" default="main">
+    <property environment="env"/>
+
+    <!-- Properties -->
+    <property name="build.dir"            value="${maven.build.directory}/forge"/>
+    <property name="resource.dir"         value="src/forge/resources"/>
+    <property name="src.forge.dir"        value="src/forge/java"/>
+    <property name="src.we.dir"           value="src/main/java"/>
+    <property name="bukkit.src.1"         value="com/sk89q/bukkit"/>
+    <property name="bukkit.src.2"         value="com/sk89q/worldedit/bukkit"/>
+    <property name="wepif.src"            value="com/sk89q/wepif"/>
+    <property name="util.yaml.src"        value="com/sk89q/util/yaml"/>
+    <property name="we.yaml.src"          value="com/sk89q/worldedit/util/YAMLConfiguration.java"/>
+
+    <property name="download.dir"         value="forge-download"/>
+
+    <property name="forge.dir"            value="${build.dir}/forge"/>
+    <property name="mcp.dir"              value="${forge.dir}/mcp"/>
+
+    <property name="minecraftsrc.dir"     value="${mcp.dir}/src/minecraft"/>
+
+    <property file="${minecraftsrc.dir}/fmlversion.properties" />
+
+    <property name="mc.version"           value="1.6.2"/>
+    <property name="forge.version"        value="9.10.1.850"/>
+
+    <!-- Targets -->
+    <target name="init-msg">
+        <echo message="Starting build for ${we.version} for MC ${mc.version}"/>
+    </target>
+
+    <target name="download">
+        <mkdir dir="${download.dir}"/>
+        
+        <get src="http://files.minecraftforge.net/minecraftforge/minecraftforge-src-${mc.version}-${forge.version}.zip" dest="${download.dir}" usetimestamp="True"/>
+        <echo message="Download finished"/>
+    </target>
+
+    <target name="check-setup-forge" depends="download">
+        <available file="${download.dir}/minecraftforge-setup-${mc.version}-${forge.version}.zip" property="setup.forge.present"/>
+    </target>
+
+    <target name="setup-forge" depends="check-setup-forge" unless="setup.forge.present">
+        <unzip dest="${build.dir}" failOnEmptyArchive="true">
+            <fileset dir="${download.dir}">
+                <include name="minecraftforge-src-${mc.version}-${forge.version}.zip"/>
+            </fileset>
+        </unzip>
+
+        <!-- Set executable permission on forge's *.sh -->
+        <chmod dir="${forge.dir}" perm="a+rx" includes="**.sh"/>
+
+        <!-- Install forge -->
+        <echo message="Starting forge install process"/>
+
+        <exec dir="${forge.dir}" executable="cmd" osfamily="windows" failonerror="true">
+            <arg value="/c"/>
+            <arg value="install.cmd"/>
+        </exec>
+
+        <exec dir="${forge.dir}" executable="sh" osfamily="unix" failonerror="true">
+            <arg value="install.sh"/>
+        </exec>
+
+        <echo message="Forge installation finished"/>
+
+        <zip destfile="${download.dir}/minecraftforge-setup-${mc.version}-${forge.version}.zip" basedir="${build.dir}"/>
+    </target>
+
+    <target name="unzip-forge" depends="check-setup-forge" if="setup.forge.present">
+        <unzip dest="${build.dir}" failOnEmptyArchive="true">
+            <fileset dir="${download.dir}">
+                <include name="minecraftforge-setup-${mc.version}-${forge.version}.zip"/>
+            </fileset>
+        </unzip>
+    </target>
+
+    <target name="copySRC" >
+        <!-- Copy WE dependencies source -->
+        <copy todir="${mcp.dir}/lib" file="${jchronic.path}"/>
+        <copy todir="${mcp.dir}/lib" file="${truezip.path}"/>
+        <copy todir="${mcp.dir}/lib" file="${rhino.path}"/>
+        <!--<copy todir="${mcp.dir}/lib" file="${snakeyaml.path}"/>-->
+        
+        <!-- Copy WE forge source -->
+        <copy todir="${minecraftsrc.dir}">
+            <fileset dir="${src.forge.dir}"/>
+        </copy>
+        <!-- Copy WE source -->
+        <copy todir="${minecraftsrc.dir}">
+            <fileset dir="${src.we.dir}"/>
+        </copy>
+        <!-- Delete bukkit related sources -->
+		<delete dir="${minecraftsrc.dir}/${bukkit.src.1}"/>
+		<delete dir="${minecraftsrc.dir}/${bukkit.src.2}"/>
+		<delete dir="${minecraftsrc.dir}/${wepif.src}"/>
+		<delete dir="${minecraftsrc.dir}/${util.yaml.src}"/>
+		<delete file="${minecraftsrc.dir}/${we.yaml.src}"/>
+
+        <!-- Set Version -->
+        <replace file="${minecraftsrc.dir}/com/sk89q/worldedit/forge/WorldEditMod.java" token="%VERSION%" value="${we.version}"/>
+    </target>
+
+    <target name="compile" depends="copySRC">
+
+        <echo message="Compiling version ${we.version}"/>
+
+        <!-- Recompile -->
+        <exec dir="${mcp.dir}" executable="cmd" osfamily="windows" failonerror="true">
+            <arg line="/c recompile.bat --client"/>
+        </exec>
+
+        <exec dir="${mcp.dir}" executable="sh" osfamily="unix" failonerror="true">
+            <arg line="recompile.sh --client"/>
+        </exec>
+
+        <!-- Reobf -->
+        <exec dir="${mcp.dir}" executable="cmd" osfamily="windows" failonerror="true">
+            <arg line="/c reobfuscate_srg.bat --client"/>
+        </exec>
+
+        <exec dir="${mcp.dir}" executable="sh" osfamily="unix" failonerror="true">
+            <arg line="reobfuscate_srg.sh --client"/>
+        </exec>
+
+        <echo message="Compiling finished"/>
+    </target>
+
+    <target name="copyclasses" depends="compile">
+        <echo message="Adding version ${we.version} to maven result"/>
+
+        <!-- Copy WE classes -->
+        <copy todir="${maven.build.directory}/classes/com/sk89q/worldedit/forge">
+            <fileset dir="${mcp.dir}/reobf/minecraft/com/sk89q/worldedit/forge"/>
+        </copy>
+
+        <!-- Copy resources -->
+        <copy todir="${maven.build.directory}/classes">
+            <fileset dir="${resource.dir}"></fileset>
+        </copy>
+
+        <replace file="${maven.build.directory}/classes/mcmod.info" token="%VERSION%" value="${we.version}"/>
+        <replace file="${maven.build.directory}/classes/mcmod.info" token="%MCVERSION%" value="${mc.version}"/>
+
+        <echo message="Adding finished"/>
+    </target>
+
+    <target name="main" depends="init-msg, unzip-forge, setup-forge, copyclasses"/>
+
+</project>

--- a/src/forge/java/com/sk89q/worldedit/forge/ForgeBiomeTypes.java
+++ b/src/forge/java/com/sk89q/worldedit/forge/ForgeBiomeTypes.java
@@ -14,7 +14,7 @@ import com.sk89q.worldedit.BiomeTypes;
 import com.sk89q.worldedit.UnknownBiomeTypeException;
 
 public class ForgeBiomeTypes implements BiomeTypes {
-    private static BiMap biomes = HashBiMap.create();
+    private static BiMap<BiomeType, BiomeGenBase> biomes = HashBiMap.create();
 
     public ForgeBiomeTypes() {
         all();
@@ -33,7 +33,7 @@ public class ForgeBiomeTypes implements BiomeTypes {
         if (biomes == null) {
             all();
         }
-        Iterator it = biomes.keySet().iterator();
+        Iterator<BiomeType> it = biomes.keySet().iterator();
         while (it.hasNext()) {
             BiomeType test = (BiomeType) it.next();
             if (test.getName().equalsIgnoreCase(name)) {
@@ -43,9 +43,9 @@ public class ForgeBiomeTypes implements BiomeTypes {
         throw new UnknownBiomeTypeException(name);
     }
 
-    public List all() {
+    public List<BiomeType> all() {
         if (biomes.isEmpty()) {
-            biomes = HashBiMap.create(new HashMap());
+            biomes = HashBiMap.create(new HashMap<BiomeType, BiomeGenBase>());
             for (BiomeGenBase biome : BiomeGenBase.biomeList) {
                 if ((biome == null) || (biomes.containsValue(biome))) {
                     continue;
@@ -53,7 +53,7 @@ public class ForgeBiomeTypes implements BiomeTypes {
                 biomes.put(new ForgeBiomeType(biome), biome);
             }
         }
-        List retBiomes = new ArrayList();
+        List<BiomeType> retBiomes = new ArrayList<BiomeType>();
         retBiomes.addAll(biomes.keySet());
         return retBiomes;
     }

--- a/src/forge/java/com/sk89q/worldedit/forge/ForgePlayer.java
+++ b/src/forge/java/com/sk89q/worldedit/forge/ForgePlayer.java
@@ -39,11 +39,11 @@ public class ForgePlayer extends LocalPlayer {
     }
 
     public double getPitch() {
-        return this.player.cameraPitch;
+        return this.player.rotationPitch;
     }
 
     public double getYaw() {
-        return this.player.cameraYaw;
+        return this.player.rotationYaw;
     }
 
     public void giveItem(int type, int amt) {
@@ -62,25 +62,25 @@ public class ForgePlayer extends LocalPlayer {
 
     public void printRaw(String msg) {
         for (String part : msg.split("\n")) {
-            this.player.sendChatToPlayer(ChatMessageComponent.func_111077_e(msg));
+            this.player.sendChatToPlayer(ChatMessageComponent.createFromText(part));
         }
     }
 
     public void printDebug(String msg) {
         for (String part : msg.split("\n")) {
-            this.player.sendChatToPlayer(ChatMessageComponent.func_111077_e("\u00a77" + part));
+            this.player.sendChatToPlayer(ChatMessageComponent.createFromText("\u00a77" + part));
         }
     }
 
     public void print(String msg) {
         for (String part : msg.split("\n")) {
-            this.player.sendChatToPlayer(ChatMessageComponent.func_111077_e("\u00a7d" + part));
+            this.player.sendChatToPlayer(ChatMessageComponent.createFromText("\u00a7d" + part));
         }
     }
 
     public void printError(String msg) {
         for (String part : msg.split("\n")) {
-            this.player.sendChatToPlayer(ChatMessageComponent.func_111077_e("\u00a7c" + part));
+            this.player.sendChatToPlayer(ChatMessageComponent.createFromText("\u00a7c" + part));
         }
     }
 

--- a/src/forge/java/com/sk89q/worldedit/forge/ForgeServerInterface.java
+++ b/src/forge/java/com/sk89q/worldedit/forge/ForgeServerInterface.java
@@ -8,8 +8,10 @@ import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.ServerCommandManager;
 import net.minecraft.entity.EntityList;
+import net.minecraft.item.Item;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.WorldServer;
+import net.minecraftforge.common.DimensionManager;
 
 import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.worldedit.BiomeTypes;
@@ -19,17 +21,27 @@ import com.sk89q.worldedit.ServerInterface;
 import cpw.mods.fml.common.FMLCommonHandler;
 
 public class ForgeServerInterface extends ServerInterface {
-    private WorldEditMod mod;
     private MinecraftServer server;
     private ForgeBiomeTypes biomes;
 
     public ForgeServerInterface() {
-        this.mod = WorldEditMod.inst;
         this.server = FMLCommonHandler.instance().getMinecraftServerInstance();
         this.biomes = new ForgeBiomeTypes();
     }
 
     public int resolveItem(String name) {
+    	if (name == null) return 0;
+        for (Item item:Item.itemsList) {
+            if (item == null) continue;
+            if (item.getUnlocalizedName() == null) continue;
+            if (item.getUnlocalizedName().startsWith("item.")) {
+                if (item.getUnlocalizedName().equalsIgnoreCase("item." + name)) return item.itemID;
+            }
+            if (item.getUnlocalizedName().startsWith("tile.")) {
+                if (item.getUnlocalizedName().equalsIgnoreCase("tile." + name)) return item.itemID;
+            }
+            if (item.getUnlocalizedName().equalsIgnoreCase(name)) return item.itemID;
+        }
         return 0;
     }
 
@@ -49,8 +61,8 @@ public class ForgeServerInterface extends ServerInterface {
     }
 
     public List<LocalWorld> getWorlds() {
-        List<WorldServer> worlds = Arrays.asList(this.server.worldServers);
-        List<LocalWorld> ret = new ArrayList(worlds.size());
+        List<WorldServer> worlds = Arrays.asList(DimensionManager.getWorlds());
+        List<LocalWorld> ret = new ArrayList<LocalWorld>(worlds.size());
         for (WorldServer world : worlds) {
             ret.add(new ForgeWorld(world));
         }
@@ -61,22 +73,26 @@ public class ForgeServerInterface extends ServerInterface {
     public void onCommandRegistration(List<Command> commands) {
         if (server == null) return;
         ServerCommandManager mcMan = (ServerCommandManager) server.getCommandManager();
-        for (Command cmd : commands) {
-            for (int i = 0; i < cmd.aliases().length; i++) {
-                final String name = cmd.aliases()[i];
-                mcMan.registerCommand(new CommandBase() {
-                    public String getCommandName() {
-                        return name;
-                    }
+        for (final Command cmd : commands) {
+            mcMan.registerCommand(new CommandBase() {
+                @Override
+                public String getCommandName() {
+                    return cmd.aliases()[0];
+                }
 
-                    public void processCommand(ICommandSender var1, String[] var2) {
-                    }
+                @Override
+                public List<String> getCommandAliases() {
+                    return Arrays.asList(cmd.aliases());
+                }
 
-                    public String getCommandUsage(ICommandSender icommandsender) {
-                        return null;
-                    }
-                });
-            }
+                @Override
+                public void processCommand(ICommandSender var1, String[] var2) {}
+
+                @Override
+                public String getCommandUsage(ICommandSender icommandsender) {
+                    return "/" + cmd.aliases()[0] + " " + cmd.usage();
+                }
+            });
         }
     }
 }

--- a/src/forge/java/com/sk89q/worldedit/forge/ForgeUtil.java
+++ b/src/forge/java/com/sk89q/worldedit/forge/ForgeUtil.java
@@ -13,12 +13,12 @@ public class ForgeUtil {
 
     public static boolean hasPermission(EntityPlayerMP player, String perm) {
         // TODO fix WEPIF
-        return FMLCommonHandler.instance().getMinecraftServerInstance().getConfigurationManager().areCommandsAllowed(player.username);
+        return FMLCommonHandler.instance().getMinecraftServerInstance().getConfigurationManager().isPlayerOpped(player.username);
     }
 
     public static ItemStack toForgeItemStack(BaseItemStack item) {
         ItemStack ret = new ItemStack(item.getType(), item.getAmount(), item.getData());
-        for (Map.Entry entry : item.getEnchantments().entrySet()) {
+        for (Map.Entry<Integer, Integer> entry : item.getEnchantments().entrySet()) {
             ret.addEnchantment(net.minecraft.enchantment.Enchantment.enchantmentsList[((Integer)entry.getKey()).intValue()], ((Integer)entry.getValue()).intValue());
         }
 

--- a/src/forge/java/com/sk89q/worldedit/forge/TileEntityBaseBlock.java
+++ b/src/forge/java/com/sk89q/worldedit/forge/TileEntityBaseBlock.java
@@ -59,7 +59,7 @@ public class TileEntityBaseBlock extends BaseBlock implements TileEntityBlock {
 
     private static TileEntity constructTEClass(World world, Vector pt, TileEntityBaseBlock block) {
         Class<? extends TileEntity> clazz = block.tile.getClass();
-        Constructor baseConstructor;
+        Constructor<? extends TileEntity> baseConstructor;
         try {
             baseConstructor = clazz.getConstructor(); // creates "blank" TE
         } catch (Throwable e) {
@@ -84,7 +84,6 @@ public class TileEntityBaseBlock extends BaseBlock implements TileEntityBlock {
     }
 
     public String getNbtId() {
-        String id = null;
         NBTTagCompound tag = new NBTTagCompound();
         try {
             this.tile.writeToNBT(tag);

--- a/src/forge/java/com/sk89q/worldedit/forge/WECUIPacketHandler.java
+++ b/src/forge/java/com/sk89q/worldedit/forge/WECUIPacketHandler.java
@@ -15,13 +15,15 @@ public class WECUIPacketHandler implements IPacketHandler {
     public static final Charset UTF_8_CHARSET = Charset.forName("UTF-8");
 
     public void onPacketData(INetworkManager manager, Packet250CustomPayload packet, Player player) {
-        LocalSession session = WorldEditMod.inst.getSession((EntityPlayerMP) player);
+        if (player instanceof EntityPlayerMP) {
+            LocalSession session = WorldEditMod.inst.getSession((EntityPlayerMP) player);
 
-        if (session.hasCUISupport()) {
-            return;
+            if (session.hasCUISupport()) {
+                return;
+            }
+        
+            String text = new String(packet.data, UTF_8_CHARSET);
+            session.handleCUIInitializationMessage(text);
         }
-
-        String text = new String(packet.data, UTF_8_CHARSET);
-        session.handleCUIInitializationMessage(text);
     }
 }

--- a/src/forge/java/com/sk89q/worldedit/forge/selections/RegionSelection.java
+++ b/src/forge/java/com/sk89q/worldedit/forge/selections/RegionSelection.java
@@ -1,5 +1,7 @@
 package com.sk89q.worldedit.forge.selections;
 
+import java.lang.ref.WeakReference;
+
 import net.minecraft.world.World;
 
 import com.sk89q.worldedit.Location;
@@ -9,16 +11,16 @@ import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionSelector;
 
 public abstract class RegionSelection implements Selection {
-    private World world;
+    private WeakReference<World> world;
     private RegionSelector selector;
     private Region region;
 
     public RegionSelection(World world) {
-        this.world = world;
+        this.world = new WeakReference<World>(world);
     }
 
     public RegionSelection(World world, RegionSelector selector, Region region) {
-        this.world = world;
+        this(world);
         this.region = region;
         this.selector = selector;
     }
@@ -40,7 +42,7 @@ public abstract class RegionSelection implements Selection {
     }
 
     public Location getMinimumPoint() {
-        return new Location(WorldEditMod.inst.getWorld(this.world), this.region.getMinimumPoint());
+        return new Location(WorldEditMod.inst.getWorld(this.world.get()), this.region.getMinimumPoint());
     }
 
     public Vector getNativeMinimumPoint() {
@@ -48,7 +50,7 @@ public abstract class RegionSelection implements Selection {
     }
 
     public Location getMaximumPoint() {
-        return new Location(WorldEditMod.inst.getWorld(this.world), this.region.getMaximumPoint());
+        return new Location(WorldEditMod.inst.getWorld(this.world.get()), this.region.getMaximumPoint());
     }
 
     public Vector getNativeMaximumPoint() {
@@ -56,7 +58,7 @@ public abstract class RegionSelection implements Selection {
     }
 
     public World getWorld() {
-        return this.world;
+        return this.world.get();
     }
 
     public int getArea() {
@@ -76,7 +78,7 @@ public abstract class RegionSelection implements Selection {
     }
 
     public boolean contains(Location pt) {
-        if (!pt.getWorld().equals(this.world)) {
+        if (!pt.getWorld().equals(this.world.get())) {
             return false;
         }
 

--- a/src/forge/resources/mcmod.info
+++ b/src/forge/resources/mcmod.info
@@ -1,0 +1,23 @@
+{
+  "modinfoversion": 2,
+  "modlist": [{
+    "modid": "WorldEdit",
+    "name": "WorldEdit",
+    "description": "WorldEdit is an easy-to-use in-game world editor for Minecraft, supporting both single player and multiplayer.",
+    "version": "%VERSION%",
+    "mcversion": "%MCVERSION%",
+    "url": "http://wiki.sk89q.com/wiki/WorldEdit",
+    "updateUrl": "",
+    "authors": [ "sk89q" ],
+    "credits": "",
+    "logoFile": "",
+    "screenshots": [],
+    "requiredMods": [
+        "Forge@[9.10.1.850,)"
+    ],
+    "dependencies": [
+        "Forge@[9.10.1.850,)"
+    ],
+    "dependants": []
+  }]
+}


### PR DESCRIPTION
This PR is to update the Forge implementation to the new MCP names, add a buildscript to automatically generate a jar file, archive it through maven and fix some bugs.

It adds the profile 'forge' to maven which is calling an ant script to build the required classes. The first run will take longer because Forge needs do download MCP, Minecraft, and all related resources as well as decompiling Minecraft and patching it with FML and Forge. That result is cached inside a zip file that is used on every further build to make the build process run faster. 

The ant script includes snakeyaml into the jar file. In order to avoid conflicts it is moved into the com.sk89q.worldedit.forge.yaml package.

This PR also adds a mcmod.info to the resources and jar file which is automatically filled with the up to date version specified in maven.

It fixes the player view direction and the printRaw command which was't printing the splited message but the hole message several times.

The reference to a world inside the implementation has been changed to a WeakReference to prevent WorldEdit from keeping unloaded worlds inside the memory.

This also adds an implementation of the regeneration code needed inside the ForgeWorld class and adds an better way of registration for command aliases and their usage to avoid empty help pages.

A working jenkins job can be found here: http://ci.thezorro266.com/job/WorldEdit/

If wanted, I can try to change the build process, so that it adds the forge classes to the main resulting jar but then we would need another solution for snakeyaml.

Comments and suggestions are welcome.
