### PR TITLE
Add "worldedit.showchatcoords" permission to show coordinates in chat.

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ClipboardCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ClipboardCommands.java
@@ -169,7 +169,11 @@ public class ClipboardCommands {
             selector.explainRegionAdjust(player, session);
         }
 
-        player.print("The clipboard has been pasted at " + to);
+        if (player.hasPermission("worldedit.showchatcoords")) {
+            player.print("The clipboard has been pasted at " + to);
+        } else {
+            player.print("The clipboard has been pasted.");
+        }
     }
 
     @Command(

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/ConvexPolyhedralRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/ConvexPolyhedralRegionSelector.java
@@ -199,8 +199,11 @@ public class ConvexPolyhedralRegionSelector extends com.sk89q.worldedit.regions.
         checkNotNull(pos);
 
         session.describeCUI(player);
-
-        player.print("Started new selection with vertex "+pos+".");
+        if (player.hasPermission("worldedit.showchatcoords")) {
+            player.print("Started new selection with vertex " + pos + ".");
+        } else {
+            player.print("Started new selection with that vertex.");
+        }
     }
 
     @Override
@@ -211,7 +214,11 @@ public class ConvexPolyhedralRegionSelector extends com.sk89q.worldedit.regions.
 
         session.describeCUI(player);
 
-        player.print("Added vertex " + pos + " to the selection.");
+        if (player.hasPermission("worldedit.showchatcoords")) {
+            player.print("Added vertex " + pos + " to the selection.");
+        } else {
+            player.print("Added that vertex to the selection.");;
+        }
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/CuboidRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/CuboidRegionSelector.java
@@ -150,9 +150,17 @@ public class CuboidRegionSelector extends com.sk89q.worldedit.regions.CuboidRegi
         checkNotNull(pos);
 
         if (position1 != null && position2 != null) {
-            player.print("First position set to " + position1 + " (" + region.getArea() + ").");
+            if (player.hasPermission("worldedit.showchatcoords")) {
+                player.print("First position set to " + position1 + " (" + region.getArea() + ").");
+            } else {
+                player.print("First position set (" + region.getArea() + ").");
+            }
         } else {
-            player.print("First position set to " + position1 + ".");
+            if (player.hasPermission("worldedit.showchatcoords")) {
+                player.print("First position set to " + position1 + ".");
+            } else {
+                player.print("First position set.");
+            }
         }
 
         session.dispatchCUIEvent(player, new SelectionPointEvent(0, pos, getArea()));
@@ -165,9 +173,17 @@ public class CuboidRegionSelector extends com.sk89q.worldedit.regions.CuboidRegi
         checkNotNull(pos);
 
         if (position1 != null && position2 != null) {
-            player.print("Second position set to " + position2 + " (" + region.getArea() + ").");
+            if (player.hasPermission("worldedit.showchatcoords")) {
+                player.print("Second position set to " + position2 + " (" + region.getArea() + ").");
+            } else {
+                player.print("Second position set (" + region.getArea() + ").");
+            }
         } else {
-            player.print("Second position set to " + position2 + ".");
+            if (player.hasPermission("worldedit.showchatcoords")) {
+                player.print("Second position set to " + position2 + ".");
+            } else {
+                player.print("Second position set.");
+            }
         }
 
         session.dispatchCUIEvent(player, new SelectionPointEvent(1, pos, getArea()));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/CylinderRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/CylinderRegionSelector.java
@@ -157,7 +157,11 @@ public class CylinderRegionSelector extends com.sk89q.worldedit.regions.Cylinder
 
     @Override
     public void explainPrimarySelection(Actor player, LocalSession session, Vector pos) {
-        player.print("Starting a new cylindrical selection at " + pos + ".");
+        if (player.hasPermission("worldedit.showchatcoords")) {
+            player.print("Starting a new cylindrical selection at " + pos + ".");
+        } else {
+            player.print("Starting a new cylindrical selection.");
+        }
 
         session.describeCUI(player);
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/EllipsoidRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/EllipsoidRegionSelector.java
@@ -141,9 +141,17 @@ public class EllipsoidRegionSelector extends com.sk89q.worldedit.regions.Ellipso
     @Override
     public void explainPrimarySelection(Actor player, LocalSession session, Vector pos) {
         if (isDefined()) {
-            player.print("Center position set to " + region.getCenter() + " (" + region.getArea() + ").");
+            if (player.hasPermission("worldedit.showchatcoords")) {
+                player.print("Center position set to " + region.getCenter() + " (" + region.getArea() + ").");
+            } else {
+                player.print("Center position set (" + region.getArea() + ").");
+            }
         } else {
-            player.print("Center position set to " + region.getCenter() + ".");
+            if (player.hasPermission("worldedit.showchatcoords")) {
+                player.print("Center position set to " + region.getCenter() + ".");
+            } else {
+                player.print("Center position set.");
+            }
         }
 
         session.describeCUI(player);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/ExtendingCuboidRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/ExtendingCuboidRegionSelector.java
@@ -130,14 +130,22 @@ public class ExtendingCuboidRegionSelector extends CuboidRegionSelector {
 
     @Override
     public void explainPrimarySelection(Actor player, LocalSession session, Vector pos) {
-        player.print("Started selection at " + pos + " (" + region.getArea() + ").");
+        if (player.hasPermission("worldedit.showchatcoords")) {
+            player.print("Started selection at " + pos + " (" + region.getArea() + ").");
+        } else {
+            player.print("Started selection (" + region.getArea() + ").");
+        }
 
         explainRegionAdjust(player, session);
     }
 
     @Override
     public void explainSecondarySelection(Actor player, LocalSession session, Vector pos) {
-        player.print("Extended selection to encompass " + pos + " (" + region.getArea() + ").");
+        if (player.hasPermission("worldedit.showchatcoords")) {
+            player.print("Extended selection to encompass " + pos + " (" + region.getArea() + ").");
+        } else {
+            player.print("Extended selection (" + region.getArea() + ").");
+        }
 
         explainRegionAdjust(player, session);
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/Polygonal2DRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/Polygonal2DRegionSelector.java
@@ -167,7 +167,7 @@ public class Polygonal2DRegionSelector extends com.sk89q.worldedit.regions.Polyg
 
     @Override
     public void explainPrimarySelection(Actor player, LocalSession session, Vector pos) {
-        if (player.hasPermission("worldedit.hidechatcoords")) {
+        if (player.hasPermission("worldedit.showchatcoords")) {
             player.print("Starting a new polygon at " + pos + ".");
         } else {
             player.print("Starting a new polygon.");

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/Polygonal2DRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/Polygonal2DRegionSelector.java
@@ -167,7 +167,11 @@ public class Polygonal2DRegionSelector extends com.sk89q.worldedit.regions.Polyg
 
     @Override
     public void explainPrimarySelection(Actor player, LocalSession session, Vector pos) {
-        player.print("Starting a new polygon at " + pos + ".");
+        if (player.hasPermission("worldedit.hidechatcoords")) {
+            player.print("Starting a new polygon at " + pos + ".");
+        } else {
+            player.print("Starting a new polygon.");
+        }
 
         session.dispatchCUIEvent(player, new SelectionShapeEvent(getTypeID()));
         session.dispatchCUIEvent(player, new SelectionPoint2DEvent(0, pos, getArea()));
@@ -176,7 +180,11 @@ public class Polygonal2DRegionSelector extends com.sk89q.worldedit.regions.Polyg
 
     @Override
     public void explainSecondarySelection(Actor player, LocalSession session, Vector pos) {
-        player.print("Added point #" + region.size() + " at " + pos + ".");
+        if (player.hasPermission("worldedit.showchatcoords")) {
+            player.print("Added point #" + region.size() + " at " + pos + ".");
+        } else {
+            player.print("Added point #" + region.size() + ".");
+        }
 
         session.dispatchCUIEvent(player, new SelectionPoint2DEvent(region.size() - 1, pos, getArea()));
         session.dispatchCUIEvent(player, new SelectionMinMaxEvent(region.getMinimumY(), region.getMaximumY()));


### PR DESCRIPTION
This is useful for people who stream on the Internet who don't want WE coordinates to show up in chat. They can revoke themselves the above permission.