### PR TITLE
Switch to JUnit 5

### DIFF
--- a/buildSrc/src/main/kotlin/PlatformConfig.kt
+++ b/buildSrc/src/main/kotlin/PlatformConfig.kt
@@ -9,6 +9,7 @@ import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.external.javadoc.CoreJavadocOptions
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.getByName
 import org.gradle.kotlin.dsl.named
@@ -36,6 +37,10 @@ fun Project.applyPlatformAndCoreConfiguration() {
     configure<CheckstyleExtension> {
         configFile = rootProject.file("config/checkstyle/checkstyle.xml")
         toolVersion = "7.6.1"
+    }
+
+    dependencies {
+        "testImplementation"("junit:junit:4.12")
     }
 
     // Java 8 turns on doclint which we fail

--- a/buildSrc/src/main/kotlin/PlatformConfig.kt
+++ b/buildSrc/src/main/kotlin/PlatformConfig.kt
@@ -6,6 +6,7 @@ import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.plugins.quality.CheckstyleExtension
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.javadoc.Javadoc
+import org.gradle.api.tasks.testing.Test
 import org.gradle.external.javadoc.CoreJavadocOptions
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
@@ -39,8 +40,13 @@ fun Project.applyPlatformAndCoreConfiguration() {
         toolVersion = "7.6.1"
     }
 
+    tasks.withType<Test>().configureEach {
+        useJUnitPlatform()
+    }
+
     dependencies {
-        "testImplementation"("junit:junit:4.12")
+        "testImplementation"("org.junit.jupiter:junit-jupiter-api:${Versions.JUNIT}")
+        "testRuntime"("org.junit.jupiter:junit-jupiter-engine:${Versions.JUNIT}")
     }
 
     // Java 8 turns on doclint which we fail

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -3,4 +3,5 @@ object Versions {
     const val TEXT_EXTRAS = "3.0.2"
     const val PISTON = "0.4.2"
     const val AUTO_VALUE = "1.6.5"
+    const val JUNIT = "5.5.0"
 }

--- a/worldedit-bukkit/build.gradle.kts
+++ b/worldedit-bukkit/build.gradle.kts
@@ -22,7 +22,9 @@ configurations.all {
 dependencies {
     "api"(project(":worldedit-core"))
     "api"(project(":worldedit-libs:bukkit"))
-    "api"("org.bukkit:bukkit:1.13.2-R0.1-SNAPSHOT")
+    "api"("org.bukkit:bukkit:1.13.2-R0.1-SNAPSHOT") {
+        exclude("junit", "junit")
+    }
     "compileOnly"("com.destroystokyo.paper:paper-api:1.13.2-R0.1-SNAPSHOT")
     "implementation"("io.papermc:paperlib:1.0.2")
     "compileOnly"("com.sk89q:dummypermscompat:1.10")

--- a/worldedit-bukkit/src/test/java/com/sk89q/wepif/DinnerPermsResolverTest.java
+++ b/worldedit-bukkit/src/test/java/com/sk89q/wepif/DinnerPermsResolverTest.java
@@ -19,26 +19,26 @@
 
 package com.sk89q.wepif;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import org.bukkit.Server;
 import org.bukkit.plugin.PluginManager;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class DinnerPermsResolverTest {
     private DinnerPermsResolver resolver;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         Server server = mock(Server.class);
         when(server.getPluginManager()).thenReturn(mock(PluginManager.class));
         resolver = new DinnerPermsResolver(server);
     }
-    
+
     @Test
     public void testBasicResolving() {
         final TestOfflinePermissible permissible = new TestOfflinePermissible();
@@ -49,7 +49,7 @@ public class DinnerPermsResolverTest {
         assertFalse(resolver.hasPermission(permissible, "completely.unrelated"));
         permissible.clearPermissions();
     }
-    
+
     @Test
     public void testBasicWildcardResolution() {
         final TestOfflinePermissible permissible = new TestOfflinePermissible();
@@ -59,7 +59,7 @@ public class DinnerPermsResolverTest {
         assertTrue(resolver.hasPermission(permissible, "commandbook.spawnmob.spider.skeleton"));
         permissible.clearPermissions();
     }
-    
+
     @Test
     public void testNegatingNodes() {
         final TestOfflinePermissible permissible = new TestOfflinePermissible();
@@ -67,16 +67,16 @@ public class DinnerPermsResolverTest {
         permissible.setPermission("commandbook.cuteasianboys", false);
         permissible.setPermission("commandbook.warp.*", false);
         permissible.setPermission("commandbook.warp.create", true);
-        
+
         assertTrue(resolver.hasPermission(permissible, "commandbook.motd"));
         assertFalse(resolver.hasPermission(permissible, "commandbook.cuteasianboys"));
         assertFalse(resolver.hasPermission(permissible, "commandbook.warp.remove"));
         assertTrue(resolver.hasPermission(permissible, "commandbook.warp.create"));
-        
+
         permissible.clearPermissions();
     }
-    
-    
+
+
     @Test
     public void testInGroup() {
         final TestOfflinePermissible permissible = new TestOfflinePermissible();

--- a/worldedit-bukkit/src/test/java/com/sk89q/worldedit/bukkit/BukkitWorldTest.java
+++ b/worldedit-bukkit/src/test/java/com/sk89q/worldedit/bukkit/BukkitWorldTest.java
@@ -20,15 +20,16 @@
 package com.sk89q.worldedit.bukkit;
 
 import com.sk89q.worldedit.util.TreeGenerator;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class BukkitWorldTest {
 
     @Test
     public void testTreeTypeMapping() {
         for (TreeGenerator.TreeType type : TreeGenerator.TreeType.values()) {
-            Assert.assertNotNull("No mapping for: " + type, BukkitWorld.toBukkitTreeType(type));
+            assertNotNull(BukkitWorld.toBukkitTreeType(type), "No mapping for: " + type);
         }
     }
 

--- a/worldedit-core/build.gradle.kts
+++ b/worldedit-core/build.gradle.kts
@@ -20,7 +20,6 @@ dependencies {
     "compile"("com.google.guava:guava:21.0")
     "compile"("com.google.code.findbugs:jsr305:1.3.9")
     "compile"("com.google.code.gson:gson:2.8.0")
-    "compile"("com.googlecode.json-simple:json-simple:1.1.1")
     "compile"("org.slf4j:slf4j-api:1.7.26")
 
     "compileOnly"(project(":worldedit-libs:core:ap"))

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/paste/EngineHubPaste.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/paste/EngineHubPaste.java
@@ -19,8 +19,9 @@
 
 package com.sk89q.worldedit.util.paste;
 
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import com.sk89q.worldedit.util.net.HttpRequest;
-import org.json.simple.JSONValue;
 
 import java.io.IOException;
 import java.net.URL;
@@ -32,6 +33,8 @@ import java.util.regex.Pattern;
 public class EngineHubPaste implements Paster {
 
     private static final Pattern URL_PATTERN = Pattern.compile("https?://.+$");
+
+    private static final Gson GSON = new Gson();
 
     @Override
     public Callable<URL> paste(String content) {
@@ -59,10 +62,10 @@ public class EngineHubPaste implements Paster {
                     .returnContent()
                     .asString("UTF-8").trim();
 
-            Object object = JSONValue.parse(result);
-            if (object instanceof Map) {
-                @SuppressWarnings("unchecked")
-                String urlString = String.valueOf(((Map<Object, Object>) object).get("url"));
+            Map<Object, Object> object = GSON.fromJson(result, new TypeToken<Map<Object, Object>>() {
+            }.getType());
+            if (object != null) {
+                String urlString = String.valueOf(object.get("url"));
                 Matcher m = URL_PATTERN.matcher(urlString);
 
                 if (m.matches()) {

--- a/worldedit-core/src/test/java/com/sk89q/minecraft/util/commands/CommandContextTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/minecraft/util/commands/CommandContextTest.java
@@ -19,19 +19,20 @@
 
 package com.sk89q.minecraft.util.commands;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.HashSet;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class CommandContextTest {
 
@@ -39,7 +40,7 @@ public class CommandContextTest {
     private static final String firstCmdString = "herpderp -opw testers \"mani world\" 'another thing'  because something";
     CommandContext firstCommand;
 
-    @Before
+    @BeforeEach
     public void setUpTest() {
         try {
             firstCommand = new CommandContext(firstCmdString, new HashSet<>(Arrays.asList('o', 'w')));
@@ -49,10 +50,12 @@ public class CommandContextTest {
         }
     }
 
-    @Test(expected = CommandException.class)
-    public void testInvalidFlags() throws CommandException {
+    @Test
+    public void testInvalidFlags() {
         final String failingCommand = "herpderp -opw testers";
-        new CommandContext(failingCommand, new HashSet<>(Arrays.asList('o', 'w')));
+        assertThrows(CommandException.class, () -> {
+            new CommandContext(failingCommand, new HashSet<>(Arrays.asList('o', 'w')));
+        });
     }
 
     @Test

--- a/worldedit-core/src/test/java/com/sk89q/worldedit/extent/transform/BlockTransformExtentTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/worldedit/extent/transform/BlockTransformExtentTest.java
@@ -19,33 +19,33 @@
 
 package com.sk89q.worldedit.extent.transform;
 
-import static org.junit.Assert.assertEquals;
-
 import com.sk89q.worldedit.math.transform.AffineTransform;
 import com.sk89q.worldedit.math.transform.Transform;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Set;
 
-@Ignore("A platform is currently required to get properties, preventing this test.")
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Disabled("A platform is currently required to get properties, preventing this test.")
 public class BlockTransformExtentTest {
 
     private static final Transform ROTATE_90 = new AffineTransform().rotateY(-90);
     private static final Transform ROTATE_NEG_90 = new AffineTransform().rotateY(90);
     private final Set<BlockType> ignored = new HashSet<>();
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         BlockType.REGISTRY.register("worldedit:test", new BlockType("worldedit:test"));
     }
 
     @Test
-    public void testTransform() throws Exception {
+    public void testTransform() {
         for (BlockType type : BlockType.REGISTRY.values()) {
             if (ignored.contains(type)) {
                 continue;

--- a/worldedit-core/src/test/java/com/sk89q/worldedit/internal/command/CommandArgParserTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/worldedit/internal/command/CommandArgParserTest.java
@@ -21,10 +21,10 @@ package com.sk89q.worldedit.internal.command;
 
 import com.google.common.collect.ImmutableList;
 import com.sk89q.worldedit.internal.util.Substring;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.sk89q.worldedit.internal.command.CommandArgParser.spaceSplit;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CommandArgParserTest {
     @Test

--- a/worldedit-core/src/test/java/com/sk89q/worldedit/internal/expression/ExpressionTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/worldedit/internal/expression/ExpressionTest.java
@@ -19,16 +19,6 @@
 
 package com.sk89q.worldedit.internal.expression;
 
-import static java.lang.Math.atan2;
-import static java.lang.Math.sin;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import com.sk89q.worldedit.LocalConfiguration;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.platform.Platform;
@@ -36,9 +26,18 @@ import com.sk89q.worldedit.internal.expression.lexer.LexerException;
 import com.sk89q.worldedit.internal.expression.parser.ParserException;
 import com.sk89q.worldedit.internal.expression.runtime.EvaluationException;
 import com.sk89q.worldedit.internal.expression.runtime.ExpressionEnvironment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static java.lang.Math.atan2;
+import static java.lang.Math.sin;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ExpressionTest {
-    @Before
+    @BeforeEach
     public void setup() {
         Platform mockPlat = Mockito.mock(Platform.class);
         Mockito.when(mockPlat.getConfiguration()).thenReturn(new LocalConfiguration() {
@@ -51,7 +50,7 @@ public class ExpressionTest {
 
     @Test
     public void testEvaluate() throws ExpressionException {
-        // check 
+        // check
         assertEquals(1 - 2 + 3, simpleEval("1 - 2 + 3"), 0);
 
         // check unary ops
@@ -74,7 +73,7 @@ public class ExpressionTest {
             compile("#");
             fail("Error expected");
         } catch (LexerException e) {
-            assertEquals("Error position", 0, e.getPosition());
+            assertEquals(0, e.getPosition(), "Error position");
         }
 
         // test parser errors
@@ -82,13 +81,13 @@ public class ExpressionTest {
             compile("x");
             fail("Error expected");
         } catch (ParserException e) {
-            assertEquals("Error position", 0, e.getPosition());
+            assertEquals(0, e.getPosition(), "Error position");
         }
         try {
             compile("x()");
             fail("Error expected");
         } catch (ParserException e) {
-            assertEquals("Error position", 0, e.getPosition());
+            assertEquals(0, e.getPosition(), "Error position");
         }
         try {
             compile("(");
@@ -104,19 +103,19 @@ public class ExpressionTest {
             compile("atan2(1)");
             fail("Error expected");
         } catch (ParserException e) {
-            assertEquals("Error position", 0, e.getPosition());
+            assertEquals(0, e.getPosition(), "Error position");
         }
         try {
             compile("atan2(1, 2, 3)");
             fail("Error expected");
         } catch (ParserException e) {
-            assertEquals("Error position", 0, e.getPosition());
+            assertEquals(0, e.getPosition(), "Error position");
         }
         try {
             compile("rotate(1, 2, 3)");
             fail("Error expected");
         } catch (ParserException e) {
-            assertEquals("Error position", 0, e.getPosition());
+            assertEquals(0, e.getPosition(), "Error position");
         }
     }
 

--- a/worldedit-core/src/test/java/com/sk89q/worldedit/internal/expression/ExpressionTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/worldedit/internal/expression/ExpressionTest.java
@@ -26,6 +26,7 @@ import com.sk89q.worldedit.internal.expression.lexer.LexerException;
 import com.sk89q.worldedit.internal.expression.parser.ParserException;
 import com.sk89q.worldedit.internal.expression.runtime.EvaluationException;
 import com.sk89q.worldedit.internal.expression.runtime.ExpressionEnvironment;
+import com.sk89q.worldedit.internal.expression.runtime.ExpressionTimeoutException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -172,7 +173,7 @@ public class ExpressionTest {
 
     @Test
     public void testTimeout() {
-        EvaluationException e = assertThrows(EvaluationException.class,
+        ExpressionTimeoutException e = assertThrows(ExpressionTimeoutException.class,
             () -> simpleEval("for(i=0;i<256;i++){for(j=0;j<256;j++){for(k=0;k<256;k++){for(l=0;l<256;l++){ln(pi)}}}}"),
             "Loop was not stopped.");
         assertTrue(e.getMessage().contains("Calculations exceeded time limit"));

--- a/worldedit-core/src/test/java/com/sk89q/worldedit/internal/expression/ExpressionTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/worldedit/internal/expression/ExpressionTest.java
@@ -32,9 +32,10 @@ import org.mockito.Mockito;
 
 import static java.lang.Math.atan2;
 import static java.lang.Math.sin;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class ExpressionTest {
     @BeforeEach
@@ -67,56 +68,46 @@ public class ExpressionTest {
     }
 
     @Test
-    public void testErrors() throws ExpressionException {
-        // test lexer errors
-        try {
-            compile("#");
-            fail("Error expected");
-        } catch (LexerException e) {
-            assertEquals(0, e.getPosition(), "Error position");
-        }
-
-        // test parser errors
-        try {
-            compile("x");
-            fail("Error expected");
-        } catch (ParserException e) {
-            assertEquals(0, e.getPosition(), "Error position");
-        }
-        try {
-            compile("x()");
-            fail("Error expected");
-        } catch (ParserException e) {
-            assertEquals(0, e.getPosition(), "Error position");
-        }
-        try {
-            compile("(");
-            fail("Error expected");
-        } catch (ParserException ignored) {}
-        try {
-            compile("x(");
-            fail("Error expected");
-        } catch (ParserException ignored) {}
-
-        // test overloader errors
-        try {
-            compile("atan2(1)");
-            fail("Error expected");
-        } catch (ParserException e) {
-            assertEquals(0, e.getPosition(), "Error position");
-        }
-        try {
-            compile("atan2(1, 2, 3)");
-            fail("Error expected");
-        } catch (ParserException e) {
-            assertEquals(0, e.getPosition(), "Error position");
-        }
-        try {
-            compile("rotate(1, 2, 3)");
-            fail("Error expected");
-        } catch (ParserException e) {
-            assertEquals(0, e.getPosition(), "Error position");
-        }
+    public void testErrors() {
+        assertAll(
+            // test lexer errors
+            () -> {
+                LexerException e = assertThrows(LexerException.class,
+                    () -> compile("#"));
+                assertEquals(0, e.getPosition(), "Error position");
+            },
+            // test parser errors
+            () -> {
+                ParserException e = assertThrows(ParserException.class,
+                    () -> compile("x"));
+                assertEquals(0, e.getPosition(), "Error position");
+            },
+            () -> {
+                ParserException e = assertThrows(ParserException.class,
+                    () -> compile("x()"));
+                assertEquals(0, e.getPosition(), "Error position");
+            },
+            () -> assertThrows(ParserException.class,
+                () -> compile("(")),
+            () -> assertThrows(ParserException.class,
+                () -> compile("x(")),
+            // test overloader errors
+            () -> {
+                ParserException e = assertThrows(ParserException.class,
+                    () -> compile("atan2(1)"));
+                assertEquals(0, e.getPosition(), "Error position");
+            },
+            () -> {
+                ParserException e = assertThrows(ParserException.class,
+                    () -> compile("atan2(1, 2, 3)"));
+                assertEquals(0, e.getPosition(), "Error position");
+            },
+            () -> {
+                ParserException e = assertThrows(ParserException.class,
+                    () -> compile("rotate(1, 2, 3)"));
+                assertEquals(0, e.getPosition(), "Error position");
+            }
+        );
     }
 
     @Test
@@ -180,13 +171,11 @@ public class ExpressionTest {
     }
 
     @Test
-    public void testTimeout() throws Exception {
-        try {
-            simpleEval("for(i=0;i<256;i++){for(j=0;j<256;j++){for(k=0;k<256;k++){for(l=0;l<256;l++){ln(pi)}}}}");
-            fail("Loop was not stopped.");
-        } catch (EvaluationException e) {
-            assertTrue(e.getMessage().contains("Calculations exceeded time limit"));
-        }
+    public void testTimeout() {
+        EvaluationException e = assertThrows(EvaluationException.class,
+            () -> simpleEval("for(i=0;i<256;i++){for(j=0;j<256;j++){for(k=0;k<256;k++){for(l=0;l<256;l++){ln(pi)}}}}"),
+            "Loop was not stopped.");
+        assertTrue(e.getMessage().contains("Calculations exceeded time limit"));
     }
 
     private double simpleEval(String expressionString) throws ExpressionException {

--- a/worldedit-core/src/test/java/com/sk89q/worldedit/util/LocationTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/worldedit/util/LocationTest.java
@@ -19,12 +19,12 @@
 
 package com.sk89q.worldedit.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-
 import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.world.World;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests {@link Location}.

--- a/worldedit-core/src/test/java/com/sk89q/worldedit/util/eventbus/EventBusTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/worldedit/util/eventbus/EventBusTest.java
@@ -19,14 +19,14 @@
 
 package com.sk89q.worldedit.util.eventbus;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class EventBusTest {
 


### PR DESCRIPTION
Final build system changes, I promise 🙂.

Biggest difference is `assertX(message, params)` is now `assertX(params, message)`, and the use of `assertThrows` instead of `try { ... fail(); } catch (X x) {}`.