### PR TITLE
Add /tracemask.

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditListener.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditListener.java
@@ -21,7 +21,6 @@
 
 package com.sk89q.worldedit.bukkit;
 
-import com.sk89q.util.StringUtil;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.platform.Actor;
@@ -33,7 +32,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
-import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerCommandSendEvent;
 import org.bukkit.event.player.PlayerGameModeChangeEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -54,12 +52,6 @@ import java.util.Optional;
 public class WorldEditListener implements Listener {
 
     private WorldEditPlugin plugin;
-
-    /**
-     * Called when a player plays an animation, such as an arm swing
-     *
-     * @param event Relevant event details
-     */
 
     /**
      * Construct the object;
@@ -112,12 +104,8 @@ public class WorldEditListener implements Listener {
             return;
         }
 
-        try {
-            if (event.getHand() == EquipmentSlot.OFF_HAND) {
-                return; // TODO api needs to be able to get either hand depending on event
-                // for now just ignore all off hand interacts
-            }
-        } catch (NoSuchMethodError | NoSuchFieldError ignored) {
+        if (event.getHand() == EquipmentSlot.OFF_HAND) {
+            return;
         }
 
         final Player player = plugin.wrapPlayer(event.getPlayer());
@@ -142,7 +130,6 @@ public class WorldEditListener implements Listener {
             if (we.handleArmSwing(player)) {
                 event.setCancelled(true);
             }
-
 
         } else if (action == Action.RIGHT_CLICK_BLOCK) {
             final Block clickedBlock = event.getClickedBlock();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolUtilCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolUtilCommands.java
@@ -51,7 +51,7 @@ public class ToolUtilCommands {
     @CommandPermissions("worldedit.superpickaxe")
     public void togglePickaxe(Player player, LocalSession session,
                               @Arg(desc = "The new super pickaxe state", def = "")
-                                  Boolean superPickaxe) throws WorldEditException {
+                                  Boolean superPickaxe) {
         boolean hasSuperPickAxe = session.hasSuperPickAxe();
         if (superPickaxe != null && superPickaxe == hasSuperPickAxe) {
             player.printError("Super pickaxe already " + (superPickaxe ? "enabled" : "disabled") + ".");

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolUtilCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolUtilCommands.java
@@ -133,7 +133,7 @@ public class ToolUtilCommands {
     )
     @CommandPermissions("worldedit.brush.options.tracemask")
     public void traceMask(Player player, LocalSession session,
-                     @Arg(desc = "The mask to set", def = "")
+                          @Arg(desc = "The mask to set", def = "")
                              Mask mask) throws WorldEditException {
         if (mask == null) {
             session.getBrushTool(player.getItemInHand(HandSide.MAIN_HAND).getType()).setTraceMask(null);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolUtilCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolUtilCommands.java
@@ -22,15 +22,19 @@ package com.sk89q.worldedit.command;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.WorldEditException;
+import com.sk89q.worldedit.command.tool.Tool;
+import com.sk89q.worldedit.command.tool.TraceTool;
 import com.sk89q.worldedit.command.util.CommandPermissions;
 import com.sk89q.worldedit.command.util.CommandPermissionsConditionGenerator;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.util.HandSide;
+import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import org.enginehub.piston.annotation.Command;
 import org.enginehub.piston.annotation.CommandContainer;
 import org.enginehub.piston.annotation.param.Arg;
+import org.enginehub.piston.exception.StopExecutionException;
 
 /**
  * Tool commands.
@@ -121,5 +125,22 @@ public class ToolUtilCommands {
 
         session.getBrushTool(player.getItemInHand(HandSide.MAIN_HAND).getType()).setSize(size);
         player.print("Brush size set.");
+    }
+
+    @Command(
+            name = "tracemask",
+            desc = "Set the mask used to stop tool traces"
+    )
+    @CommandPermissions("worldedit.brush.options.tracemask")
+    public void traceMask(Player player, LocalSession session,
+                     @Arg(desc = "The mask to set", def = "")
+                             Mask mask) throws WorldEditException {
+        if (mask == null) {
+            session.getBrushTool(player.getItemInHand(HandSide.MAIN_HAND).getType()).setTraceMask(null);
+            player.print("Trace mask disabled.");
+        } else {
+            session.getBrushTool(player.getItemInHand(HandSide.MAIN_HAND).getType()).setTraceMask(mask);
+            player.print("Trace mask set.");
+        }
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolUtilCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolUtilCommands.java
@@ -22,19 +22,15 @@ package com.sk89q.worldedit.command;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.WorldEditException;
-import com.sk89q.worldedit.command.tool.Tool;
-import com.sk89q.worldedit.command.tool.TraceTool;
 import com.sk89q.worldedit.command.util.CommandPermissions;
 import com.sk89q.worldedit.command.util.CommandPermissionsConditionGenerator;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.util.HandSide;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import org.enginehub.piston.annotation.Command;
 import org.enginehub.piston.annotation.CommandContainer;
 import org.enginehub.piston.annotation.param.Arg;
-import org.enginehub.piston.exception.StopExecutionException;
 
 /**
  * Tool commands.
@@ -79,11 +75,10 @@ public class ToolUtilCommands {
     public void mask(Player player, LocalSession session,
                      @Arg(desc = "The mask to set", def = "")
                          Mask mask) throws WorldEditException {
+        session.getBrushTool(player.getItemInHand(HandSide.MAIN_HAND).getType()).setMask(mask);
         if (mask == null) {
-            session.getBrushTool(player.getItemInHand(HandSide.MAIN_HAND).getType()).setMask(null);
             player.print("Brush mask disabled.");
         } else {
-            session.getBrushTool(player.getItemInHand(HandSide.MAIN_HAND).getType()).setMask(mask);
             player.print("Brush mask set.");
         }
     }
@@ -128,18 +123,17 @@ public class ToolUtilCommands {
     }
 
     @Command(
-            name = "tracemask",
-            desc = "Set the mask used to stop tool traces"
+        name = "tracemask",
+        desc = "Set the mask used to stop tool traces"
     )
     @CommandPermissions("worldedit.brush.options.tracemask")
     public void traceMask(Player player, LocalSession session,
-                          @Arg(desc = "The mask to set", def = "")
+                          @Arg(desc = "The trace mask to set", def = "")
                              Mask mask) throws WorldEditException {
+        session.getBrushTool(player.getItemInHand(HandSide.MAIN_HAND).getType()).setTraceMask(mask);
         if (mask == null) {
-            session.getBrushTool(player.getItemInHand(HandSide.MAIN_HAND).getType()).setTraceMask(null);
             player.print("Trace mask disabled.");
         } else {
-            session.getBrushTool(player.getItemInHand(HandSide.MAIN_HAND).getType()).setTraceMask(mask);
             player.print("Trace mask set.");
         }
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BrushTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BrushTool.java
@@ -34,7 +34,6 @@ import com.sk89q.worldedit.extent.inventory.BlockBag;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.mask.MaskIntersection;
 import com.sk89q.worldedit.function.pattern.Pattern;
-import com.sk89q.worldedit.session.request.Request;
 import com.sk89q.worldedit.util.Location;
 
 import javax.annotation.Nullable;
@@ -47,6 +46,7 @@ public class BrushTool implements TraceTool {
     protected static int MAX_RANGE = 500;
     protected int range = -1;
     private Mask mask = null;
+    private Mask traceMask = null;
     private Brush brush = new SphereBrush();
     @Nullable
     private Pattern material;
@@ -84,6 +84,24 @@ public class BrushTool implements TraceTool {
      */
     public void setMask(Mask filter) {
         this.mask = filter;
+    }
+
+    /**
+     * Get the mask used for identifying where to stop traces
+     *
+     * @return the mask used to stop block traces
+     */
+    public @Nullable Mask getTraceMask() {
+        return mask;
+    }
+
+    /**
+     * Set the block mask used for identifying where to stop traces.
+     *
+     * @param traceMask the mask used to stop block traces
+     */
+    public void setTraceMask(@Nullable Mask traceMask) {
+        this.traceMask = traceMask;
     }
 
     /**
@@ -162,8 +180,12 @@ public class BrushTool implements TraceTool {
 
     @Override
     public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session) {
-        Location target = null;
-        target = player.getBlockTrace(getRange(), true);
+        Location target;
+        if (traceMask == null) {
+            target = player.getBlockTrace(getRange(), true);
+        } else {
+            target = player.getBlockTrace(getRange(), true, traceMask);
+        }
 
         if (target == null) {
             player.printError("No block in sight!");

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BrushTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BrushTool.java
@@ -87,7 +87,7 @@ public class BrushTool implements TraceTool {
     }
 
     /**
-     * Get the mask used for identifying where to stop traces
+     * Get the mask used for identifying where to stop traces.
      *
      * @return the mask used to stop block traces
      */
@@ -180,12 +180,7 @@ public class BrushTool implements TraceTool {
 
     @Override
     public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session) {
-        Location target;
-        if (traceMask == null) {
-            target = player.getBlockTrace(getRange(), true);
-        } else {
-            target = player.getBlockTrace(getRange(), true, traceMask);
-        }
+        Location target = player.getBlockTrace(getRange(), true, traceMask);
 
         if (target == null) {
             player.printError("No block in sight!");

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/DistanceWand.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/DistanceWand.java
@@ -25,6 +25,7 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.extension.platform.permission.ActorSelectorLimits;
+import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.RegionSelector;
 import com.sk89q.worldedit.util.Location;
@@ -58,7 +59,6 @@ public class DistanceWand extends BrushTool implements DoubleActionTraceTool {
 
         }
         return false;
-
     }
 
     @Override
@@ -78,12 +78,21 @@ public class DistanceWand extends BrushTool implements DoubleActionTraceTool {
         return false;
     }
 
-    public Location getTarget(Player player) {
+    private Location getTarget(Player player) {
         Location target;
+        Mask mask = getTraceMask();
         if (this.range > -1) {
-            target = player.getBlockTrace(getRange(), true);
+            if (mask != null) {
+                target = player.getBlockTrace(getRange(), true, mask);
+            } else {
+                target = player.getBlockTrace(getRange(), true);
+            }
         } else {
-            target = player.getBlockTrace(MAX_RANGE);
+            if (mask != null) {
+                target = player.getBlockTrace(MAX_RANGE, false, mask);
+            } else {
+                target = player.getBlockTrace(MAX_RANGE);
+            }
         }
 
         if (target == null) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/DistanceWand.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/DistanceWand.java
@@ -82,17 +82,9 @@ public class DistanceWand extends BrushTool implements DoubleActionTraceTool {
         Location target;
         Mask mask = getTraceMask();
         if (this.range > -1) {
-            if (mask != null) {
-                target = player.getBlockTrace(getRange(), true, mask);
-            } else {
-                target = player.getBlockTrace(getRange(), true);
-            }
+            target = player.getBlockTrace(getRange(), true, mask);
         } else {
-            if (mask != null) {
-                target = player.getBlockTrace(MAX_RANGE, false, mask);
-            } else {
-                target = player.getBlockTrace(MAX_RANGE);
-            }
+            target = player.getBlockTrace(MAX_RANGE, false, mask);
         }
 
         if (target == null) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/LongRangeBuildTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/LongRangeBuildTool.java
@@ -26,6 +26,7 @@ import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extension.platform.Platform;
+import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Location;
@@ -91,8 +92,14 @@ public class LongRangeBuildTool extends BrushTool implements DoubleActionTraceTo
         return false;
     }
 
-    public Location getTargetFace(Player player) {
-        Location target = player.getBlockTraceFace(getRange(), true);
+    private Location getTargetFace(Player player) {
+        Location target;
+        Mask mask = getTraceMask();
+        if (mask != null) {
+            target = player.getBlockTraceFace(getRange(), true, mask);
+        } else {
+            target = player.getBlockTraceFace(getRange(), true);
+        }
 
         if (target == null) {
             player.printError("No block in sight!");

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/LongRangeBuildTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/LongRangeBuildTool.java
@@ -95,10 +95,10 @@ public class LongRangeBuildTool extends BrushTool implements DoubleActionTraceTo
     private Location getTargetFace(Player player) {
         Location target;
         Mask mask = getTraceMask();
-        if (mask != null) {
-            target = player.getBlockTraceFace(getRange(), true, mask);
+        if (this.range > -1) {
+            target = player.getBlockTrace(getRange(), true, mask);
         } else {
-            target = player.getBlockTraceFace(getRange(), true);
+            target = player.getBlockTrace(MAX_RANGE, false, mask);
         }
 
         if (target == null) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/entity/Player.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/entity/Player.java
@@ -23,6 +23,7 @@ import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extent.inventory.BlockBag;
+import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.util.Direction;
@@ -211,6 +212,17 @@ public interface Player extends Entity, Actor {
     Location getBlockTrace(int range, boolean useLastBlock);
 
     /**
+     * Get the point of the block being looked at. May return null.
+     * Will return the farthest away block before matching the stop mask if useLastBlock is true and no other block is found.
+     *
+     * @param range how far to checks for blocks
+     * @param useLastBlock try to return the last valid block not matching the stop mask found
+     * @param stopMask the mask used to determine when to stop tracing
+     * @return point
+     */
+    Location getBlockTrace(int range, boolean useLastBlock, Mask stopMask);
+
+    /**
      * Get the face that the player is looking at.
      *
      * @param range the range
@@ -218,6 +230,16 @@ public interface Player extends Entity, Actor {
      * @return a face
      */
     Location getBlockTraceFace(int range, boolean useLastBlock);
+
+    /**
+     * Get the face that the player is looking at.
+     *
+     * @param range the range
+     * @param useLastBlock try to return the last valid block not matching the stop mask found
+     * @param stopMask the mask used to determine when to stop tracing
+     * @return a face
+     */
+    Location getBlockTraceFace(int range, boolean useLastBlock, Mask stopMask);
 
     /**
      * Get the point of the block being looked at. May return null.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/entity/Player.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/entity/Player.java
@@ -220,7 +220,7 @@ public interface Player extends Entity, Actor {
      * @param stopMask the mask used to determine when to stop tracing
      * @return point
      */
-    Location getBlockTrace(int range, boolean useLastBlock, Mask stopMask);
+    Location getBlockTrace(int range, boolean useLastBlock, @Nullable Mask stopMask);
 
     /**
      * Get the face that the player is looking at.
@@ -239,7 +239,7 @@ public interface Player extends Entity, Actor {
      * @param stopMask the mask used to determine when to stop tracing
      * @return a face
      */
-    Location getBlockTraceFace(int range, boolean useLastBlock, Mask stopMask);
+    Location getBlockTraceFace(int range, boolean useLastBlock, @Nullable Mask stopMask);
 
     /**
      * Get the point of the block being looked at. May return null.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
@@ -23,6 +23,7 @@ import com.sk89q.worldedit.NotABlockException;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extent.Extent;
+import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.internal.cui.CUIEvent;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
@@ -330,6 +331,20 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
     @Override
     public Location getBlockTraceFace(int range, boolean useLastBlock) {
         TargetBlock tb = new TargetBlock(this, range, 0.2);
+        return (useLastBlock ? tb.getAnyTargetBlockFace() : tb.getTargetBlockFace());
+    }
+
+    @Override
+    public Location getBlockTrace(int range, boolean useLastBlock, Mask stopMask) {
+        TargetBlock tb = new TargetBlock(this, range, 0.2);
+        tb.setStopMask(stopMask);
+        return (useLastBlock ? tb.getAnyTargetBlock() : tb.getTargetBlock());
+    }
+
+    @Override
+    public Location getBlockTraceFace(int range, boolean useLastBlock, Mask stopMask) {
+        TargetBlock tb = new TargetBlock(this, range, 0.2);
+        tb.setStopMask(stopMask);
         return (useLastBlock ? tb.getAnyTargetBlockFace() : tb.getTargetBlockFace());
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
@@ -336,14 +336,18 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
     @Override
     public Location getBlockTrace(int range, boolean useLastBlock, @Nullable Mask stopMask) {
         TargetBlock tb = new TargetBlock(this, range, 0.2);
-        tb.setStopMask(stopMask);
+        if (stopMask != null) {
+            tb.setStopMask(stopMask);
+        }
         return (useLastBlock ? tb.getAnyTargetBlock() : tb.getTargetBlock());
     }
 
     @Override
     public Location getBlockTraceFace(int range, boolean useLastBlock, @Nullable Mask stopMask) {
         TargetBlock tb = new TargetBlock(this, range, 0.2);
-        tb.setStopMask(stopMask);
+        if (stopMask != null) {
+            tb.setStopMask(stopMask);
+        }
         return (useLastBlock ? tb.getAnyTargetBlockFace() : tb.getTargetBlockFace());
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
@@ -42,6 +42,7 @@ import com.sk89q.worldedit.world.gamemode.GameModes;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.item.ItemTypes;
 
+import javax.annotation.Nullable;
 import java.io.File;
 
 /**
@@ -324,25 +325,23 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
 
     @Override
     public Location getBlockTrace(int range, boolean useLastBlock) {
-        TargetBlock tb = new TargetBlock(this, range, 0.2);
-        return (useLastBlock ? tb.getAnyTargetBlock() : tb.getTargetBlock());
+        return getBlockTrace(range, useLastBlock, null);
     }
 
     @Override
     public Location getBlockTraceFace(int range, boolean useLastBlock) {
-        TargetBlock tb = new TargetBlock(this, range, 0.2);
-        return (useLastBlock ? tb.getAnyTargetBlockFace() : tb.getTargetBlockFace());
+        return getBlockTraceFace(range, useLastBlock, null);
     }
 
     @Override
-    public Location getBlockTrace(int range, boolean useLastBlock, Mask stopMask) {
+    public Location getBlockTrace(int range, boolean useLastBlock, @Nullable Mask stopMask) {
         TargetBlock tb = new TargetBlock(this, range, 0.2);
         tb.setStopMask(stopMask);
         return (useLastBlock ? tb.getAnyTargetBlock() : tb.getTargetBlock());
     }
 
     @Override
-    public Location getBlockTraceFace(int range, boolean useLastBlock, Mask stopMask) {
+    public Location getBlockTraceFace(int range, boolean useLastBlock, @Nullable Mask stopMask) {
         TargetBlock tb = new TargetBlock(this, range, 0.2);
         tb.setStopMask(stopMask);
         return (useLastBlock ? tb.getAnyTargetBlockFace() : tb.getTargetBlockFace());

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/request/RequestExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/request/RequestExtent.java
@@ -45,7 +45,8 @@ public class RequestExtent implements Extent {
         if (request == null || !request.isValid()) {
             request = Request.request();
         }
-        return request.getEditSession();
+        final EditSession editSession = request.getEditSession();
+        return editSession == null ? request.getWorld() : editSession;
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/TargetBlock.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/TargetBlock.java
@@ -100,7 +100,7 @@ public class TargetBlock {
      * @param solidMask the mask used to stop solid block traces
      */
     public void setSolidMask(@Nullable Mask solidMask) {
-        if (solidMask == null ) {
+        if (solidMask == null) {
             this.solidMask = new SolidBlockMask(world);
         } else {
             this.solidMask = solidMask;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/TargetBlock.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/TargetBlock.java
@@ -27,7 +27,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.world.World;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import javax.annotation.Nullable;
 
 /**
  * This class uses an inefficient method to figure out what block a player
@@ -39,6 +39,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class TargetBlock {
 
     private final World world;
+
     private int maxDistance;
     private double checkDistance, curDistance;
     private BlockVector3 targetPos = BlockVector3.ZERO;
@@ -80,22 +81,30 @@ public class TargetBlock {
 
     /**
      * Set the mask used for determine where to stop traces.
+     * Setting to null will restore the default.
      *
      * @param stopMask the mask used to stop traces
      */
-    public void setStopMask(Mask stopMask) {
-        checkNotNull(stopMask);
-        this.stopMask = stopMask;
+    public void setStopMask(@Nullable Mask stopMask) {
+        if (stopMask == null) {
+            this.stopMask = new ExistingBlockMask(world);
+        } else {
+            this.stopMask = stopMask;
+        }
     }
 
     /**
      * Set the mask used for determine where to stop solid block traces.
+     * Setting to null will restore the default.
      *
      * @param solidMask the mask used to stop solid block traces
      */
-    public void setSolidMask(Mask solidMask) {
-        checkNotNull(solidMask);
-        this.solidMask = solidMask;
+    public void setSolidMask(@Nullable Mask solidMask) {
+        if (solidMask == null ) {
+            this.solidMask = new SolidBlockMask(world);
+        } else {
+            this.solidMask = solidMask;
+        }
     }
 
     /**


### PR DESCRIPTION
Allows setting a mask used for block traces. This allows brush tools to
pass through various materials, such as water (e.g. `/tracemask #solid`
or `/tracemask !air,water`) before starting to build.
By default, a null mask is equivalent to #existing (original behavior).


---

https://gfycat.com/ImmaculateFrayedCockatiel