### PR TITLE
Fix 1.13 entity direction code, port old schematics

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/EntityNBTCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/EntityNBTCompatibilityHandler.java
@@ -1,0 +1,32 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.extent.clipboard.io.legacycompat;
+
+import com.sk89q.jnbt.CompoundTag;
+import com.sk89q.jnbt.Tag;
+import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.entity.EntityType;
+
+import java.util.Map;
+
+public interface EntityNBTCompatibilityHandler {
+    boolean isAffectedEntity(EntityType type, CompoundTag entityTag);
+    CompoundTag updateNBT(EntityType type, CompoundTag entityTag);
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/Pre13HangingCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/Pre13HangingCompatibilityHandler.java
@@ -1,0 +1,25 @@
+package com.sk89q.worldedit.extent.clipboard.io.legacycompat;
+
+import com.sk89q.jnbt.ByteTag;
+import com.sk89q.jnbt.CompoundTag;
+import com.sk89q.worldedit.internal.helper.MCDirections;
+import com.sk89q.worldedit.world.entity.EntityType;
+
+public class Pre13HangingCompatibilityHandler implements EntityNBTCompatibilityHandler {
+
+    @Override
+    public boolean isAffectedEntity(EntityType type, CompoundTag entityTag) {
+        return entityTag.getValue().get("Facing") instanceof ByteTag;
+    }
+
+    @Override
+    public CompoundTag updateNBT(EntityType type, CompoundTag entityTag) {
+        int newFacing = MCDirections.toHanging(
+            MCDirections.fromPre13Hanging(entityTag.getByte("Facing"))
+        );
+        return entityTag.createBuilder()
+            .putByte("Facing", (byte) newFacing)
+            .build();
+    }
+
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/Pre13HangingCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/Pre13HangingCompatibilityHandler.java
@@ -2,24 +2,40 @@ package com.sk89q.worldedit.extent.clipboard.io.legacycompat;
 
 import com.sk89q.jnbt.ByteTag;
 import com.sk89q.jnbt.CompoundTag;
+import com.sk89q.jnbt.CompoundTagBuilder;
 import com.sk89q.worldedit.internal.helper.MCDirections;
+import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.world.entity.EntityType;
 
 public class Pre13HangingCompatibilityHandler implements EntityNBTCompatibilityHandler {
 
     @Override
-    public boolean isAffectedEntity(EntityType type, CompoundTag entityTag) {
-        return entityTag.getValue().get("Facing") instanceof ByteTag;
+    public boolean isAffectedEntity(EntityType type, CompoundTag tag) {
+        boolean hasLegacyDirection = tag.containsKey("Dir");
+        boolean hasFacing = tag.containsKey("Facing");
+        return hasLegacyDirection || hasFacing;
     }
 
     @Override
-    public CompoundTag updateNBT(EntityType type, CompoundTag entityTag) {
-        int newFacing = MCDirections.toHanging(
-            MCDirections.fromPre13Hanging(entityTag.getByte("Facing"))
-        );
-        return entityTag.createBuilder()
-            .putByte("Facing", (byte) newFacing)
-            .build();
+    public CompoundTag updateNBT(EntityType type, CompoundTag tag) {
+        boolean hasLegacyDirection = tag.containsKey("Dir");
+        boolean hasFacing = tag.containsKey("Facing");
+        int d;
+        if (hasLegacyDirection) {
+            d = MCDirections.fromLegacyHanging((byte) tag.asInt("Dir"));
+        } else {
+            d = tag.asInt("Facing");
+        }
+
+        Direction newDirection = MCDirections.fromPre13Hanging(d);
+
+        byte hangingByte = (byte) MCDirections.toHanging(newDirection);
+
+        CompoundTagBuilder builder = tag.createBuilder();
+        builder.putByte("Direction", hangingByte);
+        builder.putByte("Facing", hangingByte);
+        builder.putByte("Dir", MCDirections.toLegacyHanging(MCDirections.toHanging(newDirection)));
+        return builder.build();
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/Pre13HangingCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/Pre13HangingCompatibilityHandler.java
@@ -1,3 +1,22 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.sk89q.worldedit.extent.clipboard.io.legacycompat;
 
 import com.sk89q.jnbt.ByteTag;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/entity/ExtentEntityCopy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/entity/ExtentEntityCopy.java
@@ -144,25 +144,24 @@ public class ExtentEntityCopy implements EntityFunction {
                         .putInt("TileZ", newTilePosition.getBlockZ());
 
                 if (hasDirection || hasLegacyDirection || hasFacing) {
-                    int d;
+                    Direction direction;
                     if (hasDirection) {
-                        d = tag.asInt("Direction");
+                        direction = MCDirections.fromPre13Hanging(tag.asInt("Direction"));
                     } else if (hasLegacyDirection) {
-                        d = MCDirections.fromLegacyHanging((byte) tag.asInt("Dir"));
+                        direction = MCDirections.fromPre13Hanging(
+                            MCDirections.fromLegacyHanging((byte) tag.asInt("Dir"))
+                        );
                     } else {
-                        d = tag.asInt("Facing");
+                        direction = MCDirections.fromHanging(tag.asInt("Facing"));
                     }
-
-                    Direction direction = MCDirections.fromHanging(d);
 
                     if (direction != null) {
                         Vector3 vector = transform.apply(direction.toVector()).subtract(transform.apply(Vector3.ZERO)).normalize();
                         Direction newDirection = Direction.findClosest(vector, Flag.CARDINAL);
 
                         if (newDirection != null) {
-                            byte hangingByte = (byte) MCDirections.toHanging(newDirection);
-                            builder.putByte("Direction", hangingByte);
-                            builder.putByte("Facing", hangingByte);
+                            builder.putByte("Direction", (byte) MCDirections.toPre13Hanging(newDirection));
+                            builder.putByte("Facing", (byte) MCDirections.toHanging(newDirection));
                             builder.putByte("Dir", MCDirections.toLegacyHanging(MCDirections.toHanging(newDirection)));
                         }
                     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/helper/MCDirections.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/helper/MCDirections.java
@@ -32,6 +32,44 @@ public final class MCDirections {
     public static Direction fromHanging(int i) {
         switch (i) {
             case 0:
+                return Direction.DOWN;
+            case 1:
+                return Direction.UP;
+            case 2:
+                return Direction.NORTH;
+            case 3:
+                return Direction.SOUTH;
+            case 4:
+                return Direction.WEST;
+            case 5:
+                return Direction.EAST;
+            default:
+                return Direction.DOWN;
+        }
+    }
+
+    public static int toHanging(Direction direction) {
+        switch (direction) {
+            case DOWN:
+                return 0;
+            case UP:
+                return 1;
+            case NORTH:
+                return 2;
+            case SOUTH:
+                return 3;
+            case WEST:
+                return 4;
+            case EAST:
+                return 5;
+            default:
+                return 0;
+        }
+    }
+
+    public static Direction fromPre13Hanging(int i) {
+        switch (i) {
+            case 0:
                 return Direction.SOUTH;
             case 1:
                 return Direction.WEST;
@@ -44,7 +82,7 @@ public final class MCDirections {
         }
     }
 
-    public static int toHanging(Direction direction) {
+    public static int toPre13Hanging(Direction direction) {
         switch (direction) {
             case SOUTH:
                 return 0;


### PR DESCRIPTION
1.13 changed the `Facing` tag on us.

I added some code to the MCEdit reader to port old values to 1.13 as well.