### PR TITLE
Add Stained Glass to usesData HashSet

### DIFF
--- a/src/main/java/com/sk89q/worldedit/blocks/BlockType.java
+++ b/src/main/java/com/sk89q/worldedit/blocks/BlockType.java
@@ -786,6 +786,7 @@ public enum BlockType {
         usesData.add(BlockID.DROPPER);
         usesData.add(BlockID.HOPPER);
         usesData.add(BlockID.STAINED_CLAY);
+        usesData.add(BlockID.STAINED_GLASS);
         usesData.add(BlockID.STAINED_GLASS_PANE);
         usesData.add(BlockID.HAY_BLOCK);
         usesData.add(BlockID.CARPET);


### PR DESCRIPTION
fixes an issue with stained glass held in a player's hand having its damage value set to zero (white) when breaking a block and using the item-durability: false option
