### PR TITLE
Remove redundant block vector method to avoid confusion

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitAdapter.java
@@ -214,7 +214,7 @@ public class BukkitAdapter {
         checkNotNull(position);
         return new org.bukkit.Location(
                 world,
-                position.getX(), position.getY(), position.getZ());
+                position.getBlockX(), position.getBlockY(), position.getBlockZ());
     }
 
     /**

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
@@ -260,7 +260,7 @@ public class BukkitPlayer extends AbstractPlayerActor {
 
     @Override
     public <B extends BlockStateHolder<B>> void sendFakeBlock(BlockVector3 pos, B block) {
-        Location loc = new Location(player.getWorld(), pos.getX(), pos.getY(), pos.getZ());
+        Location loc = new Location(player.getWorld(), pos.getBlockX(), pos.getBlockY(), pos.getBlockZ());
         if (block == null) {
             player.sendBlockChange(loc, player.getWorld().getBlockAt(loc).getBlockData());
         } else {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -2233,7 +2233,7 @@ public class EditSession implements Extent, AutoCloseable {
     private static Set<BlockVector3> getHollowed(Set<BlockVector3> vset) {
         Set<BlockVector3> returnset = new HashSet<>();
         for (BlockVector3 v : vset) {
-            double x = v.getX(), y = v.getY(), z = v.getZ();
+            double x = v.getBlockX(), y = v.getBlockY(), z = v.getBlockZ();
             if (!(vset.contains(BlockVector3.at(x + 1, y, z)) &&
                     vset.contains(BlockVector3.at(x - 1, y, z)) &&
                     vset.contains(BlockVector3.at(x, y + 1, z)) &&

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SelectionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SelectionCommands.java
@@ -602,7 +602,7 @@ public class SelectionCommands {
             player.print("Cuboid dimensions (max - min): " + size);
             player.print("Offset: " + origin);
             player.print("Cuboid distance: " + size.distance(BlockVector3.ONE));
-            player.print("# of blocks: " + (int) (size.getX() * size.getY() * size.getZ()));
+            player.print("# of blocks: " + (int) (size.getBlockX() * size.getBlockY() * size.getBlockZ()));
             return;
         }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
@@ -159,7 +159,7 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
         byte free = 0;
         byte spots = 0;
 
-        while (y <= world.getMaximumPoint().getY() + 2) {
+        while (y <= world.getMaximumPoint().getBlockY() + 2) {
             if (!world.getBlock(BlockVector3.at(x, y, z)).getBlockType().getMaterial().isMovementBlocker()) {
                 ++free;
             } else {
@@ -253,7 +253,7 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
             return false;
         }
 
-        while (y <= world.getMaximumPoint().getY()) {
+        while (y <= world.getMaximumPoint().getBlockY()) {
             // Found a ceiling!
             if (world.getBlock(BlockVector3.at(x, y, z)).getBlockType().getMaterial().isMovementBlocker()) {
                 int platformY = Math.max(initialY, y - 3 - clearance);
@@ -282,7 +282,7 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
         final int maxY = Math.min(getWorld().getMaxY() + 1, initialY + distance);
         final Extent world = getLocation().getExtent();
 
-        while (y <= world.getMaximumPoint().getY() + 2) {
+        while (y <= world.getMaximumPoint().getBlockY() + 2) {
             if (world.getBlock(BlockVector3.at(x, y, z)).getBlockType().getMaterial().isMovementBlocker()) {
                 break; // Hit something
             } else if (y > maxY + 1) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/BoundedHeightMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/BoundedHeightMask.java
@@ -48,7 +48,7 @@ public class BoundedHeightMask extends AbstractMask {
 
     @Override
     public boolean test(BlockVector3 vector) {
-        return vector.getY() >= minY && vector.getY() <= maxY;
+        return vector.getBlockY() >= minY && vector.getBlockY() <= maxY;
     }
 
     @Nullable

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/ExpressionMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/ExpressionMask.java
@@ -21,7 +21,6 @@ package com.sk89q.worldedit.function.mask;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.internal.expression.Expression;
 import com.sk89q.worldedit.internal.expression.ExpressionException;
 import com.sk89q.worldedit.internal.expression.runtime.EvaluationException;
@@ -74,9 +73,9 @@ public class ExpressionMask extends AbstractMask {
                 ((WorldEditExpressionEnvironment) expression.getEnvironment()).setCurrentBlock(vector.toVector3());
             }
             if (timeout == null) {
-                return expression.evaluate(vector.getX(), vector.getY(), vector.getZ()) > 0;
+                return expression.evaluate(vector.getBlockX(), vector.getBlockY(), vector.getBlockZ()) > 0;
             } else {
-                return expression.evaluate(new double[]{vector.getX(), vector.getY(), vector.getZ()},
+                return expression.evaluate(new double[]{vector.getBlockX(), vector.getBlockY(), vector.getBlockZ()},
                         timeout.getAsInt()) > 0;
             }
         } catch (EvaluationException e) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/ExpressionMask2D.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/ExpressionMask2D.java
@@ -21,7 +21,6 @@ package com.sk89q.worldedit.function.mask;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.internal.expression.Expression;
 import com.sk89q.worldedit.internal.expression.ExpressionException;
 import com.sk89q.worldedit.internal.expression.runtime.EvaluationException;
@@ -64,9 +63,9 @@ public class ExpressionMask2D extends AbstractMask2D {
     public boolean test(BlockVector2 vector) {
         try {
             if (timeout != null) {
-                return expression.evaluate(vector.getX(), 0, vector.getZ()) > 0;
+                return expression.evaluate(vector.getBlockX(), 0, vector.getBlockZ()) > 0;
             } else {
-                return expression.evaluate(new double[]{vector.getX(), 0, vector.getZ()}, timeout.getAsInt()) > 0;
+                return expression.evaluate(new double[]{vector.getBlockX(), 0, vector.getBlockZ()}, timeout.getAsInt()) > 0;
             }
         } catch (EvaluationException e) {
             return false;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/cui/SelectionPoint2DEvent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/cui/SelectionPoint2DEvent.java
@@ -31,15 +31,15 @@ public class SelectionPoint2DEvent implements CUIEvent {
 
     public SelectionPoint2DEvent(int id, BlockVector2 pos, int area) {
         this.id = id;
-        this.blockX = pos.getX();
-        this.blockZ = pos.getZ();
+        this.blockX = pos.getBlockX();
+        this.blockZ = pos.getBlockZ();
         this.area = area;
     }
 
     public SelectionPoint2DEvent(int id, BlockVector3 pos, int area) {
         this.id = id;
-        this.blockX = pos.getX();
-        this.blockZ = pos.getZ();
+        this.blockX = pos.getBlockX();
+        this.blockZ = pos.getBlockZ();
         this.area = area;
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector2.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector2.java
@@ -93,15 +93,6 @@ public final class BlockVector2 {
      *
      * @return the x coordinate
      */
-    public int getX() {
-        return x;
-    }
-
-    /**
-     * Get the X coordinate.
-     *
-     * @return the x coordinate
-     */
     public int getBlockX() {
         return x;
     }
@@ -114,15 +105,6 @@ public final class BlockVector2 {
      */
     public BlockVector2 withX(int x) {
         return BlockVector2.at(x, z);
-    }
-
-    /**
-     * Get the Z coordinate.
-     *
-     * @return the z coordinate
-     */
-    public int getZ() {
-        return z;
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector3.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector3.java
@@ -100,15 +100,6 @@ public final class BlockVector3 {
      *
      * @return the x coordinate
      */
-    public int getX() {
-        return x;
-    }
-
-    /**
-     * Get the X coordinate.
-     *
-     * @return the x coordinate
-     */
     public int getBlockX() {
         return x;
     }
@@ -128,15 +119,6 @@ public final class BlockVector3 {
      *
      * @return the y coordinate
      */
-    public int getY() {
-        return y;
-    }
-
-    /**
-     * Get the Y coordinate.
-     *
-     * @return the y coordinate
-     */
     public int getBlockY() {
         return y;
     }
@@ -149,15 +131,6 @@ public final class BlockVector3 {
      */
     public BlockVector3 withY(int y) {
         return BlockVector3.at(x, y, z);
-    }
-
-    /**
-     * Get the Z coordinate.
-     *
-     * @return the z coordinate
-     */
-    public int getZ() {
-        return z;
     }
 
     /**
@@ -528,16 +501,16 @@ public final class BlockVector3 {
      * @return pitch in radians
      */
     public double toPitch() {
-        double x = getX();
-        double z = getZ();
+        double x = getBlockX();
+        double z = getBlockZ();
 
         if (x == 0 && z == 0) {
-            return getY() > 0 ? -90 : 90;
+            return getBlockY() > 0 ? -90 : 90;
         } else {
             double x2 = x * x;
             double z2 = z * z;
             double xz = Math.sqrt(x2 + z2);
-            return Math.toDegrees(Math.atan(-getY() / xz));
+            return Math.toDegrees(Math.atan(-getBlockY() / xz));
         }
     }
 
@@ -547,8 +520,8 @@ public final class BlockVector3 {
      * @return yaw in radians
      */
     public double toYaw() {
-        double x = getX();
-        double z = getZ();
+        double x = getBlockX();
+        double z = getBlockZ();
 
         double t = Math.atan2(-x, z);
         double tau = 2 * Math.PI;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/transform/AffineTransform.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/transform/AffineTransform.java
@@ -242,7 +242,7 @@ public class AffineTransform implements Transform {
     }
 
     public AffineTransform translate(BlockVector3 vec) {
-        return translate(vec.getX(), vec.getY(), vec.getZ());
+        return translate(vec.getBlockX(), vec.getBlockY(), vec.getBlockZ());
     }
 
     public AffineTransform translate(double x, double y, double z) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/AbstractRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/AbstractRegion.java
@@ -91,10 +91,10 @@ public abstract class AbstractRegion implements Region {
 
         final List<BlockVector2> points = new ArrayList<>(4);
 
-        points.add(BlockVector2.at(min.getX(), min.getZ()));
-        points.add(BlockVector2.at(min.getX(), max.getZ()));
-        points.add(BlockVector2.at(max.getX(), max.getZ()));
-        points.add(BlockVector2.at(max.getX(), min.getZ()));
+        points.add(BlockVector2.at(min.getBlockX(), min.getBlockZ()));
+        points.add(BlockVector2.at(min.getBlockX(), max.getBlockZ()));
+        points.add(BlockVector2.at(max.getBlockX(), max.getBlockZ()));
+        points.add(BlockVector2.at(max.getBlockX(), min.getBlockZ()));
 
         return points;
     }
@@ -109,9 +109,9 @@ public abstract class AbstractRegion implements Region {
         BlockVector3 min = getMinimumPoint();
         BlockVector3 max = getMaximumPoint();
 
-        return (max.getX() - min.getX() + 1) *
-                (max.getY() - min.getY() + 1) *
-                (max.getZ() - min.getZ() + 1);
+        return (max.getBlockX() - min.getBlockX() + 1) *
+                (max.getBlockY() - min.getBlockY() + 1) *
+                (max.getBlockZ() - min.getBlockZ() + 1);
     }
 
     /**
@@ -124,7 +124,7 @@ public abstract class AbstractRegion implements Region {
         BlockVector3 min = getMinimumPoint();
         BlockVector3 max = getMaximumPoint();
 
-        return max.getX() - min.getX() + 1;
+        return max.getBlockX() - min.getBlockX() + 1;
     }
 
     /**
@@ -137,7 +137,7 @@ public abstract class AbstractRegion implements Region {
         BlockVector3 min = getMinimumPoint();
         BlockVector3 max = getMaximumPoint();
 
-        return max.getY() - min.getY() + 1;
+        return max.getBlockY() - min.getBlockY() + 1;
     }
 
     /**
@@ -150,7 +150,7 @@ public abstract class AbstractRegion implements Region {
         BlockVector3 min = getMinimumPoint();
         BlockVector3 max = getMaximumPoint();
 
-        return max.getZ() - min.getZ() + 1;
+        return max.getBlockZ() - min.getBlockZ() + 1;
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CuboidRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CuboidRegion.java
@@ -121,16 +121,16 @@ public class CuboidRegion extends AbstractRegion implements FlatRegion {
 
         return new RegionIntersection(
                 // Project to Z-Y plane
-                new CuboidRegion(pos1.withX(min.getX()), pos2.withX(min.getX())),
-                new CuboidRegion(pos1.withX(max.getX()), pos2.withX(max.getX())),
+                new CuboidRegion(pos1.withX(min.getBlockX()), pos2.withX(min.getBlockX())),
+                new CuboidRegion(pos1.withX(max.getBlockX()), pos2.withX(max.getBlockX())),
 
                 // Project to X-Y plane
-                new CuboidRegion(pos1.withZ(min.getZ()), pos2.withZ(min.getZ())),
-                new CuboidRegion(pos1.withZ(max.getZ()), pos2.withZ(max.getZ())),
+                new CuboidRegion(pos1.withZ(min.getBlockZ()), pos2.withZ(min.getBlockZ())),
+                new CuboidRegion(pos1.withZ(max.getBlockZ()), pos2.withZ(max.getBlockZ())),
 
                 // Project to the X-Z plane
-                new CuboidRegion(pos1.withY(min.getY()), pos2.withY(min.getY())),
-                new CuboidRegion(pos1.withY(max.getY()), pos2.withY(max.getY())));
+                new CuboidRegion(pos1.withY(min.getBlockY()), pos2.withY(min.getBlockY())),
+                new CuboidRegion(pos1.withY(max.getBlockY()), pos2.withY(max.getBlockY())));
     }
 
     /**
@@ -145,12 +145,12 @@ public class CuboidRegion extends AbstractRegion implements FlatRegion {
 
         return new RegionIntersection(
                 // Project to Z-Y plane
-                new CuboidRegion(pos1.withX(min.getX()), pos2.withX(min.getX())),
-                new CuboidRegion(pos1.withX(max.getX()), pos2.withX(max.getX())),
+                new CuboidRegion(pos1.withX(min.getBlockX()), pos2.withX(min.getBlockX())),
+                new CuboidRegion(pos1.withX(max.getBlockX()), pos2.withX(max.getBlockX())),
 
                 // Project to X-Y plane
-                new CuboidRegion(pos1.withZ(min.getZ()), pos2.withZ(min.getZ())),
-                new CuboidRegion(pos1.withZ(max.getZ()), pos2.withZ(max.getZ())));
+                new CuboidRegion(pos1.withZ(min.getBlockZ()), pos2.withZ(min.getBlockZ())),
+                new CuboidRegion(pos1.withZ(max.getBlockZ()), pos2.withZ(max.getBlockZ())));
     }
 
     @Override
@@ -178,45 +178,45 @@ public class CuboidRegion extends AbstractRegion implements FlatRegion {
         checkNotNull(changes);
 
         for (BlockVector3 change : changes) {
-            if (change.getX() > 0) {
-                if (Math.max(pos1.getX(), pos2.getX()) == pos1.getX()) {
-                    pos1 = pos1.add(change.getX(), 0, 0);
+            if (change.getBlockX() > 0) {
+                if (Math.max(pos1.getBlockX(), pos2.getBlockX()) == pos1.getBlockX()) {
+                    pos1 = pos1.add(change.getBlockX(), 0, 0);
                 } else {
-                    pos2 = pos2.add(change.getX(), 0, 0);
+                    pos2 = pos2.add(change.getBlockX(), 0, 0);
                 }
             } else {
-                if (Math.min(pos1.getX(), pos2.getX()) == pos1.getX()) {
-                    pos1 = pos1.add(change.getX(), 0, 0);
+                if (Math.min(pos1.getBlockX(), pos2.getBlockX()) == pos1.getBlockX()) {
+                    pos1 = pos1.add(change.getBlockX(), 0, 0);
                 } else {
-                    pos2 = pos2.add(change.getX(), 0, 0);
+                    pos2 = pos2.add(change.getBlockX(), 0, 0);
                 }
             }
 
-            if (change.getY() > 0) {
-                if (Math.max(pos1.getY(), pos2.getY()) == pos1.getY()) {
-                    pos1 = pos1.add(0, change.getY(), 0);
+            if (change.getBlockY() > 0) {
+                if (Math.max(pos1.getBlockY(), pos2.getBlockY()) == pos1.getBlockY()) {
+                    pos1 = pos1.add(0, change.getBlockY(), 0);
                 } else {
-                    pos2 = pos2.add(0, change.getY(), 0);
+                    pos2 = pos2.add(0, change.getBlockY(), 0);
                 }
             } else {
-                if (Math.min(pos1.getY(), pos2.getY()) == pos1.getY()) {
-                    pos1 = pos1.add(0, change.getY(), 0);
+                if (Math.min(pos1.getBlockY(), pos2.getBlockY()) == pos1.getBlockY()) {
+                    pos1 = pos1.add(0, change.getBlockY(), 0);
                 } else {
-                    pos2 = pos2.add(0, change.getY(), 0);
+                    pos2 = pos2.add(0, change.getBlockY(), 0);
                 }
             }
 
-            if (change.getZ() > 0) {
-                if (Math.max(pos1.getZ(), pos2.getZ()) == pos1.getZ()) {
-                    pos1 = pos1.add(0, 0, change.getZ());
+            if (change.getBlockZ() > 0) {
+                if (Math.max(pos1.getBlockZ(), pos2.getBlockZ()) == pos1.getBlockZ()) {
+                    pos1 = pos1.add(0, 0, change.getBlockZ());
                 } else {
-                    pos2 = pos2.add(0, 0, change.getZ());
+                    pos2 = pos2.add(0, 0, change.getBlockZ());
                 }
             } else {
-                if (Math.min(pos1.getZ(), pos2.getZ()) == pos1.getZ()) {
-                    pos1 = pos1.add(0, 0, change.getZ());
+                if (Math.min(pos1.getBlockZ(), pos2.getBlockZ()) == pos1.getBlockZ()) {
+                    pos1 = pos1.add(0, 0, change.getBlockZ());
                 } else {
-                    pos2 = pos2.add(0, 0, change.getZ());
+                    pos2 = pos2.add(0, 0, change.getBlockZ());
                 }
             }
         }
@@ -229,45 +229,45 @@ public class CuboidRegion extends AbstractRegion implements FlatRegion {
         checkNotNull(changes);
 
         for (BlockVector3 change : changes) {
-            if (change.getX() < 0) {
-                if (Math.max(pos1.getX(), pos2.getX()) == pos1.getX()) {
-                    pos1 = pos1.add(change.getX(), 0, 0);
+            if (change.getBlockX() < 0) {
+                if (Math.max(pos1.getBlockX(), pos2.getBlockX()) == pos1.getBlockX()) {
+                    pos1 = pos1.add(change.getBlockX(), 0, 0);
                 } else {
-                    pos2 = pos2.add(change.getX(), 0, 0);
+                    pos2 = pos2.add(change.getBlockX(), 0, 0);
                 }
             } else {
-                if (Math.min(pos1.getX(), pos2.getX()) == pos1.getX()) {
-                    pos1 = pos1.add(change.getX(), 0, 0);
+                if (Math.min(pos1.getBlockX(), pos2.getBlockX()) == pos1.getBlockX()) {
+                    pos1 = pos1.add(change.getBlockX(), 0, 0);
                 } else {
-                    pos2 = pos2.add(change.getX(), 0, 0);
+                    pos2 = pos2.add(change.getBlockX(), 0, 0);
                 }
             }
 
-            if (change.getY() < 0) {
-                if (Math.max(pos1.getY(), pos2.getY()) == pos1.getY()) {
-                    pos1 = pos1.add(0, change.getY(), 0);
+            if (change.getBlockY() < 0) {
+                if (Math.max(pos1.getBlockY(), pos2.getBlockY()) == pos1.getBlockY()) {
+                    pos1 = pos1.add(0, change.getBlockY(), 0);
                 } else {
-                    pos2 = pos2.add(0, change.getY(), 0);
+                    pos2 = pos2.add(0, change.getBlockY(), 0);
                 }
             } else {
-                if (Math.min(pos1.getY(), pos2.getY()) == pos1.getY()) {
-                    pos1 = pos1.add(0, change.getY(), 0);
+                if (Math.min(pos1.getBlockY(), pos2.getBlockY()) == pos1.getBlockY()) {
+                    pos1 = pos1.add(0, change.getBlockY(), 0);
                 } else {
-                    pos2 = pos2.add(0, change.getY(), 0);
+                    pos2 = pos2.add(0, change.getBlockY(), 0);
                 }
             }
 
-            if (change.getZ() < 0) {
-                if (Math.max(pos1.getZ(), pos2.getZ()) == pos1.getZ()) {
-                    pos1 = pos1.add(0, 0, change.getZ());
+            if (change.getBlockZ() < 0) {
+                if (Math.max(pos1.getBlockZ(), pos2.getBlockZ()) == pos1.getBlockZ()) {
+                    pos1 = pos1.add(0, 0, change.getBlockZ());
                 } else {
-                    pos2 = pos2.add(0, 0, change.getZ());
+                    pos2 = pos2.add(0, 0, change.getBlockZ());
                 }
             } else {
-                if (Math.min(pos1.getZ(), pos2.getZ()) == pos1.getZ()) {
-                    pos1 = pos1.add(0, 0, change.getZ());
+                if (Math.min(pos1.getBlockZ(), pos2.getBlockZ()) == pos1.getBlockZ()) {
+                    pos1 = pos1.add(0, 0, change.getBlockZ());
                 } else {
-                    pos2 = pos2.add(0, 0, change.getZ());
+                    pos2 = pos2.add(0, 0, change.getBlockZ());
                 }
             }
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegion.java
@@ -260,13 +260,13 @@ public class Polygonal2DRegion extends AbstractRegion implements FlatRegion {
 
     @Override
     public void shift(BlockVector3 change) throws RegionOperationException {
-        final double changeX = change.getX();
-        final double changeY = change.getY();
-        final double changeZ = change.getZ();
+        final double changeX = change.getBlockX();
+        final double changeY = change.getBlockY();
+        final double changeZ = change.getBlockZ();
 
         for (int i = 0; i < points.size(); ++i) {
             BlockVector2 point = points.get(i);
-            points.set(i, BlockVector2.at(point.getX() + changeX, point.getZ() + changeZ));
+            points.set(i, BlockVector2.at(point.getBlockX() + changeX, point.getBlockZ() + changeZ));
         }
 
         minY += changeY;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Regions.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Regions.java
@@ -35,7 +35,7 @@ public final class Regions {
      * @return the Y coordinate
      */
     public static double minimumY(Region region) {
-        return region.getMinimumPoint().getY();
+        return region.getMinimumPoint().getBlockY();
     }
 
     /**
@@ -46,7 +46,7 @@ public final class Regions {
      * @return the Y coordinate
      */
     public static double maximumY(Region region) {
-        return region.getMaximumPoint().getY();
+        return region.getMaximumPoint().getBlockY();
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/ExtendingCuboidRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/ExtendingCuboidRegionSelector.java
@@ -105,13 +105,13 @@ public class ExtendingCuboidRegionSelector extends CuboidRegionSelector {
             return false;
         }
 
-        double x1 = Math.min(position.getX(), position1.getX());
-        double y1 = Math.min(position.getY(), position1.getY());
-        double z1 = Math.min(position.getZ(), position1.getZ());
+        double x1 = Math.min(position.getBlockX(), position1.getBlockX());
+        double y1 = Math.min(position.getBlockY(), position1.getBlockY());
+        double z1 = Math.min(position.getBlockZ(), position1.getBlockZ());
 
-        double x2 = Math.max(position.getX(), position2.getX());
-        double y2 = Math.max(position.getY(), position2.getY());
-        double z2 = Math.max(position.getZ(), position2.getZ());
+        double x2 = Math.max(position.getBlockX(), position2.getBlockX());
+        double y2 = Math.max(position.getBlockY(), position2.getBlockY());
+        double z2 = Math.max(position.getBlockZ(), position2.getBlockZ());
 
         final BlockVector3 o1 = position1;
         final BlockVector3 o2 = position2;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/Polygonal2DRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/Polygonal2DRegionSelector.java
@@ -109,7 +109,7 @@ public class Polygonal2DRegionSelector implements RegionSelector, CUIRegion {
         checkNotNull(points);
         
         final BlockVector2 pos2D = points.get(0);
-        pos1 = BlockVector3.at(pos2D.getX(), minY, pos2D.getZ());
+        pos1 = BlockVector3.at(pos2D.getBlockX(), minY, pos2D.getBlockZ());
         region = new Polygonal2DRegion(world, points, minY, maxY);
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/ArbitraryBiomeShape.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/ArbitraryBiomeShape.java
@@ -55,8 +55,8 @@ public abstract class ArbitraryBiomeShape {
         cacheOffsetX = min.getBlockX() - 1;
         cacheOffsetZ = min.getBlockZ() - 1;
 
-        cacheSizeX = max.getX() - cacheOffsetX + 2;
-        cacheSizeZ = max.getZ() - cacheOffsetZ + 2;
+        cacheSizeX = max.getBlockX() - cacheOffsetX + 2;
+        cacheSizeZ = max.getBlockZ() - cacheOffsetZ + 2;
 
         cache = new BiomeType[cacheSizeX * cacheSizeZ];
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/ArbitraryShape.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/ArbitraryShape.java
@@ -59,9 +59,9 @@ public abstract class ArbitraryShape {
         cacheOffsetY = min.getBlockY() - 1;
         cacheOffsetZ = min.getBlockZ() - 1;
 
-        cacheSizeX = max.getX() - cacheOffsetX + 2;
-        cacheSizeY = max.getY() - cacheOffsetY + 2;
-        cacheSizeZ = max.getZ() - cacheOffsetZ + 2;
+        cacheSizeX = max.getBlockX() - cacheOffsetX + 2;
+        cacheSizeY = max.getBlockY() - cacheOffsetY + 2;
+        cacheSizeZ = max.getBlockZ() - cacheOffsetZ + 2;
 
         cache = new byte[cacheSizeX * cacheSizeY * cacheSizeZ];
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/AnvilChunk.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/AnvilChunk.java
@@ -118,9 +118,9 @@ public class AnvilChunk implements Chunk {
     }
     
     private int getBlockID(BlockVector3 position) throws DataException {
-        int x = position.getX() - rootX * 16;
-        int y = position.getY();
-        int z = position.getZ() - rootZ * 16;
+        int x = position.getBlockX() - rootX * 16;
+        int y = position.getBlockY();
+        int z = position.getBlockZ() - rootZ * 16;
 
         int section = y >> 4;
         if (section < 0 || section >= blocks.length) {
@@ -151,9 +151,9 @@ public class AnvilChunk implements Chunk {
     }
 
     private int getBlockData(BlockVector3 position) throws DataException {
-        int x = position.getX() - rootX * 16;
-        int y = position.getY();
-        int z = position.getZ() - rootZ * 16;
+        int x = position.getBlockX() - rootX * 16;
+        int y = position.getBlockY();
+        int z = position.getBlockZ() - rootZ * 16;
 
         int section = y >> 4;
         int yIndex = y & 0x0F;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/AnvilChunk13.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/AnvilChunk13.java
@@ -230,9 +230,9 @@ public class AnvilChunk13 implements Chunk {
 
     @Override
     public BaseBlock getBlock(BlockVector3 position) throws DataException {
-        int x = position.getX() - rootX * 16;
-        int y = position.getY();
-        int z = position.getZ() - rootZ * 16;
+        int x = position.getBlockX() - rootX * 16;
+        int y = position.getBlockY();
+        int z = position.getBlockZ() - rootZ * 16;
 
         int section = y >> 4;
         int yIndex = y & 0x0F;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/OldChunk.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/OldChunk.java
@@ -154,12 +154,12 @@ public class OldChunk implements Chunk {
 
     @Override
     public BaseBlock getBlock(BlockVector3 position) throws DataException {
-        if(position.getY() >= 128) return BlockTypes.VOID_AIR.getDefaultState().toBaseBlock();
+        if(position.getBlockY() >= 128) return BlockTypes.VOID_AIR.getDefaultState().toBaseBlock();
         int id, dataVal;
 
-        int x = position.getX() - rootX * 16;
-        int y = position.getY();
-        int z = position.getZ() - rootZ * 16;
+        int x = position.getBlockX() - rootX * 16;
+        int y = position.getBlockY();
+        int z = position.getBlockZ() - rootZ * 16;
         int index = y + (z * 128 + (x * 128 * 16));
         try {
             id = blocks[index];

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/ChunkStore.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/ChunkStore.java
@@ -57,7 +57,7 @@ public abstract class ChunkStore implements Closeable {
      * @return chunk coordinates
      */
     public static BlockVector2 toChunk(BlockVector3 position) {
-        return BlockVector2.at(position.getX() >> CHUNK_SHIFTS, position.getZ() >> CHUNK_SHIFTS);
+        return BlockVector2.at(position.getBlockX() >> CHUNK_SHIFTS, position.getBlockZ() >> CHUNK_SHIFTS);
     }
 
     /**


### PR DESCRIPTION
BlockVector class has both getX and getBlockX etc. which is redundant

This removes getX in favor of getBlockX
(as getX is used by Vector2/3)