### PR TITLE
Fix server side for Forge.

### DIFF
--- a/src/forge/java/com/sk89q/worldedit/forge/ForgeWorld.java
+++ b/src/forge/java/com/sk89q/worldedit/forge/ForgeWorld.java
@@ -393,7 +393,7 @@ public class ForgeWorld extends AbstractWorld {
     @Override
     public List<? extends Entity> getEntities() {
         List<Entity> entities = new ArrayList<Entity>();
-        for (Object entity : getWorld().getLoadedEntityList()) {
+        for (Object entity : getWorld().loadedEntityList) {
             entities.add(new ForgeEntity((net.minecraft.entity.Entity) entity));
         }
         return entities;


### PR DESCRIPTION
`getLoadedEntityList()` is `@SideOnly(Side.CLIENT)` so the server doesn't have that method, but the field is universal.
