### PR TITLE
Add support for listing schematics inside subdirectories

### DIFF
--- a/src/main/java/com/sk89q/worldedit/commands/SchematicCommands.java
+++ b/src/main/java/com/sk89q/worldedit/commands/SchematicCommands.java
@@ -224,14 +224,12 @@ public class SchematicCommands {
         if (files == null) {
             throw new FilenameResolutionException(dir.getPath(), "Schematics directory invalid or not found.");
         }
-        StringBuilder build = new StringBuilder("Available schematics (Filename (Format)): ");
 
         final int sortType = args.hasFlag('d') ? -1 : args.hasFlag('n') ? 1 : 0;
         // cleanup file list
         Arrays.sort(files, new Comparator<File>(){
             @Override
             public int compare(File f1, File f2) {
-                if (!f1.isFile() || !f2.isFile()) return -1; // don't care, will get removed
                 // http://stackoverflow.com/questions/203030/best-way-to-list-files-in-java-sorted-by-date-modified
                 int result = sortType == 0 ? f1.getName().compareToIgnoreCase(f2.getName()) : // use name by default
                     Long.valueOf(f1.lastModified()).compareTo(f2.lastModified()); // use date if there is a flag
@@ -240,14 +238,27 @@ public class SchematicCommands {
             }
         });
 
+        player.print("Available schematics (Filename (Format)):");
+        player.print(listFiles("", files));
+    }
+
+    private String listFiles(String prefix, File[] files) {
+        StringBuilder build = new StringBuilder();
         for (File file : files) {
+            if (file.isDirectory()) {
+                build.append(listFiles(prefix + file.getName() + "/", file.listFiles()));
+                continue;
+            }
+
             if (!file.isFile()) {
                 continue;
             }
+
             build.append("\n\u00a79");
             SchematicFormat format = SchematicFormat.getFormat(file);
-            build.append(file.getName()).append(": ").append(format == null ? "Unknown" : format.getName());
+            build.append(prefix).append(file.getName())
+               .append(": ").append(format == null ? "Unknown" : format.getName());
         }
-        player.print(build.toString());
+        return build.toString();
     }
 }


### PR DESCRIPTION
Currently the '//schematic list' command will not take into account sub-directories when listing the schematics available yet these schematics are available to use with other schematic commands.

This PR adds listing of these sub-directories to the '//schematic list' command.
