### PR TITLE
Buffered extent improvements

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -565,12 +565,12 @@ public class EditSession implements Extent, AutoCloseable {
 
     @Override
     public BlockState getBlock(BlockVector3 position) {
-        return bypassNone.getBlock(position);
+        return world.getBlock(position);
     }
 
     @Override
     public BaseBlock getFullBlock(BlockVector3 position) {
-        return bypassNone.getFullBlock(position);
+        return world.getFullBlock(position);
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -565,12 +565,12 @@ public class EditSession implements Extent, AutoCloseable {
 
     @Override
     public BlockState getBlock(BlockVector3 position) {
-        return world.getBlock(position);
+        return bypassNone.getBlock(position);
     }
 
     @Override
     public BaseBlock getFullBlock(BlockVector3 position) {
-        return world.getFullBlock(position);
+        return bypassNone.getFullBlock(position);
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/GravityBrush.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/GravityBrush.java
@@ -42,6 +42,7 @@ public class GravityBrush implements Brush {
     @Override
     public void build(EditSession editSession, BlockVector3 position, Pattern pattern, double size) throws MaxChangedBlocksException {
         double yMax = fullHeight ? editSession.getWorld().getMaxY() : position.getY() + size;
+        double yMin = Math.max(position.getY() - size, 0);
         LocatedBlockList column = new LocatedBlockList();
         Set<BlockVector3> removedBlocks = new LinkedHashSet<>();
         for (double x = position.getX() - size; x <= position.getX() + size; x++) {
@@ -55,7 +56,7 @@ public class GravityBrush implements Brush {
                  */
 
                 BlockVector3 lowestAir = null;
-                for (double y = position.getY() - size; y <= yMax; y++) {
+                for (double y = yMin; y <= yMax; y++) {
                     BlockVector3 pt = BlockVector3.at(x, y, z);
 
                     BaseBlock block = editSession.getFullBlock(pt);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/GravityBrush.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/GravityBrush.java
@@ -23,44 +23,62 @@ import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
-import com.sk89q.worldedit.world.block.BlockState;
+import com.sk89q.worldedit.util.LocatedBlock;
+import com.sk89q.worldedit.util.collection.LocatedBlockList;
+import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockTypes;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 public class GravityBrush implements Brush {
 
     private final boolean fullHeight;
-    
+
     public GravityBrush(boolean fullHeight) {
         this.fullHeight = fullHeight;
     }
 
     @Override
     public void build(EditSession editSession, BlockVector3 position, Pattern pattern, double size) throws MaxChangedBlocksException {
-        final double startY = fullHeight ? editSession.getWorld().getMaxY() : position.getBlockY() + size;
-        for (double x = position.getBlockX() + size; x > position.getBlockX() - size; --x) {
-            for (double z = position.getBlockZ() + size; z > position.getBlockZ() - size; --z) {
-                double y = startY;
-                final List<BlockState> blockTypes = new ArrayList<>();
-                for (; y > position.getBlockY() - size; --y) {
-                    final BlockVector3 pt = BlockVector3.at(x, y, z);
-                    final BlockState block = editSession.getBlock(pt);
-                    if (!block.getBlockType().getMaterial().isAir()) {
-                        blockTypes.add(block);
-                        editSession.setBlock(pt, BlockTypes.AIR.getDefaultState());
+        double yMax = fullHeight ? editSession.getWorld().getMaxY() : position.getY() + size;
+        LocatedBlockList column = new LocatedBlockList();
+        Set<BlockVector3> removedBlocks = new LinkedHashSet<>();
+        for (double x = position.getX() - size; x <= position.getX() + size; x++) {
+            for (double z = position.getZ() - size; z <= position.getZ() + size; z++) {
+                for (double y = position.getY() - size; y <= yMax; y++) {
+                    BlockVector3 newPos = BlockVector3.at(x, y - 1, z);
+                    BlockVector3 pt = BlockVector3.at(x, y, z);
+
+                    BaseBlock block = editSession.getFullBlock(pt);
+
+                    if (block.getBlockType().getMaterial().isAir()) {
+                        continue;
                     }
-                }
-                BlockVector3 pt = BlockVector3.at(x, y, z);
-                Collections.reverse(blockTypes);
-                for (int i = 0; i < blockTypes.size();) {
-                    if (editSession.getBlock(pt).getBlockType().getMaterial().isAir()) {
-                        editSession.setBlock(pt, blockTypes.get(i++));
+
+                    if (!removedBlocks.remove(newPos)) {
+                        // we have not moved the block below this one.
+                        // is it free in the edit session?
+                        if (!editSession.getBlock(newPos).getBlockType().getMaterial().isAir()) {
+                            // no -- do not move this block
+                            continue;
+                        }
                     }
-                    pt = pt.add(0, 1, 0);
+
+                    column.add(newPos, block);
+                    removedBlocks.add(pt);
                 }
+
+                for (LocatedBlock block : column) {
+                    editSession.setBlock(block.getLocation(), block.getBlock());
+                }
+
+                for (BlockVector3 removedBlock : removedBlocks) {
+                    editSession.setBlock(removedBlock, BlockTypes.AIR.getDefaultState());
+                }
+
+                column.clear();
+                removedBlocks.clear();
             }
         }
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/AbstractBufferingExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/AbstractBufferingExtent.java
@@ -1,0 +1,48 @@
+package com.sk89q.worldedit.extent;
+
+import com.sk89q.worldedit.WorldEditException;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.world.block.BaseBlock;
+import com.sk89q.worldedit.world.block.BlockState;
+import com.sk89q.worldedit.world.block.BlockStateHolder;
+
+import java.util.Optional;
+
+/**
+ * Base extent class for buffering changes between {@link #setBlock(BlockVector3, BlockStateHolder)}
+ * and the delegate extent. This class ensures that {@link #getBlock(BlockVector3)} is properly
+ * handled, by returning buffered blocks.
+ */
+public abstract class AbstractBufferingExtent extends AbstractDelegateExtent {
+    /**
+     * Create a new instance.
+     *
+     * @param extent the extent
+     */
+    protected AbstractBufferingExtent(Extent extent) {
+        super(extent);
+    }
+
+    @Override
+    public abstract <T extends BlockStateHolder<T>> boolean setBlock(BlockVector3 location, T block) throws WorldEditException;
+
+    protected final <T extends BlockStateHolder<T>> boolean setDelegateBlock(BlockVector3 location, T block) throws WorldEditException {
+        return super.setBlock(location, block);
+    }
+
+    @Override
+    public BlockState getBlock(BlockVector3 position) {
+        return getBufferedBlock(position)
+            .map(BaseBlock::toImmutableState)
+            .orElseGet(() -> super.getBlock(position));
+    }
+
+    @Override
+    public BaseBlock getFullBlock(BlockVector3 position) {
+        return getBufferedBlock(position)
+            .orElseGet(() -> super.getFullBlock(position));
+    }
+
+    protected abstract Optional<BaseBlock> getBufferedBlock(BlockVector3 position);
+
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/AbstractBufferingExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/AbstractBufferingExtent.java
@@ -1,3 +1,22 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.sk89q.worldedit.extent;
 
 import com.sk89q.worldedit.WorldEditException;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/buffer/ExtentBuffer.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/buffer/ExtentBuffer.java
@@ -21,16 +21,16 @@ package com.sk89q.worldedit.extent.buffer;
 
 import com.google.common.collect.Maps;
 import com.sk89q.worldedit.WorldEditException;
-import com.sk89q.worldedit.extent.AbstractDelegateExtent;
+import com.sk89q.worldedit.extent.AbstractBufferingExtent;
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.mask.Masks;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BaseBlock;
-import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -38,7 +38,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Buffers changes to an {@link Extent} and allows retrieval of the changed blocks,
  * without modifying the underlying extent.
  */
-public class ExtentBuffer extends AbstractDelegateExtent {
+public class ExtentBuffer extends AbstractBufferingExtent {
 
     private final Map<BlockVector3, BaseBlock> buffer = Maps.newHashMap();
     private final Mask mask;
@@ -67,23 +67,11 @@ public class ExtentBuffer extends AbstractDelegateExtent {
     }
 
     @Override
-    public BlockState getBlock(BlockVector3 position) {
+    protected Optional<BaseBlock> getBufferedBlock(BlockVector3 position) {
         if (mask.test(position)) {
-            return getOrDefault(position).toImmutableState();
+            return Optional.of(buffer.computeIfAbsent(position, (pos -> getExtent().getFullBlock(pos))));
         }
-        return super.getBlock(position);
-    }
-
-    @Override
-    public BaseBlock getFullBlock(BlockVector3 position) {
-        if (mask.test(position)) {
-            return getOrDefault(position);
-        }
-        return super.getFullBlock(position);
-    }
-
-    private BaseBlock getOrDefault(BlockVector3 position) {
-        return buffer.computeIfAbsent(position, (pos -> getExtent().getFullBlock(pos)));
+        return Optional.empty();
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector2.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector2.java
@@ -19,7 +19,6 @@
 
 package com.sk89q.worldedit.math;
 
-import com.google.common.collect.ComparisonChain;
 import com.sk89q.worldedit.math.transform.AffineTransform;
 
 import java.util.Comparator;
@@ -28,7 +27,7 @@ import java.util.Comparator;
  * An immutable 2-dimensional vector.
  */
 public final class BlockVector2 {
-    
+
     public static final BlockVector2 ZERO = new BlockVector2(0, 0);
     public static final BlockVector2 UNIT_X = new BlockVector2(1, 0);
     public static final BlockVector2 UNIT_Z = new BlockVector2(0, 1);
@@ -48,12 +47,8 @@ public final class BlockVector2 {
      * cdef
      * </pre>
      */
-    public static final Comparator<BlockVector2> COMPARING_GRID_ARRANGEMENT = (a, b) -> {
-        return ComparisonChain.start()
-                .compare(a.getBlockZ(), b.getBlockZ())
-                .compare(a.getBlockX(), b.getBlockX())
-                .result();
-    };
+    public static final Comparator<BlockVector2> COMPARING_GRID_ARRANGEMENT =
+        Comparator.comparingInt(BlockVector2::getZ).thenComparingInt(BlockVector2::getX);
 
     public static BlockVector2 at(double x, double z) {
         return at((int) Math.floor(x), (int) Math.floor(z));
@@ -304,6 +299,27 @@ public final class BlockVector2 {
     }
 
     /**
+     * Shift all components right.
+     *
+     * @param x the value to shift x by
+     * @param z the value to shift z by
+     * @return a new vector
+     */
+    public BlockVector2 shr(int x, int z) {
+        return at(this.x >> x, this.z >> z);
+    }
+
+    /**
+     * Shift all components right by {@code n}.
+     *
+     * @param n the value to shift by
+     * @return a new vector
+     */
+    public BlockVector2 shr(int n) {
+        return shr(n, n);
+    }
+
+    /**
      * Get the length of the vector.
      *
      * @return length
@@ -532,5 +548,4 @@ public final class BlockVector2 {
     public String toString() {
         return "(" + x + ", " + z + ")";
     }
-
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector3.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector3.java
@@ -19,12 +19,11 @@
 
 package com.sk89q.worldedit.math;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
-import com.google.common.collect.ComparisonChain;
 import com.sk89q.worldedit.math.transform.AffineTransform;
 
 import java.util.Comparator;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * An immutable 3-dimensional vector.
@@ -64,18 +63,15 @@ public final class BlockVector3 {
 
     // thread-safe initialization idiom
     private static final class YzxOrderComparator {
-        private static final Comparator<BlockVector3> YZX_ORDER = (a, b) -> {
-            return ComparisonChain.start()
-                    .compare(a.y, b.y)
-                    .compare(a.z, b.z)
-                    .compare(a.x, b.x)
-                    .result();
-        };
+        private static final Comparator<BlockVector3> YZX_ORDER =
+            Comparator.comparingInt(BlockVector3::getY)
+                .thenComparingInt(BlockVector3::getZ)
+                .thenComparingInt(BlockVector3::getX);
     }
 
     /**
      * Returns a comparator that sorts vectors first by Y, then Z, then X.
-     * 
+     *
      * <p>
      * Useful for sorting by chunk block storage order.
      */
@@ -346,6 +342,28 @@ public final class BlockVector3 {
      */
     public BlockVector3 divide(int n) {
         return divide(n, n, n);
+    }
+
+    /**
+     * Shift all components right.
+     *
+     * @param x the value to shift x by
+     * @param y the value to shift y by
+     * @param z the value to shift z by
+     * @return a new vector
+     */
+    public BlockVector3 shr(int x, int y, int z) {
+        return at(this.x >> x, this.y >> y, this.z >> z);
+    }
+
+    /**
+     * Shift all components right by {@code n}.
+     *
+     * @param n the value to shift by
+     * @return a new vector
+     */
+    public BlockVector3 shr(int n) {
+        return shr(n, n, n);
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector3.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector3.java
@@ -367,6 +367,28 @@ public final class BlockVector3 {
     }
 
     /**
+     * Shift all components left.
+     *
+     * @param x the value to shift x by
+     * @param y the value to shift y by
+     * @param z the value to shift z by
+     * @return a new vector
+     */
+    public BlockVector3 shl(int x, int y, int z) {
+        return at(this.x << x, this.y << y, this.z << z);
+    }
+
+    /**
+     * Shift all components left by {@code n}.
+     *
+     * @param n the value to shift by
+     * @return a new vector
+     */
+    public BlockVector3 shl(int n) {
+        return shl(n, n, n);
+    }
+
+    /**
      * Get the length of the vector.
      *
      * @return length

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/collection/LocatedBlockList.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/collection/LocatedBlockList.java
@@ -21,68 +21,72 @@ package com.sk89q.worldedit.util.collection;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.ImmutableList;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.LocatedBlock;
+import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map;
 
 /**
  * Wrapper around a list of blocks located in the world.
  */
 public class LocatedBlockList implements Iterable<LocatedBlock> {
 
-    private final List<LocatedBlock> list;
+    private final Map<BlockVector3, LocatedBlock> map = new LinkedHashMap<>();
 
     public LocatedBlockList() {
-        list = new ArrayList<>();
     }
 
     public LocatedBlockList(Collection<? extends LocatedBlock> collection) {
-        list = new ArrayList<>(collection);
+        for (LocatedBlock locatedBlock : collection) {
+            map.put(locatedBlock.getLocation(), locatedBlock);
+        }
     }
 
     public void add(LocatedBlock setBlockCall) {
         checkNotNull(setBlockCall);
-        list.add(setBlockCall);
+        map.put(setBlockCall.getLocation(), setBlockCall);
     }
 
     public <B extends BlockStateHolder<B>> void add(BlockVector3 location, B block) {
         add(new LocatedBlock(location, block.toBaseBlock()));
     }
 
+    public boolean containsLocation(BlockVector3 location) {
+        return map.containsKey(location);
+    }
+
+    public @Nullable BaseBlock get(BlockVector3 location) {
+        return map.get(location).getBlock();
+    }
+
     public int size() {
-        return list.size();
+        return map.size();
     }
 
     public void clear() {
-        list.clear();
+        map.clear();
     }
 
     @Override
     public Iterator<LocatedBlock> iterator() {
-        return list.iterator();
+        return map.values().iterator();
     }
 
     public Iterator<LocatedBlock> reverseIterator() {
-        return new Iterator<LocatedBlock>() {
-
-            private final ListIterator<LocatedBlock> backingIterator = list.listIterator(list.size());
-
-            @Override
-            public boolean hasNext() {
-                return backingIterator.hasPrevious();
-            }
-
-            @Override
-            public LocatedBlock next() {
-                return backingIterator.previous();
-            }
-        };
+        List<LocatedBlock> data = new ArrayList<>(map.values());
+        Collections.reverse(data);
+        return data.iterator();
     }
 
 }


### PR DESCRIPTION
This PR fixes problems with extents that buffer `setBlock` calls for later. I'm unsure if changing the EditSession to return blocks via the extents, rather than the world, breaks anything.