### PR TITLE
Fix tag lists getting chopped off

### DIFF
--- a/src/forge/java/com/sk89q/worldedit/forge/NBTConverter.java
+++ b/src/forge/java/com/sk89q/worldedit/forge/NBTConverter.java
@@ -178,7 +178,8 @@ final class NBTConverter {
         other = (NBTTagList) other.copy();
         List<Tag> list = new ArrayList<Tag>();
         Class<? extends Tag> listClass = StringTag.class;
-        for (int i = 0; i < other.tagCount(); i++) {
+        int tags = other.tagCount();
+        for (int i = 0; i < tags; i++) {
             Tag child = fromNative(other.removeTag(0));
             list.add(child);
             listClass = child.getClass();


### PR DESCRIPTION
While patching ForgeMultipart for WE I noticed that tag lists were getting chopped off due to bad size calculations. The list was shrinking but I assumed it was the same size. This fixes that.
