### PR TITLE
Make the selection wand and navigation wand normal tools.

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SelectionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SelectionCommands.java
@@ -25,6 +25,7 @@ import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.command.argument.SelectorChoice;
+import com.sk89q.worldedit.command.tool.SelectionWand;
 import com.sk89q.worldedit.command.util.CommandPermissions;
 import com.sk89q.worldedit.command.util.CommandPermissionsConditionGenerator;
 import com.sk89q.worldedit.command.util.Logging;
@@ -56,9 +57,13 @@ import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.formatting.component.CommandListBox;
 import com.sk89q.worldedit.util.formatting.component.SubtleFormat;
 import com.sk89q.worldedit.util.formatting.component.TextComponentProducer;
+import com.sk89q.worldedit.util.formatting.text.TextComponent;
+import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
+import com.sk89q.worldedit.util.formatting.text.format.TextColor;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
+import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.item.ItemTypes;
 import com.sk89q.worldedit.world.storage.ChunkStore;
 import org.enginehub.piston.annotation.Command;
@@ -246,24 +251,36 @@ public class SelectionCommands {
         desc = "Get the wand object"
     )
     @CommandPermissions("worldedit.wand")
-    public void wand(Player player) throws WorldEditException {
-        player.giveItem(new BaseItemStack(ItemTypes.get(we.getConfiguration().wandItem), 1));
+    public void wand(Player player, LocalSession session) throws WorldEditException {
+        String wandId = session.getWandItem();
+        if (wandId == null) {
+            wandId = we.getConfiguration().wandItem;
+        }
+        ItemType itemType = ItemTypes.get(wandId);
+        if (itemType == null) {
+            player.printError("Wand item is mis-configured or disabled.");
+            return;
+        }
+        session.setTool(itemType, new SelectionWand());
+        player.giveItem(new BaseItemStack(itemType, 1));
         player.print("Left click: select pos #1; Right click: select pos #2");
     }
 
     @Command(
         name = "toggleeditwand",
-        desc = "Toggle functionality of the edit wand"
+        desc = "Remind the user that the wand is now a tool and can be unbound with /none."
     )
     @CommandPermissions("worldedit.wand.toggle")
-    public void toggleWand(Player player, LocalSession session) throws WorldEditException {
-        session.setToolControl(!session.isToolControlEnabled());
-
-        if (session.isToolControlEnabled()) {
-            player.print("Edit wand enabled.");
-        } else {
-            player.print("Edit wand disabled.");
-        }
+    public void toggleWand(Player player) {
+        player.print(TextComponent.of("The selection wand is now a normal tool. You can disable it with ")
+                .append(TextComponent.of("/none", TextColor.AQUA).clickEvent(
+                        ClickEvent.of(ClickEvent.Action.RUN_COMMAND, "/none")))
+                .append(TextComponent.of(" and rebind it to any item with "))
+                .append(TextComponent.of("//selwand", TextColor.AQUA).clickEvent(
+                        ClickEvent.of(ClickEvent.Action.RUN_COMMAND, "//selwand")))
+                .append(TextComponent.of(" or get a new wand with "))
+                .append(TextComponent.of("//wand", TextColor.AQUA).clickEvent(
+                        ClickEvent.of(ClickEvent.Action.RUN_COMMAND, "//wand"))));
     }
 
     @Command(

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SelectionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SelectionCommands.java
@@ -25,6 +25,7 @@ import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.command.argument.SelectorChoice;
+import com.sk89q.worldedit.command.tool.NavigationWand;
 import com.sk89q.worldedit.command.tool.SelectionWand;
 import com.sk89q.worldedit.command.util.CommandPermissions;
 import com.sk89q.worldedit.command.util.CommandPermissionsConditionGenerator;
@@ -251,19 +252,25 @@ public class SelectionCommands {
         desc = "Get the wand object"
     )
     @CommandPermissions("worldedit.wand")
-    public void wand(Player player, LocalSession session) throws WorldEditException {
-        String wandId = session.getWandItem();
+    public void wand(Player player, LocalSession session,
+                        @Switch(name = 'n', desc = "Get a navigation wand") boolean navWand) throws WorldEditException {
+        String wandId = navWand ? session.getNavWandItem() : session.getWandItem();
         if (wandId == null) {
-            wandId = we.getConfiguration().wandItem;
+            wandId = navWand ? we.getConfiguration().navigationWand : we.getConfiguration().wandItem;
         }
         ItemType itemType = ItemTypes.get(wandId);
         if (itemType == null) {
             player.printError("Wand item is mis-configured or disabled.");
             return;
         }
-        session.setTool(itemType, new SelectionWand());
         player.giveItem(new BaseItemStack(itemType, 1));
-        player.print("Left click: select pos #1; Right click: select pos #2");
+        if (navWand) {
+            session.setTool(itemType, new NavigationWand());
+            player.print("Left click: jump to location; Right click: pass through walls");
+        } else {
+            session.setTool(itemType, new SelectionWand());
+            player.print("Left click: select pos #1; Right click: select pos #2");
+        }
     }
 
     @Command(

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
@@ -30,7 +30,9 @@ import com.sk89q.worldedit.command.tool.DistanceWand;
 import com.sk89q.worldedit.command.tool.FloatingTreeRemover;
 import com.sk89q.worldedit.command.tool.FloodFillTool;
 import com.sk89q.worldedit.command.tool.LongRangeBuildTool;
+import com.sk89q.worldedit.command.tool.NavigationWand;
 import com.sk89q.worldedit.command.tool.QueryTool;
+import com.sk89q.worldedit.command.tool.SelectionWand;
 import com.sk89q.worldedit.command.tool.TreePlanter;
 import com.sk89q.worldedit.command.util.CommandPermissions;
 import com.sk89q.worldedit.command.util.CommandPermissionsConditionGenerator;
@@ -39,6 +41,7 @@ import com.sk89q.worldedit.function.pattern.BlockPattern;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.util.HandSide;
 import com.sk89q.worldedit.util.TreeGenerator;
+import com.sk89q.worldedit.world.item.ItemType;
 import org.enginehub.piston.annotation.Command;
 import org.enginehub.piston.annotation.CommandContainer;
 import org.enginehub.piston.annotation.param.Arg;
@@ -62,6 +65,32 @@ public class ToolCommands {
     }
 
     @Command(
+        name = "/selwand",
+        aliases = "selwand",
+        desc = "Selection wand tool"
+    )
+    @CommandPermissions("worldedit.selection.pos")
+    public void selwand(Player player, LocalSession session) throws WorldEditException {
+
+        final ItemType itemType = player.getItemInHand(HandSide.MAIN_HAND).getType();
+        session.setTool(itemType, new SelectionWand());
+        player.print("Selection wand bound to " + itemType.getName() + ".");
+    }
+
+    @Command(
+        name = "/navwand",
+        aliases = "navwand",
+        desc = "Navigation wand tool"
+    )
+    @CommandPermissions({"worldedit.command.jumpto.tool", "worldedit.command.thru.tool"})
+    public void navwand(Player player, LocalSession session) throws WorldEditException {
+
+        BaseItemStack itemStack = player.getItemInHand(HandSide.MAIN_HAND);
+        session.setTool(itemStack.getType(), new NavigationWand());
+        player.print("Navigation wand bound to " + itemStack.getType().getName() + ".");
+    }
+
+    @Command(
         name = "info",
         desc = "Block information tool"
     )
@@ -82,6 +111,7 @@ public class ToolCommands {
     public void tree(Player player, LocalSession session,
                      @Arg(desc = "Type of tree to generate", def = "tree")
                      TreeGenerator.TreeType type) throws WorldEditException {
+
         BaseItemStack itemStack = player.getItemInHand(HandSide.MAIN_HAND);
         session.setTool(itemStack.getType(), new TreePlanter(type));
         player.print("Tree tool bound to " + itemStack.getType().getName() + ".");
@@ -95,6 +125,7 @@ public class ToolCommands {
     public void repl(Player player, LocalSession session,
                      @Arg(desc = "The pattern of blocks to place")
                          Pattern pattern) throws WorldEditException {
+
         BaseItemStack itemStack = player.getItemInHand(HandSide.MAIN_HAND);
         session.setTool(itemStack.getType(), new BlockReplacer(pattern));
         player.print("Block replacer tool bound to " + itemStack.getType().getName() + ".");

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/AreaPickaxe.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/AreaPickaxe.java
@@ -27,6 +27,7 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
@@ -48,18 +49,18 @@ public class AreaPickaxe implements BlockTool {
     }
 
     @Override
-    public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, com.sk89q.worldedit.util.Location clicked) {
+    public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked) {
         int ox = clicked.getBlockX();
         int oy = clicked.getBlockY();
         int oz = clicked.getBlockZ();
         BlockType initialType = clicked.getExtent().getBlock(clicked.toVector().toBlockPoint()).getBlockType();
 
         if (initialType.getMaterial().isAir()) {
-            return true;
+            return false;
         }
 
         if (initialType == BlockTypes.BEDROCK && !player.canDestroyBedrock()) {
-            return true;
+            return false;
         }
 
         try (EditSession editSession = session.createEditSession(player)) {
@@ -74,9 +75,10 @@ public class AreaPickaxe implements BlockTool {
                                 continue;
                             }
 
-                            ((World) clicked.getExtent()).queueBlockBreakEffect(server, pos, initialType, clicked.toVector().toBlockPoint().distanceSq(pos));
-
                             editSession.setBlock(pos, BlockTypes.AIR.getDefaultState());
+
+                            ((World) clicked.getExtent()).queueBlockBreakEffect(server, pos, initialType,
+                                    clicked.toVector().toBlockPoint().distanceSq(pos));
                         }
                     }
                 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockDataCyler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockDataCyler.java
@@ -50,8 +50,8 @@ public class BlockDataCyler implements DoubleActionBlockTool {
 
     private Map<UUID, Property<?>> selectedProperties = new HashMap<>();
 
-    private boolean handleCycle(Platform server, LocalConfiguration config,
-            Player player, LocalSession session, Location clicked, boolean forward) {
+    private boolean handleCycle(LocalConfiguration config, Player player, LocalSession session,
+                                Location clicked, boolean forward) {
 
         World world = (World) clicked.getExtent();
 
@@ -88,7 +88,7 @@ public class BlockDataCyler implements DoubleActionBlockTool {
 
                     try {
                         editSession.setBlock(blockPoint, newBlock);
-                        player.print("Value of " + currentProperty.getName() + " is now " + currentProperty.getValues().get(index).toString());
+                        player.print("Value of " + currentProperty.getName() + " is now " + currentProperty.getValues().get(index));
                     } catch (MaxChangedBlocksException e) {
                         player.printError("Max blocks change limit reached.");
                     } finally {
@@ -110,12 +110,12 @@ public class BlockDataCyler implements DoubleActionBlockTool {
 
     @Override
     public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked) {
-        return handleCycle(server, config, player, session, clicked, true);
+        return handleCycle(config, player, session, clicked, true);
     }
 
     @Override
     public boolean actSecondary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked) {
-        return handleCycle(server, config, player, session, clicked, false);
+        return handleCycle(config, player, session, clicked, false);
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockReplacer.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockReplacer.java
@@ -30,6 +30,7 @@ import com.sk89q.worldedit.extent.inventory.BlockBag;
 import com.sk89q.worldedit.function.pattern.BlockPattern;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.world.block.BlockState;
 
 /**
@@ -49,7 +50,7 @@ public class BlockReplacer implements DoubleActionBlockTool {
     }
 
     @Override
-    public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, com.sk89q.worldedit.util.Location clicked) {
+    public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked) {
         BlockBag bag = session.getBlockBag(player);
 
         try (EditSession editSession = session.createEditSession(player)) {
@@ -72,7 +73,7 @@ public class BlockReplacer implements DoubleActionBlockTool {
 
 
     @Override
-    public boolean actSecondary(Platform server, LocalConfiguration config, Player player, LocalSession session, com.sk89q.worldedit.util.Location clicked) {
+    public boolean actSecondary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked) {
         BlockState targetBlock = player.getWorld().getBlock(clicked.toVector().toBlockPoint());
 
         if (targetBlock != null) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockTool.java
@@ -27,5 +27,15 @@ import com.sk89q.worldedit.util.Location;
 
 public interface BlockTool extends Tool {
 
+    /**
+     * Perform the primary action of this tool.
+     *
+     * @param server
+     * @param config
+     * @param player
+     * @param session
+     * @param clicked
+     * @return true to cancel the original event which triggered this action (if possible)
+     */
     boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked);
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/DistanceWand.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/DistanceWand.java
@@ -22,7 +22,6 @@ package com.sk89q.worldedit.command.tool;
 import com.sk89q.worldedit.LocalConfiguration;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.entity.Player;
-import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.extension.platform.permission.ActorSelectorLimits;
 import com.sk89q.worldedit.function.mask.Mask;
@@ -36,46 +35,33 @@ import com.sk89q.worldedit.util.Location;
 public class DistanceWand extends BrushTool implements DoubleActionTraceTool {
 
     public DistanceWand() {
-        super("worldedit.wand");
-    }
-
-    @Override
-    public boolean canUse(Actor player) {
-        return player.hasPermission("worldedit.wand");
+        super("worldedit.selection.pos");
     }
 
     @Override
     public boolean actSecondary(Platform server, LocalConfiguration config, Player player, LocalSession session) {
-        if (session.isToolControlEnabled() && player.hasPermission("worldedit.selection.pos")) {
-            Location target = getTarget(player);
-            if (target == null) return true;
+        Location target = getTarget(player);
+        if (target == null) return true;
 
-            RegionSelector selector = session.getRegionSelector(player.getWorld());
-            BlockVector3 blockPoint = target.toVector().toBlockPoint();
-            if (selector.selectPrimary(blockPoint, ActorSelectorLimits.forActor(player))) {
-                selector.explainPrimarySelection(player, session, blockPoint);
-            }
-            return true;
-
+        RegionSelector selector = session.getRegionSelector(player.getWorld());
+        BlockVector3 blockPoint = target.toVector().toBlockPoint();
+        if (selector.selectPrimary(blockPoint, ActorSelectorLimits.forActor(player))) {
+            selector.explainPrimarySelection(player, session, blockPoint);
         }
-        return false;
+        return true;
     }
 
     @Override
     public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session) {
-        if (session.isToolControlEnabled() && player.hasPermission("worldedit.selection.pos")) {
-            Location target = getTarget(player);
-            if (target == null) return true;
+        Location target = getTarget(player);
+        if (target == null) return true;
 
-            RegionSelector selector = session.getRegionSelector(player.getWorld());
-            BlockVector3 blockPoint = target.toVector().toBlockPoint();
-            if (selector.selectSecondary(blockPoint, ActorSelectorLimits.forActor(player))) {
-                selector.explainSecondarySelection(player, session, blockPoint);
-            }
-            return true;
-
+        RegionSelector selector = session.getRegionSelector(player.getWorld());
+        BlockVector3 blockPoint = target.toVector().toBlockPoint();
+        if (selector.selectSecondary(blockPoint, ActorSelectorLimits.forActor(player))) {
+            selector.explainSecondarySelection(player, session, blockPoint);
         }
-        return false;
+        return true;
     }
 
     private Location getTarget(Player player) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/DoubleActionBlockTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/DoubleActionBlockTool.java
@@ -30,6 +30,16 @@ import com.sk89q.worldedit.util.Location;
  */
 public interface DoubleActionBlockTool extends BlockTool {
 
+    /**
+     * Perform the secondary action of this block tool.
+     *
+     * @param server
+     * @param config
+     * @param player
+     * @param session
+     * @param clicked
+     * @return true to cancel the original event which triggered this action (if possible)
+     */
     boolean actSecondary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked);
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/DoubleActionTraceTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/DoubleActionTraceTool.java
@@ -29,6 +29,15 @@ import com.sk89q.worldedit.extension.platform.Platform;
  */
 public interface DoubleActionTraceTool extends TraceTool {
 
+    /**
+     * Perform the secondary function of this tool.
+     *
+     * @param server
+     * @param config
+     * @param player
+     * @param session
+     * @return true to cancel the original event which triggered this action (if possible)
+     */
     boolean actSecondary(Platform server, LocalConfiguration config, Player player, LocalSession session);
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/FloatingTreeRemover.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/FloatingTreeRemover.java
@@ -116,7 +116,7 @@ public class FloatingTreeRemover implements BlockTool {
      * @param origin any point contained in the floating tree
      * @return a set containing all blocks in the tree/shroom or null if this is not a floating tree/shroom.
      */
-    private Set<BlockVector3> bfs(World world, BlockVector3 origin) throws MaxChangedBlocksException {
+    private Set<BlockVector3> bfs(World world, BlockVector3 origin) {
         final Set<BlockVector3> visited = new HashSet<>();
         final LinkedList<BlockVector3> queue = new LinkedList<>();
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/LongRangeBuildTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/LongRangeBuildTool.java
@@ -65,7 +65,7 @@ public class LongRangeBuildTool extends BrushTool implements DoubleActionTraceTo
                 eS.setBlock(pos.toVector().subtract(pos.getDirection()).toBlockPoint(), secondary);
             }
             return true;
-        } catch (MaxChangedBlocksException e) {
+        } catch (MaxChangedBlocksException ignored) {
             // one block? eat it
         }
         return false;
@@ -86,7 +86,7 @@ public class LongRangeBuildTool extends BrushTool implements DoubleActionTraceTo
                 eS.setBlock(pos.toVector().subtract(pos.getDirection()).toBlockPoint(), primary);
             }
             return true;
-        } catch (MaxChangedBlocksException e) {
+        } catch (MaxChangedBlocksException ignored) {
             // one block? eat it
         }
         return false;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/QueryTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/QueryTool.java
@@ -27,6 +27,7 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BaseBlock;
 
@@ -41,7 +42,7 @@ public class QueryTool implements BlockTool {
     }
 
     @Override
-    public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, com.sk89q.worldedit.util.Location clicked) {
+    public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked) {
 
         World world = (World) clicked.getExtent();
         EditSession editSession = session.createEditSession(player);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/RecursivePickaxe.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/RecursivePickaxe.java
@@ -27,6 +27,7 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
@@ -52,18 +53,18 @@ public class RecursivePickaxe implements BlockTool {
     }
 
     @Override
-    public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, com.sk89q.worldedit.util.Location clicked) {
+    public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked) {
         World world = (World) clicked.getExtent();
 
         BlockVector3 origin = clicked.toVector().toBlockPoint();
         BlockType initialType = world.getBlock(origin).getBlockType();
 
         if (initialType.getMaterial().isAir()) {
-            return true;
+            return false;
         }
 
         if (initialType == BlockTypes.BEDROCK && !player.canDestroyBedrock()) {
-            return true;
+            return false;
         }
 
         try (EditSession editSession = session.createEditSession(player)) {
@@ -96,9 +97,9 @@ public class RecursivePickaxe implements BlockTool {
             return;
         }
 
-        world.queueBlockBreakEffect(server, pos, initialType, distanceSq);
-
         editSession.setBlock(pos, BlockTypes.AIR.getDefaultState());
+
+        world.queueBlockBreakEffect(server, pos, initialType, distanceSq);
 
         recurse(server, editSession, world, pos.add(1, 0, 0),
                 origin, size, initialType, visited);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/TraceTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/TraceTool.java
@@ -26,5 +26,14 @@ import com.sk89q.worldedit.extension.platform.Platform;
 
 public interface TraceTool extends Tool {
 
+    /**
+     * Perform the primary action of this trace tool.
+     *
+     * @param server
+     * @param config
+     * @param player
+     * @param session
+     * @return true to cancel the original event which triggered this action (if possible)
+     */
     boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session);
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/TreePlanter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/TreePlanter.java
@@ -26,6 +26,7 @@ import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extension.platform.Platform;
+import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.TreeGenerator;
 
@@ -52,8 +53,9 @@ public class TreePlanter implements BlockTool {
             try {
                 boolean successful = false;
 
+                final BlockVector3 pos = clicked.toVector().add(0, 1, 0).toBlockPoint();
                 for (int i = 0; i < 10; i++) {
-                    if (treeType.generate(editSession, clicked.toVector().add(0, 1, 0).toBlockPoint())) {
+                    if (treeType.generate(editSession, pos)) {
                         successful = true;
                         break;
                     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
@@ -166,8 +166,12 @@ public class SessionManager {
             session.setBlockChangeLimit(config.defaultChangeLimit);
             session.setTimeout(config.calculationTimeout);
             try {
-                setDefaultWand(session.getWandItem(), config.wandItem, session, new SelectionWand());
-                setDefaultWand(session.getNavWandItem(), config.navigationWand, session, new NavigationWand());
+                if (owner.hasPermission("worldedit.selection.pos")) {
+                    setDefaultWand(session.getWandItem(), config.wandItem, session, new SelectionWand());
+                }
+                if (owner.hasPermission("worldedit.command.jumpto.tool") || owner.hasPermission("worldedit.command.thru.tool")) {
+                    setDefaultWand(session.getNavWandItem(), config.navigationWand, session, new NavigationWand());
+                }
             } catch (InvalidToolBindException e) {
                 if (!warnedInvalidTool) {
                     warnedInvalidTool = true;


### PR DESCRIPTION
This means users can bind and unbind them to any item, like other tools.
By default, the items in config will be automatically bound. After
setting a different item via `//selwand` or `//navwand`, that item will
subsequently be used for that user.

Also various other tool-related cleanup.