### PR TITLE
Update ForgeWorldEdit.java

### DIFF
--- a/src/forge/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
+++ b/src/forge/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
@@ -61,7 +61,7 @@ import static net.minecraftforge.event.entity.player.PlayerInteractEvent.Action;
 /**
  * The Forge implementation of WorldEdit.
  */
-@Mod(modid = "WorldEdit", name = "WorldEdit", version = "%VERSION%")
+@Mod(modid = "WorldEdit", name = "WorldEdit", version = "%VERSION%", acceptableRemoteVersions = "*")
 public class ForgeWorldEdit {
 
     public static Logger logger;


### PR DESCRIPTION
This fixes clients being required to install Forge WorldEdit when connecting to servers running Forge WorldEdit.
