### PR TITLE
Fixed WorldEdit Bukkit profile being inactive if the java8-disable-docli...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -530,7 +530,9 @@
       <id>bukkit</id>
 
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!skipBukkitProfile</name>
+        </property>
       </activation>
 
       <repositories>


### PR DESCRIPTION
...nt profile is active

The issue is that the activeByDefault setting only applies if no other profiles activate:
http://maven.apache.org/guides/introduction/introduction-to-profiles.html

Per this discussion, and testing this solution resolves the issue:
http://stackoverflow.com/questions/5309379/how-to-keep-maven-profiles-which-are-activebydefault-active-even-if-another-prof
