### PR TITLE
Add //hemisphere

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1432,7 +1432,7 @@ public class EditSession implements Extent {
      * @param filled If false, only a shell will be generated.
      * @param hemi If true, only the top half will be generated.
      * @param upsideDown If true and hemi is true, only the bottom half will be generated.
-     * @param directionVector If not null and hemi is true, the hemisphere's orientation will depend on the player's viewing angle.
+     * @param directionVector If not null and hemi is true, the hemisphere's direction will match to the vector.
      * @return number of blocks changed
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -24,7 +24,6 @@ import com.sk89q.worldedit.blocks.BlockID;
 import com.sk89q.worldedit.blocks.BlockType;
 import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.entity.Entity;
-import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.event.extent.EditSessionEvent;
 import com.sk89q.worldedit.extent.ChangeSetExtent;
 import com.sk89q.worldedit.extent.Extent;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1417,8 +1417,8 @@ public class EditSession implements Extent {
     * @return number of blocks changed
     * @throws MaxChangedBlocksException thrown if too many blocks are changed
     */
-    public int makeSphere(Vector pos, Pattern block, double radius, boolean filled) throws MaxChangedBlocksException {
-        return makeSphere(pos, block, radius, radius, radius, filled);
+    public int makeSphere(Vector pos, Pattern block, double radius, boolean filled, boolean semi) throws MaxChangedBlocksException {
+        return makeSphere(pos, block, radius, radius, radius, filled, semi);
     }
 
     /**
@@ -1430,10 +1430,11 @@ public class EditSession implements Extent {
      * @param radiusY The sphere/ellipsoid's largest up/down extent
      * @param radiusZ The sphere/ellipsoid's largest east/west extent
      * @param filled If false, only a shell will be generated.
+     * @param semi If true, only the top half will be generated.
      * @return number of blocks changed
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */
-    public int makeSphere(Vector pos, Pattern block, double radiusX, double radiusY, double radiusZ, boolean filled) throws MaxChangedBlocksException {
+    public int makeSphere(Vector pos, Pattern block, double radiusX, double radiusY, double radiusZ, boolean filled, boolean semi) throws MaxChangedBlocksException {
         int affected = 0;
 
         radiusX += 0.5;
@@ -1484,23 +1485,25 @@ public class EditSession implements Extent {
                     if (setBlock(pos.add(-x, y, z), block)) {
                         ++affected;
                     }
-                    if (setBlock(pos.add(x, -y, z), block)) {
-                        ++affected;
-                    }
                     if (setBlock(pos.add(x, y, -z), block)) {
-                        ++affected;
-                    }
-                    if (setBlock(pos.add(-x, -y, z), block)) {
-                        ++affected;
-                    }
-                    if (setBlock(pos.add(x, -y, -z), block)) {
                         ++affected;
                     }
                     if (setBlock(pos.add(-x, y, -z), block)) {
                         ++affected;
                     }
-                    if (setBlock(pos.add(-x, -y, -z), block)) {
-                        ++affected;
+                    if(!semi) {
+                        if (setBlock(pos.add(x, -y, z), block)) {
+                            ++affected;
+                        }
+                        if (setBlock(pos.add(-x, -y, z), block)) {
+                            ++affected;
+                        }
+                        if (setBlock(pos.add(x, -y, -z), block)) {
+                            ++affected;
+                        }
+                        if (setBlock(pos.add(-x, -y, -z), block)) {
+                            ++affected;
+                        }
                     }
                 }
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1432,30 +1432,12 @@ public class EditSession implements Extent {
      * @param filled If false, only a shell will be generated.
      * @param hemi If true, only the top half will be generated.
      * @param upsideDown If true and hemi is true, only the bottom half will be generated.
-     * @param directionVector If not null and hemi is true, the hemisphere's direction will match to the vector.
+     * @param directionVector If not null and hemi is true, the hemisphere's direction will match the vector.
      * @return number of blocks changed
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */
     public int makeSphere(Vector pos, Pattern block, double radiusX, double radiusY, double radiusZ, boolean filled, boolean hemi, boolean upsideDown, @Nullable Vector directionVector) throws MaxChangedBlocksException {
         int affected = 0;
-
-        if(!hemi) {
-            if(directionVector != null) {
-                return -2;
-            }
-
-            if(upsideDown) {
-                return -3;
-            }
-        }
-
-        if ((directionVector != null) && !hemi) {
-            return -2;
-        }
-
-        if (upsideDown && !hemi) {
-            return -3;
-        }
 
         radiusX += 0.5;
         radiusY += 0.5;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1432,11 +1432,30 @@ public class EditSession implements Extent {
      * @param filled If false, only a shell will be generated.
      * @param hemi If true, only the top half will be generated.
      * @param upsideDown If true and hemi is true, only the bottom half will be generated.
+     * @param directionVector If true and hemi is true, the hemisphere's orientation will depend on the player's viewing angle.
      * @return number of blocks changed
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */
     public int makeSphere(Vector pos, Pattern block, double radiusX, double radiusY, double radiusZ, boolean filled, boolean hemi, boolean upsideDown, @Nullable Vector directionVector) throws MaxChangedBlocksException {
         int affected = 0;
+
+        if(!hemi) {
+            if(directionVector != null) {
+                return -2;
+            }
+
+            if(upsideDown) {
+                return -3;
+            }
+        }
+
+        if ((directionVector != null) && !hemi) {
+            return -2;
+        }
+
+        if (upsideDown && !hemi) {
+            return -3;
+        }
 
         radiusX += 0.5;
         radiusY += 0.5;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1452,6 +1452,9 @@ public class EditSession implements Extent {
         final int ceilRadiusY = (int) Math.ceil(radiusY);
         final int ceilRadiusZ = (int) Math.ceil(radiusZ);
 
+        final boolean genUp = (!hemi || (hemi && !upsideDown));
+        final boolean genDown = (!hemi || (hemi && upsideDown));
+
         double nextXn = 0;
         forX: for (int x = 0; x <= ceilRadiusX; ++x) {
             final double xn = nextXn;
@@ -1482,7 +1485,7 @@ public class EditSession implements Extent {
                         }
                     }
 
-                    if(!hemi || (hemi && !upsideDown)) {
+                    if(genUp) {
                         if (setBlock(pos.add(x, y, z), block)) {
                             ++affected;
                         }
@@ -1496,7 +1499,7 @@ public class EditSession implements Extent {
                             ++affected;
                         }
                     }
-                    if(!hemi || (hemi && upsideDown)) {
+                    if(genDown) {
                         if (setBlock(pos.add(x, -y, z), block)) {
                             ++affected;
                         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1432,7 +1432,7 @@ public class EditSession implements Extent {
      * @param filled If false, only a shell will be generated.
      * @param hemi If true, only the top half will be generated.
      * @param upsideDown If true and hemi is true, only the bottom half will be generated.
-     * @param directionVector If true and hemi is true, the hemisphere's orientation will depend on the player's viewing angle.
+     * @param directionVector If not null and hemi is true, the hemisphere's orientation will depend on the player's viewing angle.
      * @return number of blocks changed
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1414,11 +1414,13 @@ public class EditSession implements Extent {
     * @param block The block pattern to use
     * @param radius The sphere's radius
     * @param filled If false, only a shell will be generated.
+    * @param hemi If true, only the top half will be generated.
+    * @param upsideDown If true and hemi is true, only the bottom half will be generated.
     * @return number of blocks changed
     * @throws MaxChangedBlocksException thrown if too many blocks are changed
     */
-    public int makeSphere(Vector pos, Pattern block, double radius, boolean filled, boolean semi) throws MaxChangedBlocksException {
-        return makeSphere(pos, block, radius, radius, radius, filled, semi);
+    public int makeSphere(Vector pos, Pattern block, double radius, boolean filled, boolean hemi, boolean upsideDown) throws MaxChangedBlocksException {
+        return makeSphere(pos, block, radius, radius, radius, filled, hemi, upsideDown);
     }
 
     /**
@@ -1430,11 +1432,12 @@ public class EditSession implements Extent {
      * @param radiusY The sphere/ellipsoid's largest up/down extent
      * @param radiusZ The sphere/ellipsoid's largest east/west extent
      * @param filled If false, only a shell will be generated.
-     * @param semi If true, only the top half will be generated.
+     * @param hemi If true, only the top half will be generated.
+     * @param upsideDown If true and hemi is true, only the bottom half will be generated.
      * @return number of blocks changed
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */
-    public int makeSphere(Vector pos, Pattern block, double radiusX, double radiusY, double radiusZ, boolean filled, boolean semi) throws MaxChangedBlocksException {
+    public int makeSphere(Vector pos, Pattern block, double radiusX, double radiusY, double radiusZ, boolean filled, boolean hemi, boolean upsideDown) throws MaxChangedBlocksException {
         int affected = 0;
 
         radiusX += 0.5;
@@ -1479,19 +1482,21 @@ public class EditSession implements Extent {
                         }
                     }
 
-                    if (setBlock(pos.add(x, y, z), block)) {
-                        ++affected;
+                    if(!hemi || (hemi && !upsideDown)) {
+                        if (setBlock(pos.add(x, y, z), block)) {
+                            ++affected;
+                        }
+                        if (setBlock(pos.add(-x, y, z), block)) {
+                            ++affected;
+                        }
+                        if (setBlock(pos.add(x, y, -z), block)) {
+                            ++affected;
+                        }
+                        if (setBlock(pos.add(-x, y, -z), block)) {
+                            ++affected;
+                        }
                     }
-                    if (setBlock(pos.add(-x, y, z), block)) {
-                        ++affected;
-                    }
-                    if (setBlock(pos.add(x, y, -z), block)) {
-                        ++affected;
-                    }
-                    if (setBlock(pos.add(-x, y, -z), block)) {
-                        ++affected;
-                    }
-                    if(!semi) {
+                    if(!hemi || (hemi && upsideDown)) {
                         if (setBlock(pos.add(x, -y, z), block)) {
                             ++affected;
                         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1492,7 +1492,7 @@ public class EditSession implements Extent {
 
                         for (Vector vector : vectors) {
                             Vector vectorFromCenter = vector.subtract(pos);
-                            if((vectorFromCenter.dot(directionVector) >= 0) && (setBlock(vector, block))) {
+                            if ((vectorFromCenter.dot(directionVector) >= 0) && (setBlock(vector, block))) {
                                        ++affected;
                             }
                         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GenerationCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GenerationCommands.java
@@ -150,8 +150,8 @@ public class GenerationCommands {
             "By specifying 3 radii, separated by commas,\n" +
             "you can generate an ellipsoid. The order of the ellipsoid radii\n" +
             "is north/south, up/down, east/west.",
-            min = 2,
-            max = 3
+        min = 2,
+        max = 3
     )
     @CommandPermissions("worldedit.generation.sphere")
     @Logging(PLACEMENT)

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GenerationCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GenerationCommands.java
@@ -122,28 +122,28 @@ public class GenerationCommands {
     }
 
     @Command(
-       aliases = { "/semisphere" },
-       usage = "<block> <radius>[,<radius>,<radius>] [raised?]",
-       flags = "h",
-       desc = "Generates a filled semisphere.",
+       aliases = { "/hemisphere" },
+       usage = "<block> <radius>[,<radius>,<radius>]",
+       flags = "ih",
+       desc = "Generates a filled hemisphere.",
        help =
-           "Generates a filled semisphere.\n" +
+           "Generates a filled hemisphere.\n" +
            "By specifying 3 radii, separated by commas,\n" +
            "you can generate an ellipsoid. The order of the ellipsoid radii\n" +
            "is north/south, up/down, east/west.",
        min = 2,
        max = 3
     )
-    @CommandPermissions("worldedit.generation.semisphere")
+    @CommandPermissions("worldedit.generation.hemisphere")
     @Logging(PLACEMENT)
-    public void semisphere(Player player, LocalSession session, EditSession editSession, Pattern pattern, String radiusString, @Optional("false") boolean raised, @Switch('h') boolean hollow) throws WorldEditException {
-        sphere(player, session, editSession, pattern, radiusString, raised, hollow, true);
+    public void hemisphere(Player player, LocalSession session, EditSession editSession, Pattern pattern, String radiusString, @Switch('h') boolean hollow, @Switch('i') boolean upsideDown) throws WorldEditException {
+        sphere(player, session, editSession, pattern, radiusString, false, hollow, true, upsideDown);
     }
 
     @Command(
         aliases = { "/hsphere" },
         usage = "<block> <radius>[,<radius>,<radius>] [raised?]",
-        flags = "s",
+        flags = "si",
         desc = "Generates a hollow sphere.",
         help =
             "Generates a hollow sphere.\n" +
@@ -155,14 +155,14 @@ public class GenerationCommands {
     )
     @CommandPermissions("worldedit.generation.sphere")
     @Logging(PLACEMENT)
-    public void hsphere(Player player, LocalSession session, EditSession editSession, Pattern pattern, String radiusString, @Optional("false") boolean raised, @Switch('s') boolean semi) throws WorldEditException {
-        sphere(player, session, editSession, pattern, radiusString, raised, true, semi);
+    public void hsphere(Player player, LocalSession session, EditSession editSession, Pattern pattern, String radiusString, @Optional("false") boolean raised, @Switch('s') boolean hemi, @Switch('i') boolean upsideDown) throws WorldEditException {
+        sphere(player, session, editSession, pattern, radiusString, raised, true, hemi, upsideDown);
     }
 
     @Command(
         aliases = { "/sphere" },
         usage = "<block> <radius>[,<radius>,<radius>] [raised?]",
-        flags = "hs",
+        flags = "hsi",
         desc = "Generates a filled sphere.",
         help =
             "Generates a filled sphere.\n" +
@@ -174,7 +174,7 @@ public class GenerationCommands {
     )
     @CommandPermissions("worldedit.generation.sphere")
     @Logging(PLACEMENT)
-    public void sphere(Player player, LocalSession session, EditSession editSession, Pattern pattern, String radiusString, @Optional("false") boolean raised, @Switch('h') boolean hollow, @Switch('s') boolean semi) throws WorldEditException {
+    public void sphere(Player player, LocalSession session, EditSession editSession, Pattern pattern, String radiusString, @Optional("false") boolean raised, @Switch('h') boolean hollow, @Switch('s') boolean hemi, @Switch('i') boolean upsideDown) throws WorldEditException {
         String[] radii = radiusString.split(",");
         final double radiusX, radiusY, radiusZ;
         switch (radii.length) {
@@ -198,11 +198,11 @@ public class GenerationCommands {
         worldEdit.checkMaxRadius(radiusZ);
 
         Vector pos = session.getPlacementPosition(player);
-        if (raised && !semi) {
+        if (raised && !hemi) {
             pos = pos.add(0, radiusY, 0);
         }
 
-        int affected = editSession.makeSphere(pos, Patterns.wrap(pattern), radiusX, radiusY, radiusZ, !hollow, semi);
+        int affected = editSession.makeSphere(pos, Patterns.wrap(pattern), radiusX, radiusY, radiusZ, !hollow, hemi, upsideDown);
         player.findFreePosition();
         player.print(affected + " block(s) have been created.");
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GenerationCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GenerationCommands.java
@@ -122,75 +122,75 @@ public class GenerationCommands {
     }
 
     @Command(
-       aliases = { "/hemisphere" },
-       usage = "<block> <radius>[,<radius>,<radius>]",
-       flags = "ih",
-       desc = "Generates a filled hemisphere.",
-       help =
-           "Generates a filled hemisphere.\n" +
-           "By specifying 3 radii, separated by commas,\n" +
-           "you can generate an ellipsoid. The order of the ellipsoid radii\n" +
-           "is north/south, up/down, east/west.",
-       min = 2,
-       max = 3
+            aliases = { "/hemisphere" },
+            usage = "<block> <radius>[,<radius>,<radius>]",
+            flags = "hip",
+            desc = "Generates a filled hemisphere.",
+            help =
+                    "Generates a filled hemisphere.\n" +
+                            "By specifying 3 radii, separated by commas,\n" +
+                            "you can generate an ellipsoid. The order of the ellipsoid radii\n" +
+                            "is north/south, up/down, east/west.",
+            min = 2,
+            max = 3
     )
     @CommandPermissions("worldedit.generation.hemisphere")
     @Logging(PLACEMENT)
-    public void hemisphere(Player player, LocalSession session, EditSession editSession, Pattern pattern, String radiusString, @Switch('h') boolean hollow, @Switch('i') boolean upsideDown) throws WorldEditException {
-        sphere(player, session, editSession, pattern, radiusString, false, hollow, true, upsideDown);
+    public void hemisphere(Player player, LocalSession session, EditSession editSession, Pattern pattern, String radiusString, @Switch('h') boolean hollow, @Switch('i') boolean upsideDown, @Switch('p') boolean precisionMode) throws WorldEditException {
+        sphere(player, session, editSession, pattern, radiusString, false, hollow, true, upsideDown, precisionMode);
     }
 
     @Command(
-        aliases = { "/hsphere" },
-        usage = "<block> <radius>[,<radius>,<radius>] [raised?]",
-        flags = "si",
-        desc = "Generates a hollow sphere.",
-        help =
-            "Generates a hollow sphere.\n" +
-            "By specifying 3 radii, separated by commas,\n" +
-            "you can generate an ellipsoid. The order of the ellipsoid radii\n" +
-            "is north/south, up/down, east/west.",
-        min = 2,
-        max = 3
+            aliases = { "/hsphere" },
+            usage = "<block> <radius>[,<radius>,<radius>] [raised?]",
+            flags = "sip",
+            desc = "Generates a hollow sphere.",
+            help =
+                    "Generates a hollow sphere.\n" +
+                            "By specifying 3 radii, separated by commas,\n" +
+                            "you can generate an ellipsoid. The order of the ellipsoid radii\n" +
+                            "is north/south, up/down, east/west.",
+            min = 2,
+            max = 3
     )
     @CommandPermissions("worldedit.generation.sphere")
     @Logging(PLACEMENT)
-    public void hsphere(Player player, LocalSession session, EditSession editSession, Pattern pattern, String radiusString, @Optional("false") boolean raised, @Switch('s') boolean hemi, @Switch('i') boolean upsideDown) throws WorldEditException {
-        sphere(player, session, editSession, pattern, radiusString, raised, true, hemi, upsideDown);
+    public void hsphere(Player player, LocalSession session, EditSession editSession, Pattern pattern, String radiusString, @Optional("false") boolean raised, @Switch('s') boolean hemi, @Switch('i') boolean upsideDown, @Switch('p') boolean precisionMode) throws WorldEditException {
+        sphere(player, session, editSession, pattern, radiusString, raised, true, hemi, upsideDown, precisionMode);
     }
 
     @Command(
-        aliases = { "/sphere" },
-        usage = "<block> <radius>[,<radius>,<radius>] [raised?]",
-        flags = "hsi",
-        desc = "Generates a filled sphere.",
-        help =
-            "Generates a filled sphere.\n" +
-            "By specifying 3 radii, separated by commas,\n" +
-            "you can generate an ellipsoid. The order of the ellipsoid radii\n" +
-            "is north/south, up/down, east/west.",
-        min = 2,
-        max = 3
+            aliases = { "/sphere" },
+            usage = "<block> <radius>[,<radius>,<radius>] [raised?]",
+            flags = "hsip",
+            desc = "Generates a filled sphere.",
+            help =
+                    "Generates a filled sphere.\n" +
+                            "By specifying 3 radii, separated by commas,\n" +
+                            "you can generate an ellipsoid. The order of the ellipsoid radii\n" +
+                            "is north/south, up/down, east/west.",
+            min = 2,
+            max = 3
     )
     @CommandPermissions("worldedit.generation.sphere")
     @Logging(PLACEMENT)
-    public void sphere(Player player, LocalSession session, EditSession editSession, Pattern pattern, String radiusString, @Optional("false") boolean raised, @Switch('h') boolean hollow, @Switch('s') boolean hemi, @Switch('i') boolean upsideDown) throws WorldEditException {
+    public void sphere(Player player, LocalSession session, EditSession editSession, Pattern pattern, String radiusString, @Optional("false") boolean raised, @Switch('h') boolean hollow, @Switch('s') boolean hemi, @Switch('i') boolean upsideDown, @Switch('p') boolean precisionMode) throws WorldEditException {
         String[] radii = radiusString.split(",");
         final double radiusX, radiusY, radiusZ;
         switch (radii.length) {
-        case 1:
-            radiusX = radiusY = radiusZ = Math.max(1, Double.parseDouble(radii[0]));
-            break;
+            case 1:
+                radiusX = radiusY = radiusZ = Math.max(1, Double.parseDouble(radii[0]));
+                break;
 
-        case 3:
-            radiusX = Math.max(1, Double.parseDouble(radii[0]));
-            radiusY = Math.max(1, Double.parseDouble(radii[1]));
-            radiusZ = Math.max(1, Double.parseDouble(radii[2]));
-            break;
+            case 3:
+                radiusX = Math.max(1, Double.parseDouble(radii[0]));
+                radiusY = Math.max(1, Double.parseDouble(radii[1]));
+                radiusZ = Math.max(1, Double.parseDouble(radii[2]));
+                break;
 
-        default:
-            player.printError("You must either specify 1 or 3 radius values.");
-            return;
+            default:
+                player.printError("You must either specify 1 or 3 radius values.");
+                return;
         }
 
         worldEdit.checkMaxRadius(radiusX);
@@ -202,7 +202,12 @@ public class GenerationCommands {
             pos = pos.add(0, radiusY, 0);
         }
 
-        int affected = editSession.makeSphere(pos, Patterns.wrap(pattern), radiusX, radiusY, radiusZ, !hollow, hemi, upsideDown);
+        Vector directionVector = null;
+        if (hemi && precisionMode) {
+            directionVector = player.getLocation().getDirection();
+        }
+
+        int affected = editSession.makeSphere(pos, Patterns.wrap(pattern), radiusX, radiusY, radiusZ, !hollow, hemi, upsideDown, directionVector);
         player.findFreePosition();
         player.print(affected + " block(s) have been created.");
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GenerationCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GenerationCommands.java
@@ -122,17 +122,17 @@ public class GenerationCommands {
     }
 
     @Command(
-            aliases = { "/hemisphere" },
-            usage = "<block> <radius>[,<radius>,<radius>]",
-            flags = "hip",
-            desc = "Generates a filled hemisphere.",
-            help =
-                    "Generates a filled hemisphere.\n" +
-                            "By specifying 3 radii, separated by commas,\n" +
-                            "you can generate an ellipsoid. The order of the ellipsoid radii\n" +
-                            "is north/south, up/down, east/west.",
-            min = 2,
-            max = 3
+        aliases = { "/hemisphere" },
+        usage = "<block> <radius>[,<radius>,<radius>]",
+        flags = "hip",
+        desc = "Generates a filled hemisphere.",
+        help =
+            "Generates a filled hemisphere.\n" +
+            "By specifying 3 radii, separated by commas,\n" +
+            "you can generate an ellipsoid. The order of the ellipsoid radii\n" +
+            "is north/south, up/down, east/west.",
+        min = 2,
+        max = 2
     )
     @CommandPermissions("worldedit.generation.hemisphere")
     @Logging(PLACEMENT)
@@ -141,15 +141,15 @@ public class GenerationCommands {
     }
 
     @Command(
-            aliases = { "/hsphere" },
-            usage = "<block> <radius>[,<radius>,<radius>] [raised?]",
-            flags = "sip",
-            desc = "Generates a hollow sphere.",
-            help =
-                    "Generates a hollow sphere.\n" +
-                            "By specifying 3 radii, separated by commas,\n" +
-                            "you can generate an ellipsoid. The order of the ellipsoid radii\n" +
-                            "is north/south, up/down, east/west.",
+        aliases = { "/hsphere" },
+        usage = "<block> <radius>[,<radius>,<radius>] [raised?]",
+        flags = "sip",
+        desc = "Generates a hollow sphere.",
+        help =
+            "Generates a hollow sphere.\n" +
+            "By specifying 3 radii, separated by commas,\n" +
+            "you can generate an ellipsoid. The order of the ellipsoid radii\n" +
+            "is north/south, up/down, east/west.",
             min = 2,
             max = 3
     )
@@ -160,21 +160,38 @@ public class GenerationCommands {
     }
 
     @Command(
-            aliases = { "/sphere" },
-            usage = "<block> <radius>[,<radius>,<radius>] [raised?]",
-            flags = "hsip",
-            desc = "Generates a filled sphere.",
-            help =
-                    "Generates a filled sphere.\n" +
-                            "By specifying 3 radii, separated by commas,\n" +
-                            "you can generate an ellipsoid. The order of the ellipsoid radii\n" +
-                            "is north/south, up/down, east/west.",
-            min = 2,
-            max = 3
+        aliases = { "/sphere" },
+        usage = "<block> <radius>[,<radius>,<radius>] [raised?]",
+        flags = "hsip",
+        desc = "Generates a filled sphere.",
+        help =
+            "Generates a filled sphere.\n" +
+            "By specifying 3 radii, separated by commas,\n" +
+            "you can generate an ellipsoid. The order of the ellipsoid radii\n" +
+            "is north/south, up/down, east/west.",
+        min = 2,
+        max = 3
     )
     @CommandPermissions("worldedit.generation.sphere")
     @Logging(PLACEMENT)
     public void sphere(Player player, LocalSession session, EditSession editSession, Pattern pattern, String radiusString, @Optional("false") boolean raised, @Switch('h') boolean hollow, @Switch('s') boolean hemi, @Switch('i') boolean upsideDown, @Switch('p') boolean precisionMode) throws WorldEditException {
+        boolean error = false;
+        if(!hemi) {
+            if(precisionMode) {
+                player.printError("-p flag doesn't have effect when it's not an hemisphere.");
+                error = true;
+            }
+
+            if(upsideDown) {
+                player.printError("-i flag doesn't have effect when it's not an hemisphere.");
+                error = true;
+            }
+        }
+
+        if(error) {
+            return;
+        }
+
         String[] radii = radiusString.split(",");
         final double radiusX, radiusY, radiusZ;
         switch (radii.length) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GenerationCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GenerationCommands.java
@@ -122,8 +122,28 @@ public class GenerationCommands {
     }
 
     @Command(
+       aliases = { "/semisphere" },
+       usage = "<block> <radius>[,<radius>,<radius>] [raised?]",
+       flags = "h",
+       desc = "Generates a filled semisphere.",
+       help =
+           "Generates a filled semisphere.\n" +
+           "By specifying 3 radii, separated by commas,\n" +
+           "you can generate an ellipsoid. The order of the ellipsoid radii\n" +
+           "is north/south, up/down, east/west.",
+       min = 2,
+       max = 3
+    )
+    @CommandPermissions("worldedit.generation.semisphere")
+    @Logging(PLACEMENT)
+    public void semisphere(Player player, LocalSession session, EditSession editSession, Pattern pattern, String radiusString, @Optional("false") boolean raised, @Switch('h') boolean hollow) throws WorldEditException {
+        sphere(player, session, editSession, pattern, radiusString, raised, hollow, true);
+    }
+
+    @Command(
         aliases = { "/hsphere" },
         usage = "<block> <radius>[,<radius>,<radius>] [raised?]",
+        flags = "s",
         desc = "Generates a hollow sphere.",
         help =
             "Generates a hollow sphere.\n" +
@@ -135,14 +155,14 @@ public class GenerationCommands {
     )
     @CommandPermissions("worldedit.generation.sphere")
     @Logging(PLACEMENT)
-    public void hsphere(Player player, LocalSession session, EditSession editSession, Pattern pattern, String radiusString, @Optional("false") boolean raised) throws WorldEditException {
-        sphere(player, session, editSession, pattern, radiusString, raised, true);
+    public void hsphere(Player player, LocalSession session, EditSession editSession, Pattern pattern, String radiusString, @Optional("false") boolean raised, @Switch('s') boolean semi) throws WorldEditException {
+        sphere(player, session, editSession, pattern, radiusString, raised, true, semi);
     }
 
     @Command(
         aliases = { "/sphere" },
         usage = "<block> <radius>[,<radius>,<radius>] [raised?]",
-        flags = "h",
+        flags = "hs",
         desc = "Generates a filled sphere.",
         help =
             "Generates a filled sphere.\n" +
@@ -154,7 +174,7 @@ public class GenerationCommands {
     )
     @CommandPermissions("worldedit.generation.sphere")
     @Logging(PLACEMENT)
-    public void sphere(Player player, LocalSession session, EditSession editSession, Pattern pattern, String radiusString, @Optional("false") boolean raised, @Switch('h') boolean hollow) throws WorldEditException {
+    public void sphere(Player player, LocalSession session, EditSession editSession, Pattern pattern, String radiusString, @Optional("false") boolean raised, @Switch('h') boolean hollow, @Switch('s') boolean semi) throws WorldEditException {
         String[] radii = radiusString.split(",");
         final double radiusX, radiusY, radiusZ;
         switch (radii.length) {
@@ -178,11 +198,11 @@ public class GenerationCommands {
         worldEdit.checkMaxRadius(radiusZ);
 
         Vector pos = session.getPlacementPosition(player);
-        if (raised) {
+        if (raised && !semi) {
             pos = pos.add(0, radiusY, 0);
         }
 
-        int affected = editSession.makeSphere(pos, Patterns.wrap(pattern), radiusX, radiusY, radiusZ, !hollow);
+        int affected = editSession.makeSphere(pos, Patterns.wrap(pattern), radiusX, radiusY, radiusZ, !hollow, semi);
         player.findFreePosition();
         player.print(affected + " block(s) have been created.");
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GenerationCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GenerationCommands.java
@@ -176,19 +176,19 @@ public class GenerationCommands {
     @Logging(PLACEMENT)
     public void sphere(Player player, LocalSession session, EditSession editSession, Pattern pattern, String radiusString, @Optional("false") boolean raised, @Switch('h') boolean hollow, @Switch('s') boolean hemi, @Switch('i') boolean upsideDown, @Switch('p') boolean precisionMode) throws WorldEditException {
         boolean error = false;
-        if(!hemi) {
-            if(precisionMode) {
-                player.printError("-p flag doesn't have effect when it's not an hemisphere.");
+        if (!hemi) {
+            if (precisionMode) {
+                player.printError("-p flag doesn't have an effect when it's not a hemisphere.");
                 error = true;
             }
 
-            if(upsideDown) {
-                player.printError("-i flag doesn't have effect when it's not an hemisphere.");
+            if (upsideDown) {
+                player.printError("-i flag doesn't have an effect when it's not a hemisphere.");
                 error = true;
             }
         }
 
-        if(error) {
+        if (error) {
             return;
         }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GenerationCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GenerationCommands.java
@@ -195,19 +195,19 @@ public class GenerationCommands {
         String[] radii = radiusString.split(",");
         final double radiusX, radiusY, radiusZ;
         switch (radii.length) {
-            case 1:
-                radiusX = radiusY = radiusZ = Math.max(1, Double.parseDouble(radii[0]));
-                break;
+        case 1:
+            radiusX = radiusY = radiusZ = Math.max(1, Double.parseDouble(radii[0]));
+            break;
 
-            case 3:
-                radiusX = Math.max(1, Double.parseDouble(radii[0]));
-                radiusY = Math.max(1, Double.parseDouble(radii[1]));
-                radiusZ = Math.max(1, Double.parseDouble(radii[2]));
-                break;
+        case 3:
+            radiusX = Math.max(1, Double.parseDouble(radii[0]));
+            radiusY = Math.max(1, Double.parseDouble(radii[1]));
+            radiusZ = Math.max(1, Double.parseDouble(radii[2]));
+            break;
 
-            default:
-                player.printError("You must either specify 1 or 3 radius values.");
-                return;
+        default:
+            player.printError("You must either specify 1 or 3 radius values.");
+            return;
         }
 
         worldEdit.checkMaxRadius(radiusX);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/HollowSphereBrush.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/HollowSphereBrush.java
@@ -35,6 +35,6 @@ public class HollowSphereBrush implements Brush {
         if (pattern == null) {
             pattern = new BlockPattern(new BaseBlock(BlockID.COBBLESTONE));
         }
-        editSession.makeSphere(position, Patterns.wrap(pattern), size, size, size, false, false, false);
+        editSession.makeSphere(position, Patterns.wrap(pattern), size, size, size, false, false, false, null);
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/HollowSphereBrush.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/HollowSphereBrush.java
@@ -35,6 +35,6 @@ public class HollowSphereBrush implements Brush {
         if (pattern == null) {
             pattern = new BlockPattern(new BaseBlock(BlockID.COBBLESTONE));
         }
-        editSession.makeSphere(position, Patterns.wrap(pattern), size, size, size, false, false);
+        editSession.makeSphere(position, Patterns.wrap(pattern), size, size, size, false, false, false);
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/HollowSphereBrush.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/HollowSphereBrush.java
@@ -35,6 +35,6 @@ public class HollowSphereBrush implements Brush {
         if (pattern == null) {
             pattern = new BlockPattern(new BaseBlock(BlockID.COBBLESTONE));
         }
-        editSession.makeSphere(position, Patterns.wrap(pattern), size, size, size, false);
+        editSession.makeSphere(position, Patterns.wrap(pattern), size, size, size, false, false);
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/SphereBrush.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/SphereBrush.java
@@ -35,6 +35,6 @@ public class SphereBrush implements Brush {
         if (pattern == null) {
             pattern = new BlockPattern(new BaseBlock(BlockID.COBBLESTONE));
         }
-        editSession.makeSphere(position, Patterns.wrap(pattern), size, size, size, true, false, false);
+        editSession.makeSphere(position, Patterns.wrap(pattern), size, size, size, true, false, false, null);
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/SphereBrush.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/SphereBrush.java
@@ -35,6 +35,6 @@ public class SphereBrush implements Brush {
         if (pattern == null) {
             pattern = new BlockPattern(new BaseBlock(BlockID.COBBLESTONE));
         }
-        editSession.makeSphere(position, Patterns.wrap(pattern), size, size, size, true);
+        editSession.makeSphere(position, Patterns.wrap(pattern), size, size, size, true, false);
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/SphereBrush.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/SphereBrush.java
@@ -35,6 +35,6 @@ public class SphereBrush implements Brush {
         if (pattern == null) {
             pattern = new BlockPattern(new BaseBlock(BlockID.COBBLESTONE));
         }
-        editSession.makeSphere(position, Patterns.wrap(pattern), size, size, size, true, false);
+        editSession.makeSphere(position, Patterns.wrap(pattern), size, size, size, true, false, false);
     }
 }


### PR DESCRIPTION
We've added a feature: the possibility to generate hemispheres using the generation command //hemisphere.

Its usage is similar to //sphere's: `//hemisphere [-h] <block> <radius>[,<radius>,<radius>]`.
The raised argument is ignored since we felt it didn't make sense to be used with hemispheres.

We also added a -s flag to the //sphere and //hsphere commands, similar to how -h flag matches the //hsphere command.

We reused methods associated to the //sphere command to avoid duplicated code.

Using the 3 commands:
//hemisphere -h snowblock 8,4,2
//hemisphere -h snowblock 4
//hemisphere -h snowblock 4,5,6
generates the following, from left to right:
![2016-12-17_03 00 46](https://cloud.githubusercontent.com/assets/12088738/21283957/59e71e76-c405-11e6-8e38-72f87db82d5e.png)

EDIT: "semisphere" -> "hemisphere"

