### PR TITLE
Enable creation of source jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <createSourcesJar>true</createSourcesJar>
               <artifactSet>
                 <includes>
                   <include>com.sk89q:jchronic</include>


### PR DESCRIPTION
When you add worldedit as a maven dependency, there is no sources jar to download from the repo. Having one is helpful because then IDEs can show javadocs and function definitions.
