### PR TITLE
Print //calc input before its result

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/UtilityCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/UtilityCommands.java
@@ -545,12 +545,15 @@ public class UtilityCommands {
     public void calc(Actor actor, @Text String input) throws CommandException {
         try {
             Expression expression = Expression.compile(input);
+            double result;
             if (actor instanceof SessionOwner) {
-                actor.print("= " + expression.evaluate(
-                        new double[]{}, WorldEdit.getInstance().getSessionManager().get((SessionOwner) actor).getTimeout()));
+                result = expression.evaluate(
+                        new double[]{}, WorldEdit.getInstance().getSessionManager().get((SessionOwner) actor).getTimeout());
             } else {
-                actor.print("= " + expression.evaluate());
+                result = expression.evaluate();
             }
+
+            actor.print(result + " = " + input);
         } catch (EvaluationException e) {
             actor.printError(String.format(
                     "'%s' could not be evaluated (error: %s)", input, e.getMessage()));


### PR DESCRIPTION
Currently, `//calc` history is unreadable when many calculations are performed.

![image](https://user-images.githubusercontent.com/4578571/56811383-dd31da80-6838-11e9-877f-08a2a1bffaee.png)
