### PR TITLE
Shade Rhino and truezip into Forge dist

### DIFF
--- a/worldedit-core/build.gradle
+++ b/worldedit-core/build.gradle
@@ -17,7 +17,7 @@ configurations.all { Configuration it ->
 dependencies {
     compile project(':worldedit-libs:core')
     compile 'de.schlichtherle:truezip:6.8.3'
-    compile 'rhino:js:1.7R2'
+    compile 'org.mozilla:rhino:1.7R5'
     compile 'org.yaml:snakeyaml:1.9'
     compile 'com.google.guava:guava:21.0'
     compile 'com.google.code.findbugs:jsr305:1.3.9'

--- a/worldedit-forge/build.gradle
+++ b/worldedit-forge/build.gradle
@@ -82,8 +82,7 @@ processResources {
 
 jar {
     manifest {
-        attributes("Class-Path": "truezip.jar WorldEdit/truezip.jar js.jar WorldEdit/js.jar",
-                   "WorldEdit-Version": version)
+        attributes("WorldEdit-Version": version)
     }
 }
 
@@ -94,6 +93,8 @@ shadowJar {
 
         include(dependency('org.slf4j:slf4j-api'))
         include(dependency("org.apache.logging.log4j:log4j-slf4j-impl"))
+        include(dependency("de.schlichtherle:truezip"))
+        include(dependency("org.mozilla:rhino"))
     }
 }
 


### PR DESCRIPTION
This allows them to be loaded again, since Forge stopped forcing jars onto the classpath.