### PR TITLE
Added blocks method

### DIFF
--- a/src/main/java/com/sk89q/worldedit/bukkit/selections/RegionSelection.java
+++ b/src/main/java/com/sk89q/worldedit/bukkit/selections/RegionSelection.java
@@ -26,6 +26,10 @@ import org.bukkit.World;
 import com.sk89q.worldedit.Vector;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionSelector;
+import org.bukkit.block.BlockState;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public abstract class RegionSelection implements Selection {
 
@@ -101,6 +105,30 @@ public abstract class RegionSelection implements Selection {
         }
 
         return region.contains(toVector(pt));
+    }
+
+    public List<BlockState> getBlocks() {
+        List<BlockState> blocks = new ArrayList<BlockState>();
+
+        int minX = getMinimumPoint().getBlockX();
+        int minY = getMinimumPoint().getBlockY();
+        int minZ = getMinimumPoint().getBlockZ();
+
+        int maxX = getMaximumPoint().getBlockX();
+        int maxY = getMaximumPoint().getBlockY();
+        int maxZ = getMaximumPoint().getBlockZ();
+
+        World world = getWorld();
+
+        for(int x = minX; x < maxX; x++) {
+            for(int y = minY; y < maxY; y++) {
+                for(int z = minZ; z < maxZ; z++) {
+                    blocks.add(world.getBlockAt(x, y, z).getState());
+                }
+            }
+        }
+
+        return blocks;
     }
 
 }

--- a/src/main/java/com/sk89q/worldedit/bukkit/selections/Selection.java
+++ b/src/main/java/com/sk89q/worldedit/bukkit/selections/Selection.java
@@ -23,6 +23,9 @@ import org.bukkit.Location;
 import org.bukkit.World;
 import com.sk89q.worldedit.Vector;
 import com.sk89q.worldedit.regions.RegionSelector;
+import org.bukkit.block.BlockState;
+
+import java.util.List;
 
 public interface Selection {
     /**
@@ -102,4 +105,12 @@ public interface Selection {
      * @return 
      */
     public boolean contains(Location pt);
+
+    /**
+     * Returns a list of all blocks within the selection
+     *
+     * @return blocks
+     */
+
+    public List<BlockState> getBlocks();
 }


### PR DESCRIPTION
I was using the WorldEdit API when I noticed that it didn't have a method to get all of the blocks within a selection. This commit adds the method to Selection and creates an implementation in RegionSelection.
