### PR TITLE
Fix /up command not teleporting from the void

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
@@ -290,7 +290,7 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
             } else if (y > maxY + 1) {
                 break;
             } else if (y == maxY + 1) {
-                floatAt(x, y - 1, z, alwaysGlass);
+                floatAt(x, Math.max(1, y - 1), z, alwaysGlass);
                 return true;
             }
 


### PR DESCRIPTION
Teleporting from below Y1 is throwing an ArrayIndexOutOfBoundsException.

```java
[10:57:45 INFO]: TheMolkaPL issued server command: /up 0
[10:57:45 WARN]: java.lang.ArrayIndexOutOfBoundsException: -1
[10:57:45 WARN]:        at net.minecraft.server.v1_14_R1.Chunk.setType(Chunk.java:311)
[10:57:45 WARN]:        at net.minecraft.server.v1_14_R1.Chunk.setType(Chunk.java:302)
[10:57:45 WARN]:        at com.sk89q.worldedit.bukkit.adapter.impl.Spigot_v1_14_R2.setBlock(Spigot_v1_14_R2.java:264)
[10:57:45 WARN]:        at com.sk89q.worldedit.bukkit.BukkitWorld.setBlock(BukkitWorld.java:438)
[10:57:45 WARN]:        at com.sk89q.worldedit.world.AbstractWorld.setBlock(AbstractWorld.java:56)
[10:57:45 WARN]:        at com.sk89q.worldedit.extension.platform.AbstractPlayerActor.floatAt(AbstractPlayerActor.java:308)
[10:57:45 WARN]:        at com.sk89q.worldedit.extension.platform.AbstractPlayerActor.ascendUpwards(AbstractPlayerActor.java:293)
[10:57:45 WARN]:        at com.sk89q.worldedit.command.NavigationCommands.up(NavigationCommands.java:180)
[10:57:45 WARN]:        at com.sk89q.worldedit.command.NavigationCommandsRegistration.up(NavigationCommandsRegistration.java:258)
[10:57:45 WARN]:        at org.enginehub.piston.CommandManager.execute(CommandManager.java:158)
[10:57:45 WARN]:        at com.sk89q.worldedit.extension.platform.PlatformCommandManager.handleCommand(PlatformCommandManager.java:471)
[10:57:45 WARN]:        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[10:57:45 WARN]:        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[10:57:45 WARN]:        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[10:57:45 WARN]:        at java.lang.reflect.Method.invoke(Method.java:498)
[10:57:45 WARN]:        at com.sk89q.worldedit.util.eventbus.MethodEventHandler.dispatch(MethodEventHandler.java:58)
[10:57:45 WARN]:        at com.sk89q.worldedit.util.eventbus.EventHandler.handleEvent(EventHandler.java:73)
[10:57:45 WARN]:        at com.sk89q.worldedit.util.eventbus.EventBus.dispatch(EventBus.java:193)
[10:57:45 WARN]:        at com.sk89q.worldedit.util.eventbus.EventBus.post(EventBus.java:181)
[10:57:45 WARN]:        at com.sk89q.worldedit.bukkit.WorldEditPlugin.onCommand(WorldEditPlugin.java:328)
[10:57:45 WARN]:        at com.sk89q.bukkit.util.DynamicPluginCommand.execute(DynamicPluginCommand.java:55)
[10:57:45 WARN]:        at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:159)
[10:57:45 WARN]:        at org.bukkit.craftbukkit.v1_14_R1.CraftServer.dispatchCommand(CraftServer.java:736)
[10:57:45 WARN]:        at net.minecraft.server.v1_14_R1.PlayerConnection.handleCommand(PlayerConnection.java:1831)
[10:57:45 WARN]:        at net.minecraft.server.v1_14_R1.PlayerConnection.a(PlayerConnection.java:1639)
[10:57:45 WARN]:        at net.minecraft.server.v1_14_R1.PacketPlayInChat.a(PacketPlayInChat.java:47)
[10:57:45 WARN]:        at net.minecraft.server.v1_14_R1.PacketPlayInChat.a(PacketPlayInChat.java:5)
[10:57:45 WARN]:        at net.minecraft.server.v1_14_R1.PlayerConnectionUtils.lambda$ensureMainThread$0(PlayerConnectionUtils.java:18)
[10:57:45 WARN]:        at net.minecraft.server.v1_14_R1.TickTask.run(SourceFile:18)
[10:57:45 WARN]:        at net.minecraft.server.v1_14_R1.IAsyncTaskHandler.executeTask(IAsyncTaskHandler.java:127)
[10:57:45 WARN]:        at net.minecraft.server.v1_14_R1.IAsyncTaskHandlerReentrant.executeTask(SourceFile:23)
[10:57:45 WARN]:        at net.minecraft.server.v1_14_R1.IAsyncTaskHandler.executeNext(IAsyncTaskHandler.java:105)
[10:57:45 WARN]:        at net.minecraft.server.v1_14_R1.MinecraftServer.aW(MinecraftServer.java:998)
[10:57:45 WARN]:        at net.minecraft.server.v1_14_R1.MinecraftServer.executeNext(MinecraftServer.java:991)
[10:57:45 WARN]:        at net.minecraft.server.v1_14_R1.IAsyncTaskHandler.awaitTasks(IAsyncTaskHandler.java:115)
[10:57:45 WARN]:        at net.minecraft.server.v1_14_R1.MinecraftServer.sleepForTick(MinecraftServer.java:975)
[10:57:45 WARN]:        at net.minecraft.server.v1_14_R1.MinecraftServer.run(MinecraftServer.java:908)
[10:57:45 WARN]:        at java.lang.Thread.run(Thread.java:748)
```