### PR TITLE
Add RequestExtent to be used when a delayed EditSession is needed.

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -875,9 +875,10 @@ public class LocalSession {
         EditSession editSession = WorldEdit.getInstance().getEditSessionFactory()
                 .getEditSession(player.isPlayer() ? player.getWorld() : null,
                         getBlockChangeLimit(), blockBag, player);
+        Request.request().setEditSession(editSession);
+
         editSession.setFastMode(fastMode);
         editSession.setReorderMode(reorderMode);
-        Request.request().setEditSession(editSession);
         editSession.setMask(mask);
 
         return editSession;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -42,7 +42,6 @@ import com.sk89q.worldedit.scripting.CraftScriptContext;
 import com.sk89q.worldedit.scripting.CraftScriptEngine;
 import com.sk89q.worldedit.scripting.RhinoCraftScriptEngine;
 import com.sk89q.worldedit.session.SessionManager;
-import com.sk89q.worldedit.session.request.Request;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.eventbus.EventBus;
@@ -595,8 +594,6 @@ public final class WorldEdit {
      * @throws WorldEditException
      */
     public void runScript(Player player, File f, String[] args) throws WorldEditException {
-        Request.reset();
-
         String filename = f.getPath();
         int index = filename.lastIndexOf('.');
         String ext = filename.substring(index + 1);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/BrushCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/BrushCommands.java
@@ -24,7 +24,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
 import com.sk89q.minecraft.util.commands.CommandPermissions;
-import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.LocalConfiguration;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/BrushCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/BrushCommands.java
@@ -47,6 +47,7 @@ import com.sk89q.worldedit.function.pattern.BlockPattern;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.session.ClipboardHolder;
+import com.sk89q.worldedit.session.request.RequestExtent;
 import com.sk89q.worldedit.util.HandSide;
 import com.sk89q.worldedit.util.command.binding.Switch;
 import com.sk89q.worldedit.util.command.parametric.Optional;
@@ -81,7 +82,7 @@ public class BrushCommands {
         max = 2
     )
     @CommandPermissions("worldedit.brush.sphere")
-    public void sphereBrush(Player player, LocalSession session, EditSession editSession, Pattern fill,
+    public void sphereBrush(Player player, LocalSession session, Pattern fill,
                             @Optional("2") double radius, @Switch('h') boolean hollow) throws WorldEditException {
         worldEdit.checkMaxBrushRadius(radius);
 
@@ -110,7 +111,7 @@ public class BrushCommands {
         max = 3
     )
     @CommandPermissions("worldedit.brush.cylinder")
-    public void cylinderBrush(Player player, LocalSession session, EditSession editSession, Pattern fill,
+    public void cylinderBrush(Player player, LocalSession session, Pattern fill,
                               @Optional("2") double radius, @Optional("1") int height, @Switch('h') boolean hollow) throws WorldEditException {
         worldEdit.checkMaxBrushRadius(radius);
         worldEdit.checkMaxBrushRadius(height);
@@ -141,7 +142,7 @@ public class BrushCommands {
             "stood relative to the copied area when you copied it."
     )
     @CommandPermissions("worldedit.brush.clipboard")
-    public void clipboardBrush(Player player, LocalSession session, EditSession editSession, @Switch('a') boolean ignoreAir, @Switch('p') boolean usingOrigin) throws WorldEditException {
+    public void clipboardBrush(Player player, LocalSession session, @Switch('a') boolean ignoreAir, @Switch('p') boolean usingOrigin) throws WorldEditException {
         ClipboardHolder holder = session.getClipboard();
         Clipboard clipboard = holder.getClipboard();
 
@@ -168,7 +169,7 @@ public class BrushCommands {
         max = 3
     )
     @CommandPermissions("worldedit.brush.smooth")
-    public void smoothBrush(Player player, LocalSession session, EditSession editSession,
+    public void smoothBrush(Player player, LocalSession session,
                             @Optional("2") double radius, @Optional("4") int iterations, @Optional Mask mask) throws WorldEditException {
         worldEdit.checkMaxBrushRadius(radius);
 
@@ -187,14 +188,14 @@ public class BrushCommands {
         max = 1
     )
     @CommandPermissions("worldedit.brush.ex")
-    public void extinguishBrush(Player player, LocalSession session, EditSession editSession, @Optional("5") double radius) throws WorldEditException {
+    public void extinguishBrush(Player player, LocalSession session, @Optional("5") double radius) throws WorldEditException {
         worldEdit.checkMaxBrushRadius(radius);
 
         BrushTool tool = session.getBrushTool(player.getItemInHand(HandSide.MAIN_HAND).getType());
         Pattern fill = new BlockPattern(BlockTypes.AIR.getDefaultState());
         tool.setFill(fill);
         tool.setSize(radius);
-        tool.setMask(new BlockTypeMask(editSession, BlockTypes.FIRE));
+        tool.setMask(new BlockTypeMask(new RequestExtent(), BlockTypes.FIRE));
         tool.setBrush(new SphereBrush(), "worldedit.brush.ex");
 
         player.print(String.format("Extinguisher equipped (%.0f).", radius));
@@ -213,7 +214,7 @@ public class BrushCommands {
             max = 1
     )
     @CommandPermissions("worldedit.brush.gravity")
-    public void gravityBrush(Player player, LocalSession session, EditSession editSession, @Optional("5") double radius, @Switch('h') boolean fromMaxY) throws WorldEditException {
+    public void gravityBrush(Player player, LocalSession session, @Optional("5") double radius, @Switch('h') boolean fromMaxY) throws WorldEditException {
         worldEdit.checkMaxBrushRadius(radius);
 
         BrushTool tool = session.getBrushTool(player.getItemInHand(HandSide.MAIN_HAND).getType());
@@ -244,7 +245,7 @@ public class BrushCommands {
             max = 1
     )
     @CommandPermissions("worldedit.brush.butcher")
-    public void butcherBrush(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void butcherBrush(Player player, LocalSession session, CommandContext args) throws WorldEditException {
         LocalConfiguration config = worldEdit.getConfiguration();
 
         double radius = args.argsLength() > 0 ? args.getDouble(0) : 5;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ChunkCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ChunkCommands.java
@@ -23,7 +23,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.sk89q.minecraft.util.commands.Logging.LogMode.REGION;
 
 import com.sk89q.minecraft.util.commands.Command;
-import com.sk89q.minecraft.util.commands.CommandContext;
 import com.sk89q.minecraft.util.commands.CommandPermissions;
 import com.sk89q.minecraft.util.commands.Logging;
 import com.sk89q.worldedit.EditSession;
@@ -63,7 +62,7 @@ public class ChunkCommands {
         max = 0
     )
     @CommandPermissions("worldedit.chunkinfo")
-    public void chunkInfo(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void chunkInfo(Player player) throws WorldEditException {
         Location pos = player.getBlockIn();
         int chunkX = (int) Math.floor(pos.getBlockX() / 16.0);
         int chunkZ = (int) Math.floor(pos.getBlockZ() / 16.0);
@@ -87,7 +86,7 @@ public class ChunkCommands {
         max = 0
     )
     @CommandPermissions("worldedit.listchunks")
-    public void listChunks(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void listChunks(Player player, LocalSession session) throws WorldEditException {
         Set<BlockVector2> chunks = session.getSelection(player.getWorld()).getChunks();
 
         for (BlockVector2 chunk : chunks) {
@@ -104,7 +103,7 @@ public class ChunkCommands {
     )
     @CommandPermissions("worldedit.delchunks")
     @Logging(REGION)
-    public void deleteChunks(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void deleteChunks(Player player, LocalSession session) throws WorldEditException {
         player.print("Note that this command does not yet support the mcregion format.");
         LocalConfiguration config = worldEdit.getConfiguration();
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ClipboardCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ClipboardCommands.java
@@ -211,7 +211,7 @@ public class ClipboardCommands {
         max = 1
     )
     @CommandPermissions("worldedit.clipboard.flip")
-    public void flip(Player player, LocalSession session, EditSession editSession,
+    public void flip(Player player, LocalSession session,
                      @Optional(Direction.AIM) @Direction BlockVector3 direction) throws WorldEditException {
         ClipboardHolder holder = session.getClipboard();
         AffineTransform transform = new AffineTransform();
@@ -228,7 +228,7 @@ public class ClipboardCommands {
         max = 0
     )
     @CommandPermissions("worldedit.clipboard.clear")
-    public void clearClipboard(Player player, LocalSession session, EditSession editSession) throws WorldEditException {
+    public void clearClipboard(Player player, LocalSession session) throws WorldEditException {
         session.setClipboard(null);
         player.print("Clipboard cleared.");
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
@@ -63,7 +63,7 @@ public class GeneralCommands {
         max = 1
     )
     @CommandPermissions("worldedit.limit")
-    public void limit(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void limit(Player player, LocalSession session, CommandContext args) throws WorldEditException {
         
         LocalConfiguration config = worldEdit.getConfiguration();
         boolean mayDisable = player.hasPermission("worldedit.limit.unrestricted");
@@ -93,7 +93,7 @@ public class GeneralCommands {
             max = 1
     )
     @CommandPermissions("worldedit.timeout")
-    public void timeout(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void timeout(Player player, LocalSession session, CommandContext args) throws WorldEditException {
 
         LocalConfiguration config = worldEdit.getConfiguration();
         boolean mayDisable = player.hasPermission("worldedit.timeout.unrestricted");
@@ -123,7 +123,7 @@ public class GeneralCommands {
         max = 1
     )
     @CommandPermissions("worldedit.fast")
-    public void fast(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void fast(Player player, LocalSession session, CommandContext args) throws WorldEditException {
 
         String newState = args.getString(0, null);
         if (session.hasFastMode()) {
@@ -153,7 +153,7 @@ public class GeneralCommands {
             max = 1
     )
     @CommandPermissions("worldedit.reorder")
-    public void reorderMode(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void reorderMode(Player player, LocalSession session, CommandContext args) throws WorldEditException {
         String newState = args.getString(0, null);
         if (newState == null) {
             player.print("The reorder mode is " + session.getReorderMode().getDisplayName());
@@ -213,7 +213,7 @@ public class GeneralCommands {
         max = -1
     )
     @CommandPermissions("worldedit.global-mask")
-    public void gmask(Player player, LocalSession session, EditSession editSession, @Optional Mask mask) throws WorldEditException {
+    public void gmask(Player player, LocalSession session, @Optional Mask mask) throws WorldEditException {
         if (mask == null) {
             session.setMask((Mask) null);
             player.print("Global mask disabled.");
@@ -230,7 +230,7 @@ public class GeneralCommands {
         min = 0,
         max = 0
     )
-    public void togglePlace(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void togglePlace(Player player, LocalSession session) throws WorldEditException {
 
         if (session.togglePlacementPosition()) {
             player.print("Now placing at pos #1.");

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/HistoryCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/HistoryCommands.java
@@ -55,7 +55,7 @@ public class HistoryCommands {
         max = 2
     )
     @CommandPermissions("worldedit.history.undo")
-    public void undo(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void undo(Player player, LocalSession session, CommandContext args) throws WorldEditException {
         int times = Math.max(1, args.getInteger(0, 1));
         for (int i = 0; i < times; ++i) {
             EditSession undone;
@@ -88,7 +88,7 @@ public class HistoryCommands {
         max = 2
     )
     @CommandPermissions("worldedit.history.redo")
-    public void redo(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void redo(Player player, LocalSession session, CommandContext args) throws WorldEditException {
         
         int times = Math.max(1, args.getInteger(0, 1));
 
@@ -122,7 +122,7 @@ public class HistoryCommands {
         max = 0
     )
     @CommandPermissions("worldedit.history.clear")
-    public void clearHistory(Player player, LocalSession session, EditSession editSession) throws WorldEditException {
+    public void clearHistory(Player player, LocalSession session) throws WorldEditException {
         session.clearHistory();
         player.print("History cleared.");
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/NavigationCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/NavigationCommands.java
@@ -26,9 +26,7 @@ import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
 import com.sk89q.minecraft.util.commands.CommandPermissions;
 import com.sk89q.minecraft.util.commands.Logging;
-import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.LocalConfiguration;
-import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.entity.Player;
@@ -121,7 +119,7 @@ public class NavigationCommands {
     )
     @CommandPermissions("worldedit.navigation.ceiling")
     @Logging(POSITION)
-    public void ceiling(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void ceiling(Player player, CommandContext args) throws WorldEditException {
 
         final int clearance = args.argsLength() > 0 ?
             Math.max(0, args.getInteger(0)) : 0;
@@ -142,7 +140,7 @@ public class NavigationCommands {
         max = 0
     )
     @CommandPermissions("worldedit.navigation.thru.command")
-    public void thru(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void thru(Player player) throws WorldEditException {
         if (player.passThroughForwardWall(6)) {
             player.print("Whoosh!");
         } else {
@@ -158,7 +156,7 @@ public class NavigationCommands {
         max = 0
     )
     @CommandPermissions("worldedit.navigation.jumpto.command")
-    public void jumpTo(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void jumpTo(Player player) throws WorldEditException {
 
         Location pos = player.getSolidBlockTrace(300);
         if (pos != null) {
@@ -179,7 +177,7 @@ public class NavigationCommands {
     )
     @CommandPermissions("worldedit.navigation.up")
     @Logging(POSITION)
-    public void up(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void up(Player player, CommandContext args) throws WorldEditException {
         final int distance = args.getInteger(0);
 
         final boolean alwaysGlass = getAlwaysGlass(args);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ScriptingCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ScriptingCommands.java
@@ -26,7 +26,6 @@ import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
 import com.sk89q.minecraft.util.commands.CommandPermissions;
 import com.sk89q.minecraft.util.commands.Logging;
-import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.WorldEditException;
@@ -60,7 +59,7 @@ public class ScriptingCommands {
     )
     @CommandPermissions("worldedit.scripting.execute")
     @Logging(ALL)
-    public void execute(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void execute(Player player, LocalSession session, CommandContext args) throws WorldEditException {
 
         String[] scriptArgs = args.getSlice(1);
         String name = args.getString(0);
@@ -87,7 +86,7 @@ public class ScriptingCommands {
     )
     @CommandPermissions("worldedit.scripting.execute")
     @Logging(ALL)
-    public void executeLast(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void executeLast(Player player, LocalSession session, CommandContext args) throws WorldEditException {
         
         String lastScript = session.getLastScript();
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SelectionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SelectionCommands.java
@@ -87,7 +87,7 @@ public class SelectionCommands {
     )
     @Logging(POSITION)
     @CommandPermissions("worldedit.selection.pos")
-    public void pos1(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void pos1(Player player, LocalSession session, CommandContext args) throws WorldEditException {
 
         Location pos;
 
@@ -121,7 +121,7 @@ public class SelectionCommands {
     )
     @Logging(POSITION)
     @CommandPermissions("worldedit.selection.pos")
-    public void pos2(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void pos2(Player player, LocalSession session, CommandContext args) throws WorldEditException {
 
         Location pos;
         if (args.argsLength() == 1) {
@@ -155,7 +155,7 @@ public class SelectionCommands {
         max = 0
     )
     @CommandPermissions("worldedit.selection.hpos")
-    public void hpos1(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void hpos1(Player player, LocalSession session) throws WorldEditException {
 
         Location pos = player.getBlockTrace(300);
 
@@ -180,7 +180,7 @@ public class SelectionCommands {
         max = 0
     )
     @CommandPermissions("worldedit.selection.hpos")
-    public void hpos2(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void hpos2(Player player, LocalSession session) throws WorldEditException {
 
         Location pos = player.getBlockTrace(300);
 
@@ -215,7 +215,7 @@ public class SelectionCommands {
     )
     @Logging(POSITION)
     @CommandPermissions("worldedit.selection.chunk")
-    public void chunk(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void chunk(Player player, LocalSession session, CommandContext args) throws WorldEditException {
         final BlockVector3 min;
         final BlockVector3 max;
         final World world = player.getWorld();
@@ -277,7 +277,7 @@ public class SelectionCommands {
         max = 0
     )
     @CommandPermissions("worldedit.wand")
-    public void wand(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void wand(Player player) throws WorldEditException {
 
         player.giveItem(new BaseItemStack(ItemTypes.get(we.getConfiguration().wandItem), 1));
         player.print("Left click: select pos #1; Right click: select pos #2");
@@ -291,7 +291,7 @@ public class SelectionCommands {
         max = 0
     )
     @CommandPermissions("worldedit.wand.toggle")
-    public void toggleWand(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void toggleWand(Player player, LocalSession session, CommandContext args) throws WorldEditException {
         
         session.setToolControl(!session.isToolControlEnabled());
 
@@ -311,7 +311,7 @@ public class SelectionCommands {
     )
     @Logging(REGION)
     @CommandPermissions("worldedit.selection.expand")
-    public void expand(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void expand(Player player, LocalSession session, CommandContext args) throws WorldEditException {
 
         // Special syntax (//expand vert) to expand the selection between
         // sky and bedrock.
@@ -406,7 +406,7 @@ public class SelectionCommands {
     )
     @Logging(REGION)
     @CommandPermissions("worldedit.selection.contract")
-    public void contract(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void contract(Player player, LocalSession session, CommandContext args) throws WorldEditException {
 
         List<BlockVector3> dirs = new ArrayList<>();
         int change = args.getInteger(0);
@@ -481,7 +481,7 @@ public class SelectionCommands {
     )
     @Logging(REGION)
     @CommandPermissions("worldedit.selection.shift")
-    public void shift(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void shift(Player player, LocalSession session, CommandContext args) throws WorldEditException {
 
         List<BlockVector3> dirs = new ArrayList<>();
         int change = args.getInteger(0);
@@ -529,7 +529,7 @@ public class SelectionCommands {
     )
     @Logging(REGION)
     @CommandPermissions("worldedit.selection.outset")
-    public void outset(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void outset(Player player, LocalSession session, CommandContext args) throws WorldEditException {
         Region region = session.getSelection(player.getWorld());
         region.expand(getChangesForEachDir(args));
         session.getRegionSelector(player.getWorld()).learnChanges();
@@ -552,7 +552,7 @@ public class SelectionCommands {
     )
     @Logging(REGION)
     @CommandPermissions("worldedit.selection.inset")
-    public void inset(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void inset(Player player, LocalSession session, CommandContext args) throws WorldEditException {
         Region region = session.getSelection(player.getWorld());
         region.contract(getChangesForEachDir(args));
         session.getRegionSelector(player.getWorld()).learnChanges();
@@ -588,7 +588,7 @@ public class SelectionCommands {
         max = 0
     )
     @CommandPermissions("worldedit.selection.size")
-    public void size(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void size(Player player, LocalSession session, CommandContext args) throws WorldEditException {
         if (args.hasFlag('c')) {
             ClipboardHolder holder = session.getClipboard();
             Clipboard clipboard = holder.getClipboard();
@@ -706,7 +706,7 @@ public class SelectionCommands {
         min = 0,
         max = 1
     )
-    public void select(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void select(Player player, LocalSession session, CommandContext args) throws WorldEditException {
         final World world = player.getWorld();
         if (args.argsLength() == 0) {
             session.getRegionSelector(world).clear();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SnapshotCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SnapshotCommands.java
@@ -24,7 +24,6 @@ package com.sk89q.worldedit.command;
 import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
 import com.sk89q.minecraft.util.commands.CommandPermissions;
-import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.LocalConfiguration;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;
@@ -62,7 +61,7 @@ public class SnapshotCommands {
             max = 1
     )
     @CommandPermissions("worldedit.snapshots.list")
-    public void list(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void list(Player player, CommandContext args) throws WorldEditException {
 
         LocalConfiguration config = we.getConfiguration();
 
@@ -112,7 +111,7 @@ public class SnapshotCommands {
             max = 1
     )
     @CommandPermissions("worldedit.snapshots.restore")
-    public void use(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void use(Player player, LocalSession session, CommandContext args) throws WorldEditException {
 
         LocalConfiguration config = we.getConfiguration();
 
@@ -155,7 +154,7 @@ public class SnapshotCommands {
             max = 1
     )
     @CommandPermissions("worldedit.snapshots.restore")
-    public void sel(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void sel(Player player, LocalSession session, CommandContext args) throws WorldEditException {
         LocalConfiguration config = we.getConfiguration();
 
         if (config.snapshotRepo == null) {
@@ -202,7 +201,7 @@ public class SnapshotCommands {
             max = -1
     )
     @CommandPermissions("worldedit.snapshots.restore")
-    public void before(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void before(Player player, LocalSession session, CommandContext args) throws WorldEditException {
 
         LocalConfiguration config = we.getConfiguration();
 
@@ -241,7 +240,7 @@ public class SnapshotCommands {
             max = -1
     )
     @CommandPermissions("worldedit.snapshots.restore")
-    public void after(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void after(Player player, LocalSession session, CommandContext args) throws WorldEditException {
 
         LocalConfiguration config = we.getConfiguration();
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SuperPickaxeCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SuperPickaxeCommands.java
@@ -22,7 +22,6 @@ package com.sk89q.worldedit.command;
 import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
 import com.sk89q.minecraft.util.commands.CommandPermissions;
-import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.LocalConfiguration;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;
@@ -47,7 +46,7 @@ public class SuperPickaxeCommands {
         max = 0
     )
     @CommandPermissions("worldedit.superpickaxe")
-    public void single(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void single(Player player, LocalSession session) throws WorldEditException {
 
         session.setSuperPickaxe(new SinglePickaxe());
         session.enableSuperPickAxe();
@@ -62,7 +61,7 @@ public class SuperPickaxeCommands {
         max = 1
     )
     @CommandPermissions("worldedit.superpickaxe.area")
-    public void area(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void area(Player player, LocalSession session, CommandContext args) throws WorldEditException {
 
         LocalConfiguration config = we.getConfiguration();
         int range = args.getInteger(0);
@@ -85,7 +84,7 @@ public class SuperPickaxeCommands {
         max = 1
     )
     @CommandPermissions("worldedit.superpickaxe.recursive")
-    public void recursive(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void recursive(Player player, LocalSession session, CommandContext args) throws WorldEditException {
 
         LocalConfiguration config = we.getConfiguration();
         double range = args.getDouble(0);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
@@ -22,7 +22,6 @@ package com.sk89q.worldedit.command;
 import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
 import com.sk89q.minecraft.util.commands.CommandPermissions;
-import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.LocalConfiguration;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;
@@ -56,7 +55,7 @@ public class ToolCommands {
         min = 0,
         max = 0
     )
-    public void none(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void none(Player player, LocalSession session) throws WorldEditException {
 
         session.setTool(player.getItemInHand(HandSide.MAIN_HAND).getType(), null);
         player.print("Tool unbound from your current item.");
@@ -70,7 +69,7 @@ public class ToolCommands {
         max = 0
     )
     @CommandPermissions("worldedit.tool.info")
-    public void info(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void info(Player player, LocalSession session) throws WorldEditException {
 
         BaseItemStack itemStack = player.getItemInHand(HandSide.MAIN_HAND);
         session.setTool(itemStack.getType(), new QueryTool());
@@ -86,7 +85,7 @@ public class ToolCommands {
         max = 1
     )
     @CommandPermissions("worldedit.tool.tree")
-    public void tree(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void tree(Player player, LocalSession session, CommandContext args) throws WorldEditException {
 
         TreeGenerator.TreeType type = args.argsLength() > 0
                 ? TreeGenerator.lookup(args.getString(0))
@@ -124,7 +123,7 @@ public class ToolCommands {
         max = 0
     )
     @CommandPermissions("worldedit.tool.data-cycler")
-    public void cycler(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void cycler(Player player, LocalSession session) throws WorldEditException {
 
         BaseItemStack itemStack = player.getItemInHand(HandSide.MAIN_HAND);
         session.setTool(itemStack.getType(), new BlockDataCyler());
@@ -161,7 +160,7 @@ public class ToolCommands {
             max = 0
     )
     @CommandPermissions("worldedit.tool.deltree")
-    public void deltree(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void deltree(Player player, LocalSession session) throws WorldEditException {
 
         BaseItemStack itemStack = player.getItemInHand(HandSide.MAIN_HAND);
         session.setTool(itemStack.getType(), new FloatingTreeRemover());
@@ -177,7 +176,7 @@ public class ToolCommands {
             max = 0
     )
     @CommandPermissions("worldedit.tool.farwand")
-    public void farwand(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void farwand(Player player, LocalSession session) throws WorldEditException {
 
         BaseItemStack itemStack = player.getItemInHand(HandSide.MAIN_HAND);
         session.setTool(itemStack.getType(), new DistanceWand());

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolUtilCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolUtilCommands.java
@@ -22,7 +22,6 @@ package com.sk89q.worldedit.command;
 import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
 import com.sk89q.minecraft.util.commands.CommandPermissions;
-import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.WorldEditException;
@@ -50,7 +49,7 @@ public class ToolUtilCommands {
         max = 1
     )
     @CommandPermissions("worldedit.superpickaxe")
-    public void togglePickaxe(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void togglePickaxe(Player player, LocalSession session, CommandContext args) throws WorldEditException {
 
         String newState = args.getString(0, null);
         if (session.hasSuperPickAxe()) {
@@ -80,7 +79,7 @@ public class ToolUtilCommands {
         max = -1
     )
     @CommandPermissions("worldedit.brush.options.mask")
-    public void mask(Player player, LocalSession session, EditSession editSession, @Optional Mask mask) throws WorldEditException {
+    public void mask(Player player, LocalSession session, @Optional Mask mask) throws WorldEditException {
         if (mask == null) {
             session.getBrushTool(player.getItemInHand(HandSide.MAIN_HAND).getType()).setMask(null);
             player.print("Brush mask disabled.");
@@ -98,7 +97,7 @@ public class ToolUtilCommands {
         max = 1
     )
     @CommandPermissions("worldedit.brush.options.material")
-    public void material(Player player, LocalSession session, EditSession editSession, Pattern pattern) throws WorldEditException {
+    public void material(Player player, LocalSession session, Pattern pattern) throws WorldEditException {
         session.getBrushTool(player.getItemInHand(HandSide.MAIN_HAND).getType()).setFill(pattern);
         player.print("Brush material set.");
     }
@@ -111,7 +110,7 @@ public class ToolUtilCommands {
             max = 1
         )
     @CommandPermissions("worldedit.brush.options.range")
-    public void range(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void range(Player player, LocalSession session, CommandContext args) throws WorldEditException {
         int range = args.getInteger(0);
         session.getBrushTool(player.getItemInHand(HandSide.MAIN_HAND).getType()).setRange(range);
         player.print("Brush range set.");
@@ -125,7 +124,7 @@ public class ToolUtilCommands {
         max = 1
     )
     @CommandPermissions("worldedit.brush.options.size")
-    public void size(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void size(Player player, LocalSession session, CommandContext args) throws WorldEditException {
 
         int radius = args.getInteger(0);
         we.checkMaxBrushRadius(radius);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/WorldEditCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/WorldEditCommands.java
@@ -23,7 +23,6 @@ import com.google.common.io.Files;
 import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
 import com.sk89q.minecraft.util.commands.CommandPermissions;
-import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.WorldEditException;
@@ -126,7 +125,7 @@ public class WorldEditCommands {
         min = 0,
         max = 0
     )
-    public void cui(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void cui(Player player, LocalSession session) throws WorldEditException {
         session.setCUISupport(true);
         session.dispatchCUISetup(player);
     }
@@ -138,7 +137,7 @@ public class WorldEditCommands {
         min = 1,
         max = 1
     )
-    public void tz(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+    public void tz(Player player, LocalSession session, CommandContext args) throws WorldEditException {
         TimeZone tz = TimeZone.getTimeZone(args.getString(0));
         session.setTimezone(tz);
         player.print("Timezone set for this session to: " + tz.getDisplayName());

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BrushTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BrushTool.java
@@ -173,7 +173,6 @@ public class BrushTool implements TraceTool {
         BlockBag bag = session.getBlockBag(player);
 
         try (EditSession editSession = session.createEditSession(player)) {
-            Request.request().setEditSession(editSession);
             if (mask != null) {
                 Mask existingMask = editSession.getMask();
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BiomeMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BiomeMaskParser.java
@@ -28,6 +28,7 @@ import com.sk89q.worldedit.function.mask.BiomeMask2D;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.mask.Masks;
 import com.sk89q.worldedit.internal.registry.InputParser;
+import com.sk89q.worldedit.session.request.RequestExtent;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.biome.Biomes;
 import com.sk89q.worldedit.world.registry.BiomeRegistry;
@@ -59,6 +60,6 @@ public class BiomeMaskParser extends InputParser<Mask> {
             biomes.add(biome);
         }
 
-        return Masks.asMask(new BiomeMask2D(context.requireExtent(), biomes));
+        return Masks.asMask(new BiomeMask2D(new RequestExtent(), biomes));
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlockCategoryMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlockCategoryMaskParser.java
@@ -22,11 +22,10 @@ package com.sk89q.worldedit.extension.factory.parser.mask;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.ParserContext;
-import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.function.mask.BlockCategoryMask;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.internal.registry.InputParser;
-import com.sk89q.worldedit.session.request.Request;
+import com.sk89q.worldedit.session.request.RequestExtent;
 import com.sk89q.worldedit.world.block.BlockCategory;
 
 public class BlockCategoryMaskParser extends InputParser<Mask> {
@@ -41,14 +40,12 @@ public class BlockCategoryMaskParser extends InputParser<Mask> {
             return null;
         }
 
-        Extent extent = Request.request().getEditSession();
-
         // This means it's a tag mask.
         BlockCategory category = BlockCategory.REGISTRY.get(input.substring(2).toLowerCase());
         if (category == null) {
             throw new InputParseException("Unrecognised tag '" + input.substring(2) + '\'');
         } else {
-            return new BlockCategoryMask(extent, category);
+            return new BlockCategoryMask(new RequestExtent(), category);
         }
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlockStateMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlockStateMaskParser.java
@@ -20,20 +20,13 @@
 package com.sk89q.worldedit.extension.factory.parser.mask;
 
 import com.google.common.base.Splitter;
-import com.google.common.collect.Maps;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.ParserContext;
-import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.function.mask.BlockStateMask;
 import com.sk89q.worldedit.function.mask.Mask;
-import com.sk89q.worldedit.function.mask.NoiseFilter;
 import com.sk89q.worldedit.internal.registry.InputParser;
-import com.sk89q.worldedit.math.noise.RandomNoise;
-import com.sk89q.worldedit.session.request.Request;
-
-import java.util.Arrays;
-import java.util.stream.Collectors;
+import com.sk89q.worldedit.session.request.RequestExtent;
 
 public class BlockStateMaskParser extends InputParser<Mask> {
 
@@ -46,11 +39,11 @@ public class BlockStateMaskParser extends InputParser<Mask> {
         if (!(input.startsWith("^[") || input.startsWith("^=[")) || !input.endsWith("]")) {
             return null;
         }
-        Extent extent = Request.request().getEditSession();
+
         boolean strict = input.charAt(1) == '=';
         String states = input.substring(2 + (strict ? 1 : 0), input.length() - 1);
         try {
-            return new BlockStateMask(extent,
+            return new BlockStateMask(new RequestExtent(),
                     Splitter.on(',').omitEmptyStrings().trimResults().withKeyValueSeparator('=').split(states),
                     strict);
         } catch (Exception e) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlocksMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlocksMaskParser.java
@@ -23,11 +23,10 @@ import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.NoMatchException;
 import com.sk89q.worldedit.extension.input.ParserContext;
-import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.function.mask.BlockMask;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.internal.registry.InputParser;
-import com.sk89q.worldedit.session.request.Request;
+import com.sk89q.worldedit.session.request.RequestExtent;
 import com.sk89q.worldedit.world.block.BaseBlock;
 
 import java.util.Set;
@@ -41,9 +40,8 @@ public class BlocksMaskParser extends InputParser<Mask> {
         super(worldEdit);
     }
 
+    @Override
     public Mask parseFromInput(String component, ParserContext context) throws InputParseException {
-        Extent extent = Request.request().getEditSession();
-
         ParserContext tempContext = new ParserContext(context);
         tempContext.setRestricted(false);
         tempContext.setPreferringWildcard(true);
@@ -52,7 +50,7 @@ public class BlocksMaskParser extends InputParser<Mask> {
             if (holders.isEmpty()) {
                 return null;
             }
-            return new BlockMask(extent, holders);
+            return new BlockMask(new RequestExtent(), holders);
         } catch (NoMatchException e) {
             return null;
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/ExistingMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/ExistingMaskParser.java
@@ -21,13 +21,11 @@ package com.sk89q.worldedit.extension.factory.parser.mask;
 
 import com.google.common.collect.Lists;
 import com.sk89q.worldedit.WorldEdit;
-import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.ParserContext;
-import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.function.mask.ExistingBlockMask;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.internal.registry.SimpleInputParser;
-import com.sk89q.worldedit.session.request.Request;
+import com.sk89q.worldedit.session.request.RequestExtent;
 
 import java.util.List;
 
@@ -43,9 +41,7 @@ public class ExistingMaskParser extends SimpleInputParser<Mask> {
     }
 
     @Override
-    public Mask parseFromSimpleInput(String input, ParserContext context) throws InputParseException {
-        Extent extent = Request.request().getEditSession();
-
-        return new ExistingBlockMask(extent);
+    public Mask parseFromSimpleInput(String input, ParserContext context) {
+        return new ExistingBlockMask(new RequestExtent());
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/ExpressionMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/ExpressionMaskParser.java
@@ -31,6 +31,7 @@ import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.regions.shape.WorldEditExpressionEnvironment;
 import com.sk89q.worldedit.session.SessionOwner;
 import com.sk89q.worldedit.session.request.Request;
+import com.sk89q.worldedit.session.request.RequestExtent;
 
 import java.util.function.IntSupplier;
 
@@ -49,7 +50,7 @@ public class ExpressionMaskParser extends InputParser<Mask> {
         try {
             Expression exp = Expression.compile(input.substring(1), "x", "y", "z");
             WorldEditExpressionEnvironment env = new WorldEditExpressionEnvironment(
-                    Request.request().getEditSession(), Vector3.ONE, Vector3.ZERO);
+                    new RequestExtent(), Vector3.ONE, Vector3.ZERO);
             exp.setEnvironment(env);
             if (context.getActor() instanceof SessionOwner) {
                 SessionOwner owner = (SessionOwner) context.getActor();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/OffsetMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/OffsetMaskParser.java
@@ -22,7 +22,6 @@ package com.sk89q.worldedit.extension.factory.parser.mask;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.ParserContext;
-import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.function.mask.ExistingBlockMask;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.mask.MaskIntersection;
@@ -30,7 +29,7 @@ import com.sk89q.worldedit.function.mask.Masks;
 import com.sk89q.worldedit.function.mask.OffsetMask;
 import com.sk89q.worldedit.internal.registry.InputParser;
 import com.sk89q.worldedit.math.BlockVector3;
-import com.sk89q.worldedit.session.request.Request;
+import com.sk89q.worldedit.session.request.RequestExtent;
 
 public class OffsetMaskParser extends InputParser<Mask> {
 
@@ -45,13 +44,11 @@ public class OffsetMaskParser extends InputParser<Mask> {
             return null;
         }
 
-        Extent extent = Request.request().getEditSession();
-
         Mask submask;
         if (input.length() > 1) {
             submask = worldEdit.getMaskFactory().parseFromInput(input.substring(1), context);
         } else {
-            submask = new ExistingBlockMask(extent);
+            submask = new ExistingBlockMask(new RequestExtent());
         }
         OffsetMask offsetMask = new OffsetMask(submask, BlockVector3.at(0, firstChar == '>' ? -1 : 1, 0));
         return new MaskIntersection(offsetMask, Masks.negate(submask));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/SolidMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/SolidMaskParser.java
@@ -21,13 +21,11 @@ package com.sk89q.worldedit.extension.factory.parser.mask;
 
 import com.google.common.collect.Lists;
 import com.sk89q.worldedit.WorldEdit;
-import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.ParserContext;
-import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.mask.SolidBlockMask;
 import com.sk89q.worldedit.internal.registry.SimpleInputParser;
-import com.sk89q.worldedit.session.request.Request;
+import com.sk89q.worldedit.session.request.RequestExtent;
 
 import java.util.List;
 
@@ -43,9 +41,7 @@ public class SolidMaskParser extends SimpleInputParser<Mask> {
     }
 
     @Override
-    public Mask parseFromSimpleInput(String input, ParserContext context) throws InputParseException {
-        Extent extent = Request.request().getEditSession();
-
-        return new SolidBlockMask(extent);
+    public Mask parseFromSimpleInput(String input, ParserContext context) {
+        return new SolidBlockMask(new RequestExtent());
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/CommandManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/CommandManager.java
@@ -19,6 +19,9 @@
 
 package com.sk89q.worldedit.extension.platform;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.sk89q.worldedit.util.command.composition.LegacyCommandAdapter.adapt;
+
 import com.google.common.base.Joiner;
 import com.sk89q.minecraft.util.commands.CommandException;
 import com.sk89q.minecraft.util.commands.CommandLocals;
@@ -54,8 +57,10 @@ import com.sk89q.worldedit.command.composition.DeformCommand;
 import com.sk89q.worldedit.command.composition.PaintCommand;
 import com.sk89q.worldedit.command.composition.SelectionCommand;
 import com.sk89q.worldedit.command.composition.ShapedBrushCommand;
+import com.sk89q.worldedit.entity.Entity;
 import com.sk89q.worldedit.event.platform.CommandEvent;
 import com.sk89q.worldedit.event.platform.CommandSuggestionEvent;
+import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.function.factory.Deform;
 import com.sk89q.worldedit.function.factory.Deform.Mode;
 import com.sk89q.worldedit.internal.command.ActorAuthorizer;
@@ -76,6 +81,7 @@ import com.sk89q.worldedit.util.formatting.ColorCodeBuilder;
 import com.sk89q.worldedit.util.formatting.component.CommandUsageBox;
 import com.sk89q.worldedit.util.logging.DynamicStreamHandler;
 import com.sk89q.worldedit.util.logging.LogFormat;
+import com.sk89q.worldedit.world.World;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,9 +90,6 @@ import java.io.IOException;
 import java.util.logging.FileHandler;
 import java.util.logging.Level;
 import java.util.regex.Pattern;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.sk89q.worldedit.util.command.composition.LegacyCommandAdapter.adapt;
 
 /**
  * Handles the registration and invocation of commands.
@@ -260,6 +263,13 @@ public final class CommandManager {
         }
 
         LocalSession session = worldEdit.getSessionManager().get(actor);
+        Request.request().setSession(session);
+        if (actor instanceof Entity) {
+            Extent extent = ((Entity) actor).getExtent();
+            if (extent instanceof World) {
+                Request.request().setWorld(((World) extent));
+            }
+        }
         LocalConfiguration config = worldEdit.getConfiguration();
 
         CommandLocals locals = new CommandLocals();
@@ -335,6 +345,7 @@ public final class CommandManager {
 
                 worldEdit.flushBlockBag(actor, editSession);
             }
+            Request.reset();
         }
 
         event.setCancelled(true);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/WorldEditExpressionEnvironment.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/WorldEditExpressionEnvironment.java
@@ -19,7 +19,7 @@
 
 package com.sk89q.worldedit.regions.shape;
 
-import com.sk89q.worldedit.EditSession;
+import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.internal.expression.runtime.ExpressionEnvironment;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
@@ -29,10 +29,10 @@ public class WorldEditExpressionEnvironment implements ExpressionEnvironment {
     private final Vector3 unit;
     private final Vector3 zero2;
     private Vector3 current = Vector3.ZERO;
-    private EditSession editSession;
+    private Extent extent;
 
-    public WorldEditExpressionEnvironment(EditSession editSession, Vector3 unit, Vector3 zero) {
-        this.editSession = editSession;
+    public WorldEditExpressionEnvironment(Extent extent, Vector3 unit, Vector3 zero) {
+        this.extent = extent;
         this.unit = unit;
         this.zero2 = zero.add(0.5, 0.5, 0.5);
     }
@@ -48,7 +48,7 @@ public class WorldEditExpressionEnvironment implements ExpressionEnvironment {
 
     @Override
     public int getBlockType(double x, double y, double z) {
-        return editSession.getBlock(toWorld(x, y, z)).getBlockType().getLegacyId();
+        return extent.getBlock(toWorld(x, y, z)).getBlockType().getLegacyId();
     }
 
     @Override
@@ -58,7 +58,7 @@ public class WorldEditExpressionEnvironment implements ExpressionEnvironment {
 
     @Override
     public int getBlockTypeAbs(double x, double y, double z) {
-        return editSession.getBlock(BlockVector3.at(x, y, z)).getBlockType().getLegacyId();
+        return extent.getBlock(BlockVector3.at(x, y, z)).getBlockType().getLegacyId();
     }
 
     @Override
@@ -68,7 +68,7 @@ public class WorldEditExpressionEnvironment implements ExpressionEnvironment {
 
     @Override
     public int getBlockTypeRel(double x, double y, double z) {
-        return editSession.getBlock(toWorldRel(x, y, z).toBlockPoint()).getBlockType().getLegacyId();
+        return extent.getBlock(toWorldRel(x, y, z).toBlockPoint()).getBlockType().getLegacyId();
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/scripting/CraftScriptContext.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/scripting/CraftScriptContext.java
@@ -31,6 +31,7 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.input.ParserContext;
 import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.function.pattern.Pattern;
+import com.sk89q.worldedit.session.request.Request;
 import com.sk89q.worldedit.util.io.file.FilenameException;
 import com.sk89q.worldedit.world.block.BaseBlock;
 
@@ -65,6 +66,7 @@ public class CraftScriptContext extends CraftScriptEnvironment {
         EditSession editSession = controller.getEditSessionFactory()
                 .getEditSession(player.getWorld(),
                         session.getBlockChangeLimit(), session.getBlockBag(player), player);
+        Request.request().setEditSession(editSession);
         editSession.enableStandardMode();
         editSessions.add(editSession);
         return editSession;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
@@ -28,6 +28,7 @@ import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.event.platform.ConfigurationLoadEvent;
+import com.sk89q.worldedit.session.request.Request;
 import com.sk89q.worldedit.session.storage.JsonFileSessionStore;
 import com.sk89q.worldedit.session.storage.SessionStore;
 import com.sk89q.worldedit.session.storage.VoidStore;
@@ -151,6 +152,7 @@ public class SessionManager {
                 log.warn("Failed to load saved session", e);
                 session = new LocalSession();
             }
+            Request.request().setSession(session);
 
             session.setConfiguration(config);
             session.setBlockChangeLimit(config.defaultChangeLimit);
@@ -313,7 +315,7 @@ public class SessionManager {
     /**
      * Stores the owner of a session, the session, and the last active time.
      */
-    private static class SessionHolder {
+    private static final class SessionHolder {
         private final SessionKey key;
         private final LocalSession session;
         private long lastActive = System.currentTimeMillis();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/request/Request.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/request/Request.java
@@ -35,6 +35,7 @@ public final class Request {
     private @Nullable World world;
     private @Nullable LocalSession session;
     private @Nullable EditSession editSession;
+    private boolean valid;
 
     private Request() {
     }
@@ -106,6 +107,20 @@ public final class Request {
      * Reset the current request and clear all fields.
      */
     public static void reset() {
+        request().invalidate();
         threadLocal.remove();
+    }
+
+    /**
+     * Check if the current request object is still valid. Invalid requests may contain outdated values.
+     *
+     * @return true if the request is valid
+     */
+    public boolean isValid() {
+        return valid;
+    }
+
+    private void invalidate() {
+        valid = false;
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/request/RequestExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/request/RequestExtent.java
@@ -1,0 +1,109 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.session.request;
+
+import com.sk89q.worldedit.EditSession;
+import com.sk89q.worldedit.WorldEditException;
+import com.sk89q.worldedit.entity.BaseEntity;
+import com.sk89q.worldedit.entity.Entity;
+import com.sk89q.worldedit.extent.Extent;
+import com.sk89q.worldedit.function.operation.Operation;
+import com.sk89q.worldedit.math.BlockVector2;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.Region;
+import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldedit.world.biome.BiomeType;
+import com.sk89q.worldedit.world.block.BaseBlock;
+import com.sk89q.worldedit.world.block.BlockState;
+import com.sk89q.worldedit.world.block.BlockStateHolder;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class RequestExtent implements Extent {
+
+    private EditSession extent;
+
+    protected Extent getExtent() {
+        if (extent == null) {
+            extent = Request.request().getEditSession();
+        }
+        return extent;
+    }
+
+    @Override
+    public BlockVector3 getMinimumPoint() {
+        return getExtent().getMinimumPoint();
+    }
+
+    @Override
+    public BlockVector3 getMaximumPoint() {
+        return getExtent().getMaximumPoint();
+    }
+
+    @Override
+    public List<? extends Entity> getEntities(Region region) {
+        return getExtent().getEntities(region);
+    }
+
+    @Override
+    public List<? extends Entity> getEntities() {
+        return getExtent().getEntities();
+    }
+
+    @Override
+    @Nullable
+    public Entity createEntity(Location location, BaseEntity entity) {
+        return getExtent().createEntity(location, entity);
+    }
+
+    @Override
+    public BlockState getBlock(BlockVector3 position) {
+        return getExtent().getBlock(position);
+    }
+
+    @Override
+    public BaseBlock getFullBlock(BlockVector3 position) {
+        return getExtent().getFullBlock(position);
+    }
+
+    @Override
+    public BiomeType getBiome(BlockVector2 position) {
+        return getExtent().getBiome(position);
+    }
+
+    @Override
+    public <T extends BlockStateHolder<T>> boolean setBlock(BlockVector3 position, T block) throws WorldEditException {
+        return getExtent().setBlock(position, block);
+    }
+
+    @Override
+    public boolean setBiome(BlockVector2 position, BiomeType biome) {
+        return getExtent().setBiome(position, biome);
+    }
+
+    @Override
+    @Nullable
+    public Operation commit() {
+        Operation commit = getExtent().commit();
+        extent = null;
+        return commit;
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/request/RequestExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/request/RequestExtent.java
@@ -39,13 +39,13 @@ import java.util.List;
 
 public class RequestExtent implements Extent {
 
-    private EditSession extent;
+    private Request request;
 
     protected Extent getExtent() {
-        if (extent == null) {
-            extent = Request.request().getEditSession();
+        if (request == null || !request.isValid()) {
+            request = Request.request();
         }
-        return extent;
+        return request.getEditSession();
     }
 
     @Override
@@ -103,7 +103,7 @@ public class RequestExtent implements Extent {
     @Nullable
     public Operation commit() {
         Operation commit = getExtent().commit();
-        extent = null;
+        request = null;
         return commit;
     }
 }


### PR DESCRIPTION
For example, if you set a mask that takes an extent (many of them),
and then move to another world, the mask will test blocks in the old
world and return bad results.

~~Downside: ThreadLocal is slow?~~