### PR TITLE
Add old schematic compat handlers

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/MCEditSchematicReader.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/MCEditSchematicReader.java
@@ -39,6 +39,7 @@ import com.sk89q.worldedit.extent.clipboard.io.legacycompat.NBTCompatibilityHand
 import com.sk89q.worldedit.extent.clipboard.io.legacycompat.NoteBlockCompatibilityHandler;
 import com.sk89q.worldedit.extent.clipboard.io.legacycompat.Pre13HangingCompatibilityHandler;
 import com.sk89q.worldedit.extent.clipboard.io.legacycompat.SignCompatibilityHandler;
+import com.sk89q.worldedit.extent.clipboard.io.legacycompat.SkullBlockCompatibilityHandler;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.regions.Region;
@@ -67,8 +68,9 @@ public class MCEditSchematicReader extends NBTSchematicReader {
         = ImmutableList.of(
         new SignCompatibilityHandler(),
         new FlowerPotCompatibilityHandler(),
-        new NoteBlockCompatibilityHandler()
-        // TODO - skulls, item tags for inventories...? DFUs :>
+        new NoteBlockCompatibilityHandler(),
+        new SkullBlockCompatibilityHandler()
+        // TODO - item tags for inventories...? DFUs :>
     );
     private static final ImmutableList<EntityNBTCompatibilityHandler> ENTITY_COMPATIBILITY_HANDLERS
         = ImmutableList.of(

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/EntityNBTCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/EntityNBTCompatibilityHandler.java
@@ -1,0 +1,32 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.extent.clipboard.io.legacycompat;
+
+import com.sk89q.jnbt.CompoundTag;
+import com.sk89q.jnbt.Tag;
+import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.entity.EntityType;
+
+import java.util.Map;
+
+public interface EntityNBTCompatibilityHandler {
+    boolean isAffectedEntity(EntityType type, CompoundTag entityTag);
+    CompoundTag updateNBT(EntityType type, CompoundTag entityTag);
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/FlowerPotCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/FlowerPotCompatibilityHandler.java
@@ -1,0 +1,74 @@
+package com.sk89q.worldedit.extent.clipboard.io.legacycompat;
+
+import com.sk89q.jnbt.IntTag;
+import com.sk89q.jnbt.StringTag;
+import com.sk89q.jnbt.Tag;
+import com.sk89q.worldedit.world.block.BlockState;
+import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BlockType;
+import com.sk89q.worldedit.world.block.BlockTypes;
+import com.sk89q.worldedit.world.registry.LegacyMapper;
+
+import java.util.Map;
+
+public class FlowerPotCompatibilityHandler implements NBTCompatibilityHandler {
+    @Override
+    public <B extends BlockStateHolder<B>> boolean isAffectedBlock(B block) {
+        return block.getBlockType() == BlockTypes.FLOWER_POT;
+    }
+
+    @Override
+    public <B extends BlockStateHolder<B>> B updateNBT(B block, Map<String, Tag> values) {
+        Tag item = values.get("Item");
+        if (item instanceof StringTag) {
+            String id = ((StringTag) item).getValue();
+            int data = 0;
+            Tag dataTag = values.get("Data");
+            if (dataTag instanceof IntTag) {
+                data = ((IntTag) dataTag).getValue();
+            }
+            BlockState newState = convertLegacyBlockType(id, data);
+            if (newState != null) {
+                return (B) newState; // generics pls :\
+            }
+        }
+        return block;
+    }
+
+    private BlockState convertLegacyBlockType(String id, int data) {
+        int newId = 0;
+        switch (id) {
+            case "minecraft:red_flower":
+                newId = 38; // now poppy
+                break;
+            case "minecraft:yellow_flower":
+                newId = 37; // now dandelion
+                break;
+            case "minecraft:sapling":
+                newId = 6; // oak_sapling
+                break;
+            case "minecraft:deadbush":
+            case "minecraft:tallgrass":
+                newId = 31; // dead_bush with fern and grass (not 32!)
+                break;
+            default:
+                break;
+        }
+        String plantedName = null;
+        if (newId == 0) {
+            plantedName = id.substring(10);
+        } else {
+            BlockState plantedWithData = LegacyMapper.getInstance().getBlockFromLegacy(newId, data);
+            if (plantedWithData != null) {
+                plantedName = plantedWithData.getBlockType().getId().substring(10); // remove "minecraft:"
+            }
+        }
+        if (plantedName != null) {
+            BlockType potAndPlanted = BlockTypes.get("minecraft:potted_" + plantedName);
+            if (potAndPlanted != null) {
+                return potAndPlanted.getDefaultState();
+            }
+        }
+        return null;
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/FlowerPotCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/FlowerPotCompatibilityHandler.java
@@ -1,3 +1,22 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.sk89q.worldedit.extent.clipboard.io.legacycompat;
 
 import com.sk89q.jnbt.IntTag;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/NBTCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/NBTCompatibilityHandler.java
@@ -26,5 +26,5 @@ import java.util.Map;
 
 public interface NBTCompatibilityHandler {
     <B extends BlockStateHolder<B>> boolean isAffectedBlock(B block);
-    <B extends BlockStateHolder<B>> void updateNBT(B block, Map<String, Tag> values);
+    <B extends BlockStateHolder<B>> B updateNBT(B block, Map<String, Tag> values);
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/NoteBlockCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/NoteBlockCompatibilityHandler.java
@@ -1,0 +1,43 @@
+package com.sk89q.worldedit.extent.clipboard.io.legacycompat;
+
+import com.sk89q.jnbt.ByteTag;
+import com.sk89q.jnbt.Tag;
+import com.sk89q.worldedit.registry.state.IntegerProperty;
+import com.sk89q.worldedit.registry.state.Property;
+import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BlockTypes;
+
+import java.util.Map;
+
+public class NoteBlockCompatibilityHandler implements NBTCompatibilityHandler {
+    private static final IntegerProperty NoteProperty;
+
+    static {
+        IntegerProperty temp;
+        try {
+            temp = (IntegerProperty) (Property<?>) BlockTypes.NOTE_BLOCK.getProperty("note");
+        } catch (NullPointerException | IllegalArgumentException | ClassCastException e) {
+            temp = null;
+        }
+        NoteProperty = temp;
+    }
+
+    @Override
+    public <B extends BlockStateHolder<B>> boolean isAffectedBlock(B block) {
+        return NoteProperty != null && block.getBlockType() == BlockTypes.NOTE_BLOCK;
+    }
+
+    @Override
+    public <B extends BlockStateHolder<B>> B updateNBT(B block, Map<String, Tag> values) {
+        // note that instrument was note stored (in state or nbt) previously.
+        // it will be updated to the block below when it gets set into the world for the first time
+        Tag noteTag = values.get("note");
+        if (noteTag instanceof ByteTag) {
+            Byte note = ((ByteTag) noteTag).getValue();
+            if (note != null) {
+                return (B) block.with(NoteProperty, (int) note);
+            }
+        }
+        return block;
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/NoteBlockCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/NoteBlockCompatibilityHandler.java
@@ -1,3 +1,22 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.sk89q.worldedit.extent.clipboard.io.legacycompat;
 
 import com.sk89q.jnbt.ByteTag;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/NoteBlockCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/NoteBlockCompatibilityHandler.java
@@ -29,13 +29,13 @@ public class NoteBlockCompatibilityHandler implements NBTCompatibilityHandler {
 
     @Override
     public <B extends BlockStateHolder<B>> B updateNBT(B block, Map<String, Tag> values) {
-        // note that instrument was note stored (in state or nbt) previously.
+        // note that instrument was not stored (in state or nbt) previously.
         // it will be updated to the block below when it gets set into the world for the first time
         Tag noteTag = values.get("note");
         if (noteTag instanceof ByteTag) {
             Byte note = ((ByteTag) noteTag).getValue();
             if (note != null) {
-                return (B) block.with(NoteProperty, (int) note);
+                return block.with(NoteProperty, (int) note);
             }
         }
         return block;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/Pre13HangingCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/Pre13HangingCompatibilityHandler.java
@@ -30,30 +30,32 @@ public class Pre13HangingCompatibilityHandler implements EntityNBTCompatibilityH
 
     @Override
     public boolean isAffectedEntity(EntityType type, CompoundTag tag) {
-        boolean hasLegacyDirection = tag.containsKey("Dir");
+        if (!type.getId().startsWith("minecraft:")) {
+            return false;
+        }
+        boolean hasLegacyDirection = tag.containsKey("Dir") || tag.containsKey("Direction");
         boolean hasFacing = tag.containsKey("Facing");
         return hasLegacyDirection || hasFacing;
     }
 
     @Override
     public CompoundTag updateNBT(EntityType type, CompoundTag tag) {
-        boolean hasLegacyDirection = tag.containsKey("Dir");
-        boolean hasFacing = tag.containsKey("Facing");
-        int d;
-        if (hasLegacyDirection) {
-            d = MCDirections.fromLegacyHanging((byte) tag.asInt("Dir"));
+        boolean hasLegacyDir = tag.containsKey("Dir");
+        boolean hasLegacyDirection = tag.containsKey("Direction");
+        boolean hasPre113Facing = tag.containsKey("Facing");
+        Direction newDirection;
+        if (hasLegacyDir) {
+            newDirection = MCDirections.fromPre13Hanging(MCDirections.fromLegacyHanging((byte) tag.asInt("Dir")));
+        } else if (hasLegacyDirection) {
+            newDirection = MCDirections.fromPre13Hanging(tag.asInt("Direction"));
+        } else if (hasPre113Facing) {
+            newDirection = MCDirections.fromPre13Hanging(tag.asInt("Facing"));
         } else {
-            d = tag.asInt("Facing");
+            return tag;
         }
-
-        Direction newDirection = MCDirections.fromPre13Hanging(d);
-
         byte hangingByte = (byte) MCDirections.toHanging(newDirection);
-
         CompoundTagBuilder builder = tag.createBuilder();
-        builder.putByte("Direction", hangingByte);
         builder.putByte("Facing", hangingByte);
-        builder.putByte("Dir", MCDirections.toLegacyHanging(MCDirections.toHanging(newDirection)));
         return builder.build();
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/Pre13HangingCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/Pre13HangingCompatibilityHandler.java
@@ -1,0 +1,25 @@
+package com.sk89q.worldedit.extent.clipboard.io.legacycompat;
+
+import com.sk89q.jnbt.ByteTag;
+import com.sk89q.jnbt.CompoundTag;
+import com.sk89q.worldedit.internal.helper.MCDirections;
+import com.sk89q.worldedit.world.entity.EntityType;
+
+public class Pre13HangingCompatibilityHandler implements EntityNBTCompatibilityHandler {
+
+    @Override
+    public boolean isAffectedEntity(EntityType type, CompoundTag entityTag) {
+        return entityTag.getValue().get("Facing") instanceof ByteTag;
+    }
+
+    @Override
+    public CompoundTag updateNBT(EntityType type, CompoundTag entityTag) {
+        int newFacing = MCDirections.toHanging(
+            MCDirections.fromPre13Hanging(entityTag.getByte("Facing"))
+        );
+        return entityTag.createBuilder()
+            .putByte("Facing", (byte) newFacing)
+            .build();
+    }
+
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/Pre13HangingCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/Pre13HangingCompatibilityHandler.java
@@ -2,24 +2,40 @@ package com.sk89q.worldedit.extent.clipboard.io.legacycompat;
 
 import com.sk89q.jnbt.ByteTag;
 import com.sk89q.jnbt.CompoundTag;
+import com.sk89q.jnbt.CompoundTagBuilder;
 import com.sk89q.worldedit.internal.helper.MCDirections;
+import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.world.entity.EntityType;
 
 public class Pre13HangingCompatibilityHandler implements EntityNBTCompatibilityHandler {
 
     @Override
-    public boolean isAffectedEntity(EntityType type, CompoundTag entityTag) {
-        return entityTag.getValue().get("Facing") instanceof ByteTag;
+    public boolean isAffectedEntity(EntityType type, CompoundTag tag) {
+        boolean hasLegacyDirection = tag.containsKey("Dir");
+        boolean hasFacing = tag.containsKey("Facing");
+        return hasLegacyDirection || hasFacing;
     }
 
     @Override
-    public CompoundTag updateNBT(EntityType type, CompoundTag entityTag) {
-        int newFacing = MCDirections.toHanging(
-            MCDirections.fromPre13Hanging(entityTag.getByte("Facing"))
-        );
-        return entityTag.createBuilder()
-            .putByte("Facing", (byte) newFacing)
-            .build();
+    public CompoundTag updateNBT(EntityType type, CompoundTag tag) {
+        boolean hasLegacyDirection = tag.containsKey("Dir");
+        boolean hasFacing = tag.containsKey("Facing");
+        int d;
+        if (hasLegacyDirection) {
+            d = MCDirections.fromLegacyHanging((byte) tag.asInt("Dir"));
+        } else {
+            d = tag.asInt("Facing");
+        }
+
+        Direction newDirection = MCDirections.fromPre13Hanging(d);
+
+        byte hangingByte = (byte) MCDirections.toHanging(newDirection);
+
+        CompoundTagBuilder builder = tag.createBuilder();
+        builder.putByte("Direction", hangingByte);
+        builder.putByte("Facing", hangingByte);
+        builder.putByte("Dir", MCDirections.toLegacyHanging(MCDirections.toHanging(newDirection)));
+        return builder.build();
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/Pre13HangingCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/Pre13HangingCompatibilityHandler.java
@@ -1,3 +1,22 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.sk89q.worldedit.extent.clipboard.io.legacycompat;
 
 import com.sk89q.jnbt.ByteTag;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/SignCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/SignCompatibilityHandler.java
@@ -39,7 +39,7 @@ public class SignCompatibilityHandler implements NBTCompatibilityHandler {
     }
 
     @Override
-    public <B extends BlockStateHolder<B>> void updateNBT(B block, Map<String, Tag> values) {
+    public <B extends BlockStateHolder<B>> B updateNBT(B block, Map<String, Tag> values) {
         for (int i = 0; i < 4; ++i) {
             String key = "Text" + (i + 1);
             Tag value = values.get(key);
@@ -69,5 +69,6 @@ public class SignCompatibilityHandler implements NBTCompatibilityHandler {
                 values.put("Text" + (i + 1), new StringTag(jsonTextObject.toString()));
             }
         }
+        return block;
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/SkullBlockCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/SkullBlockCompatibilityHandler.java
@@ -1,3 +1,22 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.sk89q.worldedit.extent.clipboard.io.legacycompat;
 
 import com.sk89q.jnbt.ByteTag;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/SkullBlockCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/SkullBlockCompatibilityHandler.java
@@ -1,0 +1,81 @@
+package com.sk89q.worldedit.extent.clipboard.io.legacycompat;
+
+import com.sk89q.jnbt.ByteTag;
+import com.sk89q.jnbt.Tag;
+import com.sk89q.worldedit.registry.state.DirectionalProperty;
+import com.sk89q.worldedit.registry.state.Property;
+import com.sk89q.worldedit.world.block.BlockState;
+import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BlockType;
+import com.sk89q.worldedit.world.block.BlockTypes;
+
+import java.util.Map;
+
+public class SkullBlockCompatibilityHandler implements NBTCompatibilityHandler {
+
+    private static final DirectionalProperty FacingProperty;
+
+    static {
+        DirectionalProperty tempFacing;
+        try {
+            tempFacing = (DirectionalProperty) (Property<?>) BlockTypes.SKELETON_WALL_SKULL.getProperty("facing");
+        } catch (NullPointerException | IllegalArgumentException | ClassCastException e) {
+            tempFacing = null;
+        }
+        FacingProperty = tempFacing;
+    }
+
+    @Override
+    public <B extends BlockStateHolder<B>> boolean isAffectedBlock(B block) {
+        return block.getBlockType() == BlockTypes.SKELETON_SKULL
+                || block.getBlockType() == BlockTypes.SKELETON_WALL_SKULL;
+    }
+
+    @Override
+    public <B extends BlockStateHolder<B>> B updateNBT(B block, Map<String, Tag> values) {
+        boolean isWall = block.getBlockType() == BlockTypes.SKELETON_WALL_SKULL;
+        Tag typeTag = values.get("SkullType");
+        if (typeTag instanceof ByteTag) {
+            String skullType = convertSkullType(((ByteTag) typeTag).getValue(), isWall);
+            if (skullType != null) {
+                BlockType type = BlockTypes.get("minecraft:" + skullType);
+                if (type != null) {
+                    BlockState state = type.getDefaultState();
+                    if (isWall) {
+                        Property newProp = type.getProperty("facing");
+                        state = state.with(newProp, block.getState(FacingProperty));
+                    } else {
+                        Tag rotTag = values.get("Rot");
+                        if (rotTag instanceof ByteTag) {
+                            Property newProp = type.getProperty("rotation");
+                            state = state.with(newProp, (int) ((ByteTag) rotTag).getValue());
+                        }
+                    }
+                    values.remove("SkullType");
+                    values.remove("Rot");
+                    return (B) state;
+                }
+            }
+        }
+        return block;
+    }
+
+    private String convertSkullType(Byte oldType, boolean isWall) {
+        switch (oldType) {
+            case 0:
+                return isWall ? "skeleton_wall_skull" : "skeleton_skull";
+            case 1:
+                return isWall ? "wither_skeleton_wall_skull" : "wither_skeleton_skull";
+            case 2:
+                return isWall ? "zombie_wall_head" : "zombie_head";
+            case 3:
+                return isWall ? "player_wall_head" : "player_head";
+            case 4:
+                return isWall ? "creeper_wall_head" : "creeper_head";
+            case 5:
+                return isWall ? "dragon_wall_head" : "dragon_head";
+            default:
+                return null;
+        }
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/entity/ExtentEntityCopy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/entity/ExtentEntityCopy.java
@@ -144,25 +144,24 @@ public class ExtentEntityCopy implements EntityFunction {
                         .putInt("TileZ", newTilePosition.getBlockZ());
 
                 if (hasDirection || hasLegacyDirection || hasFacing) {
-                    int d;
+                    Direction direction;
                     if (hasDirection) {
-                        d = tag.asInt("Direction");
+                        direction = MCDirections.fromPre13Hanging(tag.asInt("Direction"));
                     } else if (hasLegacyDirection) {
-                        d = MCDirections.fromLegacyHanging((byte) tag.asInt("Dir"));
+                        direction = MCDirections.fromPre13Hanging(
+                            MCDirections.fromLegacyHanging((byte) tag.asInt("Dir"))
+                        );
                     } else {
-                        d = tag.asInt("Facing");
+                        direction = MCDirections.fromHanging(tag.asInt("Facing"));
                     }
-
-                    Direction direction = MCDirections.fromHanging(d);
 
                     if (direction != null) {
                         Vector3 vector = transform.apply(direction.toVector()).subtract(transform.apply(Vector3.ZERO)).normalize();
                         Direction newDirection = Direction.findClosest(vector, Flag.CARDINAL);
 
                         if (newDirection != null) {
-                            byte hangingByte = (byte) MCDirections.toHanging(newDirection);
-                            builder.putByte("Direction", hangingByte);
-                            builder.putByte("Facing", hangingByte);
+                            builder.putByte("Direction", (byte) MCDirections.toPre13Hanging(newDirection));
+                            builder.putByte("Facing", (byte) MCDirections.toHanging(newDirection));
                             builder.putByte("Dir", MCDirections.toLegacyHanging(MCDirections.toHanging(newDirection)));
                         }
                     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/entity/ExtentEntityCopy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/entity/ExtentEntityCopy.java
@@ -130,8 +130,6 @@ public class ExtentEntityCopy implements EntityFunction {
         if (tag != null) {
             // Handle hanging entities (paintings, item frames, etc.)
             boolean hasTilePosition = tag.containsKey("TileX") && tag.containsKey("TileY") && tag.containsKey("TileZ");
-            boolean hasDirection = tag.containsKey("Direction");
-            boolean hasLegacyDirection = tag.containsKey("Dir");
             boolean hasFacing = tag.containsKey("Facing");
 
             if (hasTilePosition) {
@@ -143,26 +141,15 @@ public class ExtentEntityCopy implements EntityFunction {
                         .putInt("TileY", newTilePosition.getBlockY())
                         .putInt("TileZ", newTilePosition.getBlockZ());
 
-                if (hasDirection || hasLegacyDirection || hasFacing) {
-                    Direction direction;
-                    if (hasDirection) {
-                        direction = MCDirections.fromPre13Hanging(tag.asInt("Direction"));
-                    } else if (hasLegacyDirection) {
-                        direction = MCDirections.fromPre13Hanging(
-                            MCDirections.fromLegacyHanging((byte) tag.asInt("Dir"))
-                        );
-                    } else {
-                        direction = MCDirections.fromHanging(tag.asInt("Facing"));
-                    }
+                if (hasFacing) {
+                    Direction direction = MCDirections.fromHanging(tag.asInt("Facing"));
 
                     if (direction != null) {
                         Vector3 vector = transform.apply(direction.toVector()).subtract(transform.apply(Vector3.ZERO)).normalize();
                         Direction newDirection = Direction.findClosest(vector, Flag.CARDINAL);
 
                         if (newDirection != null) {
-                            builder.putByte("Direction", (byte) MCDirections.toPre13Hanging(newDirection));
                             builder.putByte("Facing", (byte) MCDirections.toHanging(newDirection));
-                            builder.putByte("Dir", MCDirections.toLegacyHanging(MCDirections.toHanging(newDirection)));
                         }
                     }
                 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/helper/MCDirections.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/helper/MCDirections.java
@@ -32,6 +32,44 @@ public final class MCDirections {
     public static Direction fromHanging(int i) {
         switch (i) {
             case 0:
+                return Direction.DOWN;
+            case 1:
+                return Direction.UP;
+            case 2:
+                return Direction.NORTH;
+            case 3:
+                return Direction.SOUTH;
+            case 4:
+                return Direction.WEST;
+            case 5:
+                return Direction.EAST;
+            default:
+                return Direction.DOWN;
+        }
+    }
+
+    public static int toHanging(Direction direction) {
+        switch (direction) {
+            case DOWN:
+                return 0;
+            case UP:
+                return 1;
+            case NORTH:
+                return 2;
+            case SOUTH:
+                return 3;
+            case WEST:
+                return 4;
+            case EAST:
+                return 5;
+            default:
+                return 0;
+        }
+    }
+
+    public static Direction fromPre13Hanging(int i) {
+        switch (i) {
+            case 0:
                 return Direction.SOUTH;
             case 1:
                 return Direction.WEST;
@@ -44,7 +82,7 @@ public final class MCDirections {
         }
     }
 
-    public static int toHanging(Direction direction) {
+    public static int toPre13Hanging(Direction direction) {
         switch (direction) {
             case SOUTH:
                 return 0;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/helper/MCDirections.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/helper/MCDirections.java
@@ -82,36 +82,12 @@ public final class MCDirections {
         }
     }
 
-    public static int toPre13Hanging(Direction direction) {
-        switch (direction) {
-            case SOUTH:
-                return 0;
-            case WEST:
-                return 1;
-            case NORTH:
-                return 2;
-            case EAST:
-                return 3;
-            default:
-                return 0;
-        }
-    }
-
     public static int fromLegacyHanging(byte i) {
         switch (i) {
             case 0: return 2;
             case 1: return 1;
             case 2: return 0;
             default: return 3;
-        }
-    }
-
-    public static byte toLegacyHanging(int i) {
-        switch (i) {
-            case 0: return (byte) 2;
-            case 1: return (byte) 1;
-            case 2: return (byte) 0;
-            default: return (byte) 3;
         }
     }
 


### PR DESCRIPTION
Supersedes #460 with some cleanup to the directions.
Adds handlers for flower pots, jukeboxes, and skulls.

Also convert a lot of old entity and TE ids.
Loading even older schematics may work better, or may throw more (harmless) errors. If conversions fail, TEs just get reverted to default/empty.