### PR TITLE
Insert Locale.ROOT into all case change methods

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -57,6 +57,12 @@
     <module name="WhitespaceAround">
       <property name="tokens" value="ASSIGN"/>
     </module>
+    <!-- Validate String.to(Lower|Upper)Case() calls include Locale argument -->
+    <module name="Regexp">
+      <property name="message" value="Case-conversion calls must include an explicit Locale"/>
+      <property name="format" value="(?!Character)\.to(Lower|Upper)Case\(\)"/>
+      <property name="illegalPattern" value="true"/>
+    </module>
   </module>
   <!-- Validate that command annotations are formatted correctly -->
   <module name="RegexpMultiline">

--- a/worldedit-bukkit/src/main/java/com/sk89q/wepif/ConfigurationPermissionsResolver.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/wepif/ConfigurationPermissionsResolver.java
@@ -26,6 +26,7 @@ import org.bukkit.OfflinePlayer;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -102,8 +103,8 @@ public class ConfigurationPermissionsResolver implements PermissionsResolver {
                     }
                 }
 
-                userPermissionsCache.put(key.toLowerCase(), permsCache);
-                userGroups.put(key.toLowerCase(), new HashSet<>(groups));
+                userPermissionsCache.put(key.toLowerCase(Locale.ROOT), permsCache);
+                userGroups.put(key.toLowerCase(Locale.ROOT), new HashSet<>(groups));
             }
         }
     }
@@ -117,7 +118,7 @@ public class ConfigurationPermissionsResolver implements PermissionsResolver {
             }
         }
 
-        Set<String> perms = userPermissionsCache.get(player.toLowerCase());
+        Set<String> perms = userPermissionsCache.get(player.toLowerCase(Locale.ROOT));
         if (perms == null) {
             return defaultPermissionsCache.contains(permission)
                     || defaultPermissionsCache.contains("*");
@@ -134,7 +135,7 @@ public class ConfigurationPermissionsResolver implements PermissionsResolver {
 
     @Override
     public boolean inGroup(String player, String group) {
-        Set<String> groups = userGroups.get(player.toLowerCase());
+        Set<String> groups = userGroups.get(player.toLowerCase(Locale.ROOT));
         if (groups == null) {
             return false;
         }
@@ -144,7 +145,7 @@ public class ConfigurationPermissionsResolver implements PermissionsResolver {
 
     @Override
     public String[] getGroups(String player) {
-        Set<String> groups = userGroups.get(player.toLowerCase());
+        Set<String> groups = userGroups.get(player.toLowerCase(Locale.ROOT));
         if (groups == null) {
             return new String[0];
         }

--- a/worldedit-bukkit/src/main/java/com/sk89q/wepif/FlatFilePermissionsResolver.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/wepif/FlatFilePermissionsResolver.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -159,8 +160,8 @@ public class FlatFilePermissionsResolver implements PermissionsResolver {
                         }
                     }
 
-                    userPermissionsCache.put(key.toLowerCase(), permsCache);
-                    userGroups.put(key.toLowerCase(), new HashSet<>(Arrays.asList(groups)));
+                    userPermissionsCache.put(key.toLowerCase(Locale.ROOT), permsCache);
+                    userGroups.put(key.toLowerCase(Locale.ROOT), new HashSet<>(Arrays.asList(groups)));
                 }
             }
         } catch (IOException e) {
@@ -184,7 +185,7 @@ public class FlatFilePermissionsResolver implements PermissionsResolver {
             }
         }
 
-        Set<String> perms = userPermissionsCache.get(player.toLowerCase());
+        Set<String> perms = userPermissionsCache.get(player.toLowerCase(Locale.ROOT));
         if (perms == null) {
             return defaultPermissionsCache.contains(permission)
                     || defaultPermissionsCache.contains("*");
@@ -201,13 +202,13 @@ public class FlatFilePermissionsResolver implements PermissionsResolver {
 
     @Override
     public boolean inGroup(String player, String group) {
-        Set<String> groups = userGroups.get(player.toLowerCase());
+        Set<String> groups = userGroups.get(player.toLowerCase(Locale.ROOT));
         return groups != null && groups.contains(group);
     }
 
     @Override
     public String[] getGroups(String player) {
-        Set<String> groups = userGroups.get(player.toLowerCase());
+        Set<String> groups = userGroups.get(player.toLowerCase(Locale.ROOT));
         if (groups == null) {
             return new String[0];
         }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitAdapter.java
@@ -53,6 +53,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -278,7 +279,7 @@ public class BukkitAdapter {
         if (!itemType.getId().startsWith("minecraft:")) {
             throw new IllegalArgumentException("Bukkit only supports Minecraft items");
         }
-        return Material.getMaterial(itemType.getId().substring(10).toUpperCase());
+        return Material.getMaterial(itemType.getId().substring(10).toUpperCase(Locale.ROOT));
     }
 
     /**
@@ -292,7 +293,7 @@ public class BukkitAdapter {
         if (!blockType.getId().startsWith("minecraft:")) {
             throw new IllegalArgumentException("Bukkit only supports Minecraft blocks");
         }
-        return Material.getMaterial(blockType.getId().substring(10).toUpperCase());
+        return Material.getMaterial(blockType.getId().substring(10).toUpperCase(Locale.ROOT));
     }
 
     /**
@@ -303,7 +304,7 @@ public class BukkitAdapter {
      */
     public static GameMode adapt(org.bukkit.GameMode gameMode) {
         checkNotNull(gameMode);
-        return GameModes.get(gameMode.name().toLowerCase());
+        return GameModes.get(gameMode.name().toLowerCase(Locale.ROOT));
     }
 
     /**
@@ -313,7 +314,7 @@ public class BukkitAdapter {
      * @return WorldEdit BiomeType
      */
     public static BiomeType adapt(Biome biome) {
-        return BiomeTypes.get(biome.name().toLowerCase());
+        return BiomeTypes.get(biome.name().toLowerCase(Locale.ROOT));
     }
 
     public static Biome adapt(BiomeType biomeType) {
@@ -321,7 +322,7 @@ public class BukkitAdapter {
             throw new IllegalArgumentException("Bukkit only supports vanilla biomes");
         }
         try {
-            return Biome.valueOf(biomeType.getId().substring(10).toUpperCase());
+            return Biome.valueOf(biomeType.getId().substring(10).toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
             return null;
         }
@@ -334,7 +335,7 @@ public class BukkitAdapter {
      * @return WorldEdit EntityType
      */
     public static EntityType adapt(org.bukkit.entity.EntityType entityType) {
-        return EntityTypes.get(entityType.getName().toLowerCase());
+        return EntityTypes.get(entityType.getName().toLowerCase(Locale.ROOT));
     }
 
     public static org.bukkit.entity.EntityType adapt(EntityType entityType) {

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
@@ -44,6 +44,7 @@ import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.Locale;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -149,12 +150,12 @@ public class BukkitPlayer extends AbstractPlayerActor {
 
     @Override
     public GameMode getGameMode() {
-        return GameModes.get(player.getGameMode().name().toLowerCase());
+        return GameModes.get(player.getGameMode().name().toLowerCase(Locale.ROOT));
     }
 
     @Override
     public void setGameMode(GameMode gameMode) {
-        player.setGameMode(org.bukkit.GameMode.valueOf(gameMode.getId().toUpperCase()));
+        player.setGameMode(org.bukkit.GameMode.valueOf(gameMode.getId().toUpperCase(Locale.ROOT)));
     }
 
     @Override

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -66,6 +66,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.jar.JarFile;
 import java.util.logging.Level;
@@ -133,7 +134,8 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
     public void setupRegistries() {
         // Biome
         for (Biome biome : Biome.values()) {
-            BiomeType.REGISTRY.register("minecraft:" + biome.name().toLowerCase(), new BiomeType("minecraft:" + biome.name().toLowerCase()));
+            String lowerCaseBiomeName = biome.name().toLowerCase(Locale.ROOT);
+            BiomeType.REGISTRY.register("minecraft:" + lowerCaseBiomeName, new BiomeType("minecraft:" + lowerCaseBiomeName));
         }
         // Block & Item
         for (Material material : Material.values()) {
@@ -167,7 +169,8 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
         for (org.bukkit.entity.EntityType entityType : org.bukkit.entity.EntityType.values()) {
             String mcid = entityType.getName();
             if (mcid != null) {
-                EntityType.REGISTRY.register("minecraft:" + mcid.toLowerCase(), new EntityType("minecraft:" + mcid.toLowerCase()));
+                String lowerCaseMcId = mcid.toLowerCase(Locale.ROOT);
+                EntityType.REGISTRY.register("minecraft:" + lowerCaseMcId, new EntityType("minecraft:" + lowerCaseMcId));
             }
         }
     }

--- a/worldedit-bukkit/src/test/java/com/sk89q/wepif/TestOfflinePermissible.java
+++ b/worldedit-bukkit/src/test/java/com/sk89q/wepif/TestOfflinePermissible.java
@@ -30,6 +30,7 @@ import org.bukkit.plugin.Plugin;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -37,7 +38,7 @@ import java.util.UUID;
 public class TestOfflinePermissible implements OfflinePlayer, Permissible {
     private boolean op;
     private UUID randomUuid = UUID.randomUUID();
-    
+
     private final Map<String, Boolean> assignedPermissions = new HashMap<>();
 
     @Override
@@ -52,7 +53,7 @@ public class TestOfflinePermissible implements OfflinePlayer, Permissible {
 
     @Override
     public boolean isPermissionSet(String s) {
-        return assignedPermissions.containsKey(s.toLowerCase());
+        return assignedPermissions.containsKey(s.toLowerCase(Locale.ROOT));
     }
 
     @Override
@@ -63,7 +64,7 @@ public class TestOfflinePermissible implements OfflinePlayer, Permissible {
     @Override
     public boolean hasPermission(String s) {
         if (isPermissionSet(s)) {
-            return assignedPermissions.get(s.toLowerCase());
+            return assignedPermissions.get(s.toLowerCase(Locale.ROOT));
         }
         return false;
     }
@@ -111,19 +112,19 @@ public class TestOfflinePermissible implements OfflinePlayer, Permissible {
         }
         return ret;
     }
-    
+
     public void setPermission(String permission, boolean value) {
-        assignedPermissions.put(permission.toLowerCase(), value);
+        assignedPermissions.put(permission.toLowerCase(Locale.ROOT), value);
     }
-    
+
     public void unsetPermission(String permission) {
-        assignedPermissions.remove(permission.toLowerCase());
+        assignedPermissions.remove(permission.toLowerCase(Locale.ROOT));
     }
 
     public void clearPermissions() {
         assignedPermissions.clear();
     }
-    
+
     // -- Unneeded OfflinePlayer methods
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/jnbt/ByteArrayTag.java
+++ b/worldedit-core/src/main/java/com/sk89q/jnbt/ByteArrayTag.java
@@ -19,6 +19,8 @@
 
 package com.sk89q.jnbt;
 
+import java.util.Locale;
+
 /**
  * The {@code TAG_Byte_Array} tag.
  */
@@ -45,7 +47,7 @@ public final class ByteArrayTag extends Tag {
     public String toString() {
         StringBuilder hex = new StringBuilder();
         for (byte b : value) {
-            String hexDigits = Integer.toHexString(b).toUpperCase();
+            String hexDigits = Integer.toHexString(b).toUpperCase(Locale.ROOT);
             if (hexDigits.length() == 1) {
                 hex.append("0");
             }

--- a/worldedit-core/src/main/java/com/sk89q/jnbt/IntArrayTag.java
+++ b/worldedit-core/src/main/java/com/sk89q/jnbt/IntArrayTag.java
@@ -19,6 +19,8 @@
 
 package com.sk89q.jnbt;
 
+import java.util.Locale;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -48,7 +50,7 @@ public final class IntArrayTag extends Tag {
     public String toString() {
         StringBuilder hex = new StringBuilder();
         for (int b : value) {
-            String hexDigits = Integer.toHexString(b).toUpperCase();
+            String hexDigits = Integer.toHexString(b).toUpperCase(Locale.ROOT);
             if (hexDigits.length() == 1) {
                 hex.append("0");
             }

--- a/worldedit-core/src/main/java/com/sk89q/jnbt/LongArrayTag.java
+++ b/worldedit-core/src/main/java/com/sk89q/jnbt/LongArrayTag.java
@@ -19,6 +19,8 @@
 
 package com.sk89q.jnbt;
 
+import java.util.Locale;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -48,7 +50,7 @@ public class LongArrayTag extends Tag {
     public String toString() {
         StringBuilder hex = new StringBuilder();
         for (long b : value) {
-            String hexDigits = Long.toHexString(b).toUpperCase();
+            String hexDigits = Long.toHexString(b).toUpperCase(Locale.ROOT);
             if (hexDigits.length() == 1) {
                 hex.append("0");
             }

--- a/worldedit-core/src/main/java/com/sk89q/minecraft/util/commands/CommandsManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/minecraft/util/commands/CommandsManager.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -254,7 +255,7 @@ public abstract class CommandsManager<T> {
      * @return true if the command exists
      */
     public boolean hasCommand(String command) {
-        return commands.get(null).containsKey(command.toLowerCase());
+        return commands.get(null).containsKey(command.toLowerCase(Locale.ROOT));
     }
 
     /**
@@ -434,7 +435,7 @@ public abstract class CommandsManager<T> {
         String cmdName = args[level];
 
         Map<String, Method> map = commands.get(parent);
-        Method method = map.get(cmdName.toLowerCase());
+        Method method = map.get(cmdName.toLowerCase(Locale.ROOT));
 
         if (method == null) {
             if (parent == null) { // Root

--- a/worldedit-core/src/main/java/com/sk89q/util/StringUtil.java
+++ b/worldedit-core/src/main/java/com/sk89q/util/StringUtil.java
@@ -22,6 +22,7 @@ package com.sk89q.util;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -34,7 +35,7 @@ public final class StringUtil {
 
     /**
      * Trim a string if it is longer than a certain length.
-     *  
+     *
      * @param str the stirng
      * @param len the length to trim to
      * @return a new string
@@ -49,7 +50,7 @@ public final class StringUtil {
 
     /**
      * Join an array of strings into a string.
-     * 
+     *
      * @param str the string array
      * @param delimiter the delimiter
      * @param initialIndex the initial index to start form
@@ -68,7 +69,7 @@ public final class StringUtil {
 
     /**
      * Join an array of strings into a string.
-     * 
+     *
      * @param str the string array
      * @param delimiter the delimiter
      * @param initialIndex the initial index to start form
@@ -92,7 +93,7 @@ public final class StringUtil {
 
     /**
      * Join an array of strings into a string.
-     * 
+     *
      * @param str the string array
      * @param delimiter the delimiter
      * @return a new string
@@ -103,7 +104,7 @@ public final class StringUtil {
 
     /**
      * Join an array of strings into a string.
-     * 
+     *
      * @param str an array of objects
      * @param delimiter the delimiter
      * @param initialIndex the initial index to start form
@@ -122,7 +123,7 @@ public final class StringUtil {
 
     /**
      * Join an array of strings into a string.
-     * 
+     *
      * @param str a list of integers
      * @param delimiter the delimiter
      * @param initialIndex the initial index to start form
@@ -219,7 +220,7 @@ public final class StringUtil {
          * calculated). (Note that the arrays aren't really copied anymore, just
          * switched...this is clearly much better than cloning an array or doing
          * a System.arraycopy() each time through the outer loop.)
-         * 
+         *
          * Effectively, the difference between the two implementations is this
          * one does not cause an out of memory condition when calculating the LD
          * over two very large strings.
@@ -274,7 +275,7 @@ public final class StringUtil {
     }
 
     public static <T extends Enum<?>> T lookup(Map<String, T> lookup, String name, boolean fuzzy) {
-        String testName = name.replaceAll("[ _]", "").toLowerCase();
+        String testName = name.replaceAll("[ _]", "").toLowerCase(Locale.ROOT);
 
         T type = lookup.get(testName);
         if (type != null) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -72,6 +72,7 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static com.sk89q.worldedit.event.platform.Interaction.HIT;
@@ -403,7 +404,7 @@ public final class WorldEdit {
      * @throws UnknownDirectionException thrown if the direction is not known
      */
     public BlockVector3 getDirection(Player player, String dirStr) throws UnknownDirectionException {
-        dirStr = dirStr.toLowerCase();
+        dirStr = dirStr.toLowerCase(Locale.ROOT);
 
         final Direction dir = getPlayerDirection(player, dirStr);
 
@@ -424,7 +425,7 @@ public final class WorldEdit {
      * @throws UnknownDirectionException thrown if the direction is not known
      */
     public BlockVector3 getDiagonalDirection(Player player, String dirStr) throws UnknownDirectionException {
-        dirStr = dirStr.toLowerCase();
+        dirStr = dirStr.toLowerCase(Locale.ROOT);
 
         final Direction dir = getPlayerDirection(player, dirStr);
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/blocks/ClothColor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/blocks/ClothColor.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.blocks;
 
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import javax.annotation.Nullable;
@@ -84,7 +85,7 @@ public enum ClothColor {
      */
     @Nullable
     public static ClothColor lookup(String name) {
-        return lookup.get(name.toLowerCase());
+        return lookup.get(name.toLowerCase(Locale.ROOT));
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultBlockParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultBlockParser.java
@@ -49,6 +49,7 @@ import com.sk89q.worldedit.world.block.FuzzyBlockState;
 import com.sk89q.worldedit.world.registry.LegacyMapper;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -107,7 +108,7 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
      * @return Mapped string
      */
     private String woolMapper(String string) {
-        switch (string.toLowerCase()) {
+        switch (string.toLowerCase(Locale.ROOT)) {
             case "white":
                 return BlockTypes.WHITE_WOOL.getId();
             case "black":
@@ -272,7 +273,7 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
                 blockStates.putAll(blockInHand.getStates());
             } else {
                 // Attempt to lookup a block from ID or name.
-                blockType = BlockTypes.get(typeString.toLowerCase());
+                blockType = BlockTypes.get(typeString.toLowerCase(Locale.ROOT));
 
                 if (blockType == null) {
                     throw new NoMatchException("Does not match a valid block type: '" + input + "'");
@@ -323,7 +324,7 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
             if (blockAndExtraData.length > 1) {
                 String mobName = blockAndExtraData[1];
                 for (MobType mobType : MobType.values()) {
-                    if (mobType.getName().toLowerCase().equals(mobName.toLowerCase())) {
+                    if (mobType.getName().toLowerCase(Locale.ROOT).equals(mobName.toLowerCase(Locale.ROOT))) {
                         mobName = mobType.getName();
                         break;
                     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultItemParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultItemParser.java
@@ -28,6 +28,8 @@ import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.item.ItemTypes;
 import com.sk89q.worldedit.world.registry.LegacyMapper;
 
+import java.util.Locale;
+
 public class DefaultItemParser extends InputParser<BaseItem> {
 
     public DefaultItemParser(WorldEdit worldEdit) {
@@ -53,7 +55,7 @@ public class DefaultItemParser extends InputParser<BaseItem> {
         }
 
         if (item == null) {
-            ItemType type = ItemTypes.get(input.toLowerCase());
+            ItemType type = ItemTypes.get(input.toLowerCase(Locale.ROOT));
             if (type != null) {
                 item = new BaseItem(type);
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlockCategoryMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlockCategoryMaskParser.java
@@ -28,6 +28,8 @@ import com.sk89q.worldedit.internal.registry.InputParser;
 import com.sk89q.worldedit.session.request.RequestExtent;
 import com.sk89q.worldedit.world.block.BlockCategory;
 
+import java.util.Locale;
+
 public class BlockCategoryMaskParser extends InputParser<Mask> {
 
     public BlockCategoryMaskParser(WorldEdit worldEdit) {
@@ -41,7 +43,7 @@ public class BlockCategoryMaskParser extends InputParser<Mask> {
         }
 
         // This means it's a tag mask.
-        BlockCategory category = BlockCategory.REGISTRY.get(input.substring(2).toLowerCase());
+        BlockCategory category = BlockCategory.REGISTRY.get(input.substring(2).toLowerCase(Locale.ROOT));
         if (category == null) {
             throw new InputParseException("Unrecognised tag '" + input.substring(2) + '\'');
         } else {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/BlockCategoryPatternParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/BlockCategoryPatternParser.java
@@ -30,6 +30,7 @@ import com.sk89q.worldedit.world.block.BlockCategory;
 import com.sk89q.worldedit.world.block.BlockType;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -49,7 +50,7 @@ public class BlockCategoryPatternParser extends InputParser<Pattern> {
         if (!input.startsWith("##")) {
             return null;
         }
-        String tag = input.substring(2).toLowerCase();
+        String tag = input.substring(2).toLowerCase(Locale.ROOT);
         boolean anyState = false;
         if (tag.startsWith("*")) {
             tag = tag.substring(1);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
@@ -123,6 +123,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.logging.FileHandler;
@@ -425,7 +426,7 @@ public final class PlatformCommandManager {
             split = newSplit;
         }
 
-        String searchCmd = split[0].toLowerCase();
+        String searchCmd = split[0].toLowerCase(Locale.ROOT);
 
         // Try to detect the command
         if (!commandManager.containsCommand(searchCmd)) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/MCEditSchematicReader.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/MCEditSchematicReader.java
@@ -56,6 +56,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -261,7 +262,7 @@ public class MCEditSchematicReader extends NBTSchematicReader {
                     Location location = NBTConversions.toLocation(clipboard, compound.getListTag("Pos"), compound.getListTag("Rotation"));
 
                     if (!id.isEmpty()) {
-                        EntityType entityType = EntityTypes.get(id.toLowerCase());
+                        EntityType entityType = EntityTypes.get(id.toLowerCase(Locale.ROOT));
                         if (entityType != null) {
                             for (EntityNBTCompatibilityHandler compatibilityHandler : ENTITY_COMPATIBILITY_HANDLERS) {
                                 if (compatibilityHandler.isAffectedEntity(entityType, compound)) {
@@ -271,7 +272,7 @@ public class MCEditSchematicReader extends NBTSchematicReader {
                             BaseEntity state = new BaseEntity(entityType, compound);
                             clipboard.createEntity(location, state);
                         } else {
-                            log.warn("Unknown entity when pasting schematic: " + id.toLowerCase());
+                            log.warn("Unknown entity when pasting schematic: " + id.toLowerCase(Locale.ROOT));
                         }
                     }
                 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/registry/Registry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/registry/Registry.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -44,14 +45,14 @@ public class Registry<V> implements Iterable<V> {
     }
 
     public @Nullable V get(final String key) {
-        checkState(key.equals(key.toLowerCase()), "key must be lowercase");
+        checkState(key.equals(key.toLowerCase(Locale.ROOT)), "key must be lowercase");
         return this.map.get(key);
     }
 
     public V register(final String key, final V value) {
         requireNonNull(key, "key");
         requireNonNull(value, "value");
-        checkState(key.equals(key.toLowerCase()), "key must be lowercase");
+        checkState(key.equals(key.toLowerCase(Locale.ROOT)), "key must be lowercase");
         checkState(!this.map.containsKey(key), "key '%s' already has an associated %s", key, this.name);
         this.map.put(key, value);
         return value;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/registry/state/DirectionalProperty.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/registry/state/DirectionalProperty.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit.registry.state;
 import com.sk89q.worldedit.util.Direction;
 
 import java.util.List;
+import java.util.Locale;
 
 import javax.annotation.Nullable;
 
@@ -34,7 +35,7 @@ public class DirectionalProperty extends AbstractProperty<Direction> {
     @Nullable
     @Override
     public Direction getValueFor(final String string) {
-        Direction direction = Direction.valueOf(string.toUpperCase());
+        Direction direction = Direction.valueOf(string.toUpperCase(Locale.ROOT));
         if (!getValues().contains(direction)) {
             throw new IllegalArgumentException("Invalid direction value: " + string + ". Must be in " + getValues().toString());
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/TreeGenerator.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/TreeGenerator.java
@@ -31,6 +31,7 @@ import com.sk89q.worldedit.world.block.BlockTypes;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
@@ -161,7 +162,7 @@ public class TreeGenerator {
          */
         @Nullable
         public static TreeType lookup(String name) {
-            return lookup.get(name.toLowerCase());
+            return lookup.get(name.toLowerCase(Locale.ROOT));
         }
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/function/LevenshteinDistance.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/function/LevenshteinDistance.java
@@ -23,6 +23,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Function;
 
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
@@ -60,7 +61,7 @@ public class LevenshteinDistance implements Function<String, Integer> {
         checkNotNull(baseString);
         this.caseSensitive = caseSensitive;
         this.replacePattern = replacePattern;
-        baseString = caseSensitive ? baseString : baseString.toLowerCase();
+        baseString = caseSensitive ? baseString : baseString.toLowerCase(Locale.ROOT);
         baseString = replacePattern != null ? replacePattern.matcher(baseString).replaceAll("") : baseString;
         this.baseString = baseString;
     }
@@ -79,7 +80,7 @@ public class LevenshteinDistance implements Function<String, Integer> {
         if (caseSensitive) {
             return distance(baseString, input);
         } else {
-            return distance(baseString, input.toLowerCase());
+            return distance(baseString, input.toLowerCase(Locale.ROOT));
         }
     }
 
@@ -189,5 +190,5 @@ public class LevenshteinDistance implements Function<String, Integer> {
         // actually has the most recent cost counts
         return p[n];
     }
-    
+
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockStateHolder.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockStateHolder.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit.world.block;
 import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.worldedit.registry.state.Property;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -92,9 +93,11 @@ public interface BlockStateHolder<B extends BlockStateHolder<B>> {
         if (getStates().isEmpty()) {
             return this.getBlockType().getId();
         } else {
-            String properties =
-                    getStates().entrySet().stream().map(entry -> entry.getKey().getName() + "=" + entry.getValue().toString().toLowerCase()).collect(Collectors.joining(
-                    ","));
+            String properties = getStates().entrySet().stream()
+                .map(entry -> entry.getKey().getName()
+                    + "="
+                    + entry.getValue().toString().toLowerCase(Locale.ROOT))
+                .collect(Collectors.joining(","));
             return this.getBlockType().getId() + "[" + properties + "]";
         }
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/snapshot/Snapshot.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/snapshot/Snapshot.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.time.ZonedDateTime;
+import java.util.Locale;
 import java.util.zip.ZipFile;
 
 /**
@@ -83,7 +84,8 @@ public class Snapshot implements Comparable<Snapshot> {
      * @throws DataException
      */
     private ChunkStore internalGetChunkStore() throws IOException, DataException {
-        if (file.getName().toLowerCase().endsWith(".zip")) {
+        String lowerCaseFileName = file.getName().toLowerCase(Locale.ROOT);
+        if (lowerCaseFileName.endsWith(".zip")) {
             try {
                 ChunkStore chunkStore = new TrueZipMcRegionChunkStore(file);
 
@@ -101,9 +103,9 @@ public class Snapshot implements Comparable<Snapshot> {
 
                 return chunkStore;
             }
-        } else if (file.getName().toLowerCase().endsWith(".tar.bz2")
-                || file.getName().toLowerCase().endsWith(".tar.gz")
-                || file.getName().toLowerCase().endsWith(".tar")) {
+        } else if (lowerCaseFileName.endsWith(".tar.bz2")
+                || lowerCaseFileName.endsWith(".tar.gz")
+                || lowerCaseFileName.endsWith(".tar")) {
             try {
                 ChunkStore chunkStore = new TrueZipMcRegionChunkStore(file);
 
@@ -133,14 +135,15 @@ public class Snapshot implements Comparable<Snapshot> {
      */
     public boolean containsWorld(String worldname) {
         try {
-            if (file.getName().toLowerCase().endsWith(".zip")) {
+            String lowerCaseFileName = file.getName().toLowerCase(Locale.ROOT);
+            if (lowerCaseFileName.endsWith(".zip")) {
                 try (ZipFile entry = new ZipFile(file)) {
                     return (entry.getEntry(worldname) != null
                             || entry.getEntry(worldname + "/level.dat") != null);
                 }
-            } else if (file.getName().toLowerCase().endsWith(".tar.bz2")
-                    || file.getName().toLowerCase().endsWith(".tar.gz")
-                    || file.getName().toLowerCase().endsWith(".tar")) {
+            } else if (lowerCaseFileName.endsWith(".tar.bz2")
+                    || lowerCaseFileName.endsWith(".tar.gz")
+                    || lowerCaseFileName.endsWith(".tar")) {
                 try {
                     de.schlichtherle.util.zip.ZipFile entry = new de.schlichtherle.util.zip.ZipFile(file);
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/snapshot/SnapshotRepository.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/snapshot/SnapshotRepository.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * A repository contains zero or more snapshots.
@@ -208,11 +209,17 @@ public class SnapshotRepository {
             return false;
         }
 
-        return (file.isDirectory() && (new File(file, "level.dat")).exists())
-                || (file.isFile() && (file.getName().toLowerCase().endsWith(".zip")
-                || file.getName().toLowerCase().endsWith(".tar.bz2")
-                || file.getName().toLowerCase().endsWith(".tar.gz")
-                || file.getName().toLowerCase().endsWith(".tar")));
+        if (file.isDirectory() && new File(file, "level.dat").exists()) {
+            return true;
+        }
+        if (file.isFile()) {
+            String lowerCaseFileName = file.getName().toLowerCase(Locale.ROOT);
+            return lowerCaseFileName.endsWith(".zip")
+                || lowerCaseFileName.endsWith(".tar.bz2")
+                || lowerCaseFileName.endsWith(".tar.gz")
+                || lowerCaseFileName.endsWith(".tar");
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
This makes all case changes locale-insensitive. I basically did a find & replace, but it doesn't look like there's any places where we have display-facing case changes where this might matter.

I also added a checkstyle rule, to prevent this issue from popping up in the future. If for some reason, we need a locale-sensitive case change, it's easy to add it to a `checkstyle-suppressions` file to exclude that file from the check, or to explicitly pass `Locale.getDefault()` (preferred solution).