### PR TITLE
Option to register permissions with Bukkit

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitConfiguration.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitConfiguration.java
@@ -30,6 +30,7 @@ import java.io.File;
 public class BukkitConfiguration extends YAMLConfiguration {
 
     public boolean noOpPermissions = false;
+    public boolean registerPermissions = false;
     private final WorldEditPlugin plugin;
 
     public BukkitConfiguration(YAMLProcessor config, WorldEditPlugin plugin) {
@@ -41,6 +42,7 @@ public class BukkitConfiguration extends YAMLConfiguration {
     public void load() {
         super.load();
         noOpPermissions = config.getBoolean("no-op-permissions", false);
+        registerPermissions = config.getBoolean("register-permissions", false);
         migrateLegacyFolders();
     }
 

--- a/worldedit-bukkit/src/main/resources/defaults/config.yml
+++ b/worldedit-bukkit/src/main/resources/defaults/config.yml
@@ -69,5 +69,7 @@ wand-item: 271
 shell-save-type:
 no-double-slash: false
 no-op-permissions: false
+register-permissions: false
+
 debug: false
 show-help-on-first-use: true


### PR DESCRIPTION
Config option to have WE register all of its command permissions with Bukkit. This allows `no-op-permissions` to work properly when other plugins test for WE perms directly through the Bukkit API.
