### PR TITLE
Better cubic chunks compatibility (negative heights, general height-related fixes)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 notifications:
   email: false

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -766,7 +766,7 @@ public class EditSession implements Extent {
         MaskIntersection mask = new MaskIntersection(
                 new RegionMask(new EllipsoidRegion(null, origin, new Vector(radius, radius, radius))),
                 new BoundedHeightMask(
-                        Math.max(origin.getBlockY() - depth + 1, 0),
+                        Math.max(origin.getBlockY() - depth + 1, getWorld().getMinY()),
                         Math.min(getWorld().getMaxY(), origin.getBlockY())),
                 Masks.negate(new ExistingBlockMask(this)));
 
@@ -1560,8 +1560,24 @@ public class EditSession implements Extent {
      * @param radius the radius
      * @return number of blocks affected
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
+     * @deprecated Use {@link #thaw(Vector, double, int)}
      */
+    @Deprecated
     public int thaw(Vector position, double radius)
+            throws MaxChangedBlocksException {
+        return thaw(position, radius, WorldEdit.getInstance().getConfiguration().defaultVerticalSize);
+    }
+
+    /**
+     * Thaw blocks in a radius.
+     *
+     * @param position the position
+     * @param radius the radius
+     * @param vertSize the vertical size (up and down)
+     * @return number of blocks affected
+     * @throws MaxChangedBlocksException thrown if too many blocks are changed
+     */
+    public int thaw(Vector position, double radius, int vertSize)
             throws MaxChangedBlocksException {
         int affected = 0;
         double radiusSq = radius * radius;
@@ -1573,6 +1589,10 @@ public class EditSession implements Extent {
         BaseBlock air = new BaseBlock(0);
         BaseBlock water = new BaseBlock(BlockID.STATIONARY_WATER);
 
+        final int centerY = Math.max(getWorld().getMinY(), Math.min(getWorld().getMaxY(), oy));
+        final int minY = Math.max(getWorld().getMinY(), centerY - vertSize);
+        final int maxY = Math.min(getWorld().getMaxY(), centerY + vertSize);
+
         int ceilRadius = (int) Math.ceil(radius);
         for (int x = ox - ceilRadius; x <= ox + ceilRadius; ++x) {
             for (int z = oz - ceilRadius; z <= oz + ceilRadius; ++z) {
@@ -1580,7 +1600,7 @@ public class EditSession implements Extent {
                     continue;
                 }
 
-                for (int y = world.getMaxY(); y >= 1; --y) {
+                for (int y = maxY; y >= minY; --y) {
                     Vector pt = new Vector(x, y, z);
                     int id = getBlockType(pt);
 
@@ -1619,8 +1639,23 @@ public class EditSession implements Extent {
      * @param radius a radius
      * @return number of blocks affected
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
+     * @deprecated Use {@link #simulateSnow(Vector, double, int)}
      */
+    @Deprecated
     public int simulateSnow(Vector position, double radius) throws MaxChangedBlocksException {
+        return simulateSnow(position, radius, WorldEdit.getInstance().getConfiguration().defaultVerticalSize);
+    }
+
+    /**
+     * Make snow in a radius.
+     *
+     * @param position a position
+     * @param radius a radius
+     * @param vertSize the vertical size (up and down)
+     * @return number of blocks affected
+     * @throws MaxChangedBlocksException thrown if too many blocks are changed
+     */
+    public int simulateSnow(Vector position, double radius, int vertSize) throws MaxChangedBlocksException {
         int affected = 0;
         double radiusSq = radius * radius;
 
@@ -1631,6 +1666,10 @@ public class EditSession implements Extent {
         BaseBlock ice = new BaseBlock(BlockID.ICE);
         BaseBlock snow = new BaseBlock(BlockID.SNOW);
 
+        final int centerY = Math.max(getWorld().getMinY(), Math.min(getWorld().getMaxY(), oy));
+        final int minY = Math.max(getWorld().getMinY(), centerY - vertSize);
+        final int maxY = Math.min(getWorld().getMaxY(), centerY + vertSize);
+
         int ceilRadius = (int) Math.ceil(radius);
         for (int x = ox - ceilRadius; x <= ox + ceilRadius; ++x) {
             for (int z = oz - ceilRadius; z <= oz + ceilRadius; ++z) {
@@ -1638,7 +1677,7 @@ public class EditSession implements Extent {
                     continue;
                 }
 
-                for (int y = world.getMaxY(); y >= 1; --y) {
+                for (int y = maxY; y >= minY; --y) {
                     Vector pt = new Vector(x, y, z);
                     int id = getBlockType(pt);
 
@@ -1686,7 +1725,7 @@ public class EditSession implements Extent {
      * @param radius a radius
      * @return number of blocks affected
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
-     * @deprecated Use {@link #green(Vector, double, boolean)}.
+     * @deprecated Use {@link #green(Vector, double, int, boolean)}.
      */
     @Deprecated
     public int green(Vector position, double radius) throws MaxChangedBlocksException {
@@ -1701,8 +1740,25 @@ public class EditSession implements Extent {
      * @param onlyNormalDirt only affect normal dirt (data value 0)
      * @return number of blocks affected
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
+     * @deprecated Use {@link #green(Vector, double, int, boolean)}.
      */
+    @Deprecated
     public int green(Vector position, double radius, boolean onlyNormalDirt)
+            throws MaxChangedBlocksException {
+        return green(position, radius, WorldEdit.getInstance().getConfiguration().defaultVerticalSize, onlyNormalDirt);
+    }
+
+    /**
+     * Make dirt green.
+     *
+     * @param position a position
+     * @param radius a radius
+     * @param vertSize the vertical size (up and down)
+     * @param onlyNormalDirt only affect normal dirt (data value 0)
+     * @return number of blocks affected
+     * @throws MaxChangedBlocksException thrown if too many blocks are changed
+     */
+    public int green(Vector position, double radius, int vertSize, boolean onlyNormalDirt)
             throws MaxChangedBlocksException {
         int affected = 0;
         final double radiusSq = radius * radius;
@@ -1713,6 +1769,10 @@ public class EditSession implements Extent {
 
         final BaseBlock grass = new BaseBlock(BlockID.GRASS);
 
+        final int centerY = Math.max(getWorld().getMinY(), Math.min(getWorld().getMaxY(), oy));
+        final int minY = Math.max(getWorld().getMinY(), centerY - vertSize);
+        final int maxY = Math.min(getWorld().getMaxY(), centerY + vertSize);
+
         final int ceilRadius = (int) Math.ceil(radius);
         for (int x = ox - ceilRadius; x <= ox + ceilRadius; ++x) {
             for (int z = oz - ceilRadius; z <= oz + ceilRadius; ++z) {
@@ -1720,7 +1780,7 @@ public class EditSession implements Extent {
                     continue;
                 }
 
-                loop: for (int y = world.getMaxY(); y >= 1; --y) {
+                loop: for (int y = maxY; y >= minY; --y) {
                     final Vector pt = new Vector(x, y, z);
                     final int id = getBlockType(pt);
                     final int data = getBlockData(pt);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalConfiguration.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalConfiguration.java
@@ -82,6 +82,7 @@ public abstract class LocalConfiguration {
     public Set<Integer> disallowedBlocks = new HashSet<Integer>();
     public int defaultChangeLimit = -1;
     public int maxChangeLimit = -1;
+    public int defaultVerticalSize = 256;
     public int defaultMaxPolygonalPoints = -1;
     public int maxPolygonalPoints = 20;
     public int defaultMaxPolyhedronPoints = -1;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/UtilityCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/UtilityCommands.java
@@ -204,8 +204,7 @@ public class UtilityCommands {
         
         int size = args.argsLength() > 0 ? Math.max(1, args.getInteger(0)) : 1;
         we.checkMaxRadius(size);
-        World world = player.getWorld();
-        int height = args.argsLength() > 1 ? Math.min((world.getMaxY() + 1), args.getInteger(1) + 2) : (world.getMaxY() + 1);
+        int height = args.argsLength() > 1 ? args.getInteger(1) + 2 : we.getConfiguration().defaultVerticalSize;
 
         int affected = editSession.removeAbove(
                 session.getPlacementPosition(player), size, height);
@@ -225,8 +224,7 @@ public class UtilityCommands {
 
         int size = args.argsLength() > 0 ? Math.max(1, args.getInteger(0)) : 1;
         we.checkMaxRadius(size);
-        World world = player.getWorld();
-        int height = args.argsLength() > 1 ? Math.min((world.getMaxY() + 1), args.getInteger(1) + 2) : (world.getMaxY() + 1);
+        int height = args.argsLength() > 1 ? args.getInteger(1) + 2 : we.getConfiguration().defaultVerticalSize;
 
         int affected = editSession.removeBelow(session.getPlacementPosition(player), size, height);
         player.print(affected + " block(s) have been removed.");
@@ -290,54 +288,57 @@ public class UtilityCommands {
 
     @Command(
         aliases = { "/snow", "snow" },
-        usage = "[radius]",
+        usage = "[radius] [vertical-size]",
         desc = "Simulates snow",
         min = 0,
-        max = 1
+        max = 2
     )
     @CommandPermissions("worldedit.snow")
     @Logging(PLACEMENT)
     public void snow(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
 
         double size = args.argsLength() > 0 ? Math.max(1, args.getDouble(0)) : 10;
+        int ySize = args.argsLength() > 1 ? Math.max(1, args.getInteger(1)) : we.getConfiguration().defaultVerticalSize;
 
-        int affected = editSession.simulateSnow(session.getPlacementPosition(player), size);
+        int affected = editSession.simulateSnow(session.getPlacementPosition(player), size, ySize);
         player.print(affected + " surfaces covered. Let it snow~");
     }
 
     @Command(
         aliases = {"/thaw", "thaw"},
-        usage = "[radius]",
+        usage = "[radius] [vertical-size]",
         desc = "Thaws the area",
         min = 0,
-        max = 1
+        max = 2
     )
     @CommandPermissions("worldedit.thaw")
     @Logging(PLACEMENT)
     public void thaw(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
 
         double size = args.argsLength() > 0 ? Math.max(1, args.getDouble(0)) : 10;
+        int ySize = args.argsLength() > 1 ? Math.max(1, args.getInteger(1)) : we.getConfiguration().defaultVerticalSize;
 
-        int affected = editSession.thaw(session.getPlacementPosition(player), size);
+        int affected = editSession.thaw(session.getPlacementPosition(player), size, ySize);
         player.print(affected + " surfaces thawed.");
     }
 
     @Command(
         aliases = { "/green", "green" },
-        usage = "[radius]",
+        usage = "[radius] [vertical-size]",
         desc = "Greens the area",
         flags = "f",
         min = 0,
-        max = 1
+        max = 2
     )
     @CommandPermissions("worldedit.green")
     @Logging(PLACEMENT)
     public void green(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
 
         final double size = args.argsLength() > 0 ? Math.max(1, args.getDouble(0)) : 10;
+        int ySize = args.argsLength() > 1 ? Math.max(1, args.getInteger(1)) : we.getConfiguration().defaultVerticalSize;
         final boolean onlyNormalDirt = !args.hasFlag('f');
 
-        final int affected = editSession.green(session.getPlacementPosition(player), size, onlyNormalDirt);
+        final int affected = editSession.green(session.getPlacementPosition(player), size, ySize, onlyNormalDirt);
         player.print(affected + " surfaces greened.");
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/GravityBrush.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/GravityBrush.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit.command.tool.brush;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.Vector;
+import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.blocks.BaseBlock;
 import com.sk89q.worldedit.blocks.BlockID;
 import com.sk89q.worldedit.function.pattern.Pattern;
@@ -39,7 +40,8 @@ public class GravityBrush implements Brush {
     @Override
     public void build(EditSession editSession, Vector position, Pattern pattern, double size) throws MaxChangedBlocksException {
         final BaseBlock air = new BaseBlock(BlockID.AIR, 0);
-        final double startY = fullHeight ? editSession.getWorld().getMaxY() : position.getBlockY() + size;
+        double ySize = fullHeight ? WorldEdit.getInstance().getConfiguration().defaultVerticalSize : size;
+        final double startY = Math.min(editSession.getWorld().getMaxY(), position.getBlockY() + ySize);
         for (double x = position.getBlockX() + size; x > position.getBlockX() - size; --x) {
             for (double z = position.getBlockZ() + size; z > position.getBlockZ() - size; --z) {
                 double y = startY;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
@@ -97,7 +97,7 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
     public void findFreePosition(WorldVector searchPos) {
         World world = searchPos.getWorld();
         int x = searchPos.getBlockX();
-        int y = Math.max(0, searchPos.getBlockY());
+        int y = Math.max(getWorld().getMinY(), searchPos.getBlockY());
         int origY = y;
         int z = searchPos.getBlockZ();
 
@@ -131,7 +131,7 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
     public void setOnGround(WorldVector searchPos) {
         World world = searchPos.getWorld();
         int x = searchPos.getBlockX();
-        int y = Math.max(0, searchPos.getBlockY());
+        int y = Math.max(getWorld().getMinY(), searchPos.getBlockY());
         int z = searchPos.getBlockZ();
 
         int minY = Math.max(getWorld().getMinY(), y - WorldEdit.getInstance().getConfiguration().defaultVerticalSize);
@@ -157,12 +157,12 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
     public boolean ascendLevel() {
         final WorldVector pos = getBlockIn();
         final int x = pos.getBlockX();
-        int y = Math.max(0, pos.getBlockY());
+        int y = Math.max(getWorld().getMinY(), pos.getBlockY());
         final int z = pos.getBlockZ();
         final World world = pos.getWorld();
 
-        byte free = 0;
-        byte spots = 0;
+        int free = 0;
+        int spots = 0;
 
         int maxY = Math.min(world.getMaxY(), y + WorldEdit.getInstance().getConfiguration().defaultVerticalSize) + 2;
 
@@ -200,7 +200,7 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
     public boolean descendLevel() {
         final WorldVector pos = getBlockIn();
         final int x = pos.getBlockX();
-        int y = Math.max(0, pos.getBlockY() - 1);
+        int y = Math.max(getWorld().getMinY(), pos.getBlockY() - 1);
         final int z = pos.getBlockZ();
         final World world = pos.getWorld();
 
@@ -219,7 +219,7 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
                 // So we've found a spot, but we have to drop the player
                 // lightly and also check to see if there's something to
                 // stand upon
-                while (y >= 0) {
+                while (y >= minY) {
                     final Vector platform = new Vector(x, y, z);
                     final BaseBlock block = world.getBlock(platform);
                     final int type = block.getId();
@@ -252,8 +252,8 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
     public boolean ascendToCeiling(int clearance, boolean alwaysGlass) {
         Vector pos = getBlockIn();
         int x = pos.getBlockX();
-        int initialY = Math.max(0, pos.getBlockY());
-        int y = Math.max(0, pos.getBlockY() + 2);
+        int initialY = Math.max(getWorld().getMinY(), pos.getBlockY());
+        int y = Math.max(getWorld().getMinY(), pos.getBlockY() + 2);
         int z = pos.getBlockZ();
         World world = getPosition().getWorld();
 
@@ -287,8 +287,8 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
     public boolean ascendUpwards(int distance, boolean alwaysGlass) {
         final Vector pos = getBlockIn();
         final int x = pos.getBlockX();
-        final int initialY = Math.max(0, pos.getBlockY());
-        int y = Math.max(0, pos.getBlockY() + 1);
+        final int initialY = Math.max(getWorld().getMinY(), pos.getBlockY());
+        int y = Math.max(getWorld().getMinY(), pos.getBlockY() + 1);
         final int z = pos.getBlockZ();
         final int maxY = Math.min(getWorld().getMaxY() + 1, initialY + distance);
         final World world = getPosition().getWorld();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit.extension.platform;
 
+import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.util.auth.AuthorizationException;
 import com.sk89q.worldedit.BlockWorldVector;
 import com.sk89q.worldedit.LocalPlayer;
@@ -100,9 +101,11 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
         int origY = y;
         int z = searchPos.getBlockZ();
 
+        int maxY = Math.min(world.getMaxY(), y + WorldEdit.getInstance().getConfiguration().defaultVerticalSize) + 2;
+
         byte free = 0;
 
-        while (y <= world.getMaxY() + 2) {
+        while (y <= maxY) {
             if (BlockType.canPassThrough(world.getBlock(new Vector(x, y, z)))) {
                 ++free;
             } else {
@@ -131,7 +134,8 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
         int y = Math.max(0, searchPos.getBlockY());
         int z = searchPos.getBlockZ();
 
-        while (y >= 0) {
+        int minY = Math.max(getWorld().getMinY(), y - WorldEdit.getInstance().getConfiguration().defaultVerticalSize);
+        while (y >= minY) {
             final Vector pos = new Vector(x, y, z);
             final int id = world.getBlockType(pos);
             final int data = world.getBlockData(pos);
@@ -160,7 +164,9 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
         byte free = 0;
         byte spots = 0;
 
-        while (y <= world.getMaxY() + 2) {
+        int maxY = Math.min(world.getMaxY(), y + WorldEdit.getInstance().getConfiguration().defaultVerticalSize) + 2;
+
+        while (y <= maxY) {
             if (BlockType.canPassThrough(world.getBlock(new Vector(x, y, z)))) {
                 ++free;
             } else {
@@ -200,7 +206,9 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
 
         byte free = 0;
 
-        while (y >= 1) {
+        int minY = Math.max(getWorld().getMinY() + 1, y - WorldEdit.getInstance().getConfiguration().defaultVerticalSize);
+
+        while (y >= minY) {
             if (BlockType.canPassThrough(world.getBlock(new Vector(x, y, z)))) {
                 ++free;
             } else {
@@ -254,7 +262,9 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
             return false;
         }
 
-        while (y <= world.getMaxY()) {
+        int maxY = Math.min(world.getMaxY(), y + WorldEdit.getInstance().getConfiguration().defaultVerticalSize);
+
+        while (y <= maxY) {
             // Found a ceiling!
             if (!BlockType.canPassThrough(world.getBlock(new Vector(x, y, z)))) {
                 int platformY = Math.max(initialY, y - 3 - clearance);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/PropertiesConfiguration.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/PropertiesConfiguration.java
@@ -85,6 +85,7 @@ public class PropertiesConfiguration extends LocalConfiguration {
         disallowedBlocks = getIntSet("disallowed-blocks", defaultDisallowedBlocks);
         defaultChangeLimit = getInt("default-max-changed-blocks", defaultChangeLimit);
         maxChangeLimit = getInt("max-changed-blocks", maxChangeLimit);
+        defaultVerticalSize = getInt("default-vertical-size", defaultVerticalSize);
         defaultMaxPolygonalPoints = getInt("default-max-polygon-points", defaultMaxPolygonalPoints);
         maxPolygonalPoints = getInt("max-polygon-points", maxPolygonalPoints);
         defaultMaxPolyhedronPoints = getInt("default-max-polyhedron-points", defaultMaxPolyhedronPoints);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/ChunkStore.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/ChunkStore.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.world.storage;
 
 import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.jnbt.Tag;
+import com.sk89q.worldedit.BlockVector;
 import com.sk89q.worldedit.BlockVector2D;
 import com.sk89q.worldedit.Vector;
 import com.sk89q.worldedit.Vector2D;
@@ -55,6 +56,20 @@ public abstract class ChunkStore {
         int chunkZ = (int) Math.floor(position.getBlockZ() / 16.0);
 
         return new BlockVector2D(chunkX, chunkZ);
+    }
+
+    /**
+     * Convert a position to a chunk, with Y representing 256-blocks tall sections
+     *
+     * @param position the position
+     * @return chunk coordinates
+     */
+    public static BlockVector toChunk3d(Vector position) {
+        int chunkX = (int) Math.floor(position.getBlockX() / 16.0);
+        int chunkY = (int) Math.floor(position.getBlockY() / 256.0);
+        int chunkZ = (int) Math.floor(position.getBlockZ() / 16.0);
+
+        return new BlockVector(chunkX, chunkY, chunkZ);
     }
 
     /**

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java
@@ -118,31 +118,7 @@ public class ForgeWorld extends AbstractWorld {
     ForgeWorld(World world) {
         checkNotNull(world);
         this.worldRef = new WeakReference<World>(world);
-
-// start hacky stuff
-        if (!checkedMinY) {
-            checkForMinHeight();
-        }
-        if (getMinYMethod != null) {
-            try {
-                minY = (int) getMinYMethod.invoke(world);
-            } catch (IllegalAccessException | InvocationTargetException ignored) {
-            }
-        }
     }
-
-    private static Method getMinYMethod;
-    private static boolean checkedMinY;
-    private int minY = super.getMinY();
-
-    private static void checkForMinHeight() {
-        checkedMinY = true;
-        try {
-            getMinYMethod = World.class.getMethod("getMinHeight");
-        } catch (NoSuchMethodException ignored) {
-        }
-    }
-// end hacky stuff
 
     /**
      * Get the underlying handle to the world.
@@ -181,7 +157,9 @@ public class ForgeWorld extends AbstractWorld {
 
     @Override
     public int getMinY() {
-        return minY;
+        // Note: this method gets overwritten by cubic chunks.
+        // Existence of this method here signals that this version of WorldEdit is aware of it
+        return 0;
     }
 
     @Override


### PR DESCRIPTION
Changes so far:
 * A `default-vertical-size` config option that controls effects of functionality that previously worked over the entire world height
 * `//thaw`, `//snow` and `//green` now take an optional vertical size parameter, defaults to `default-vertical-size`
 * `//chunk` command selects the current `16x256x16` section instead of the whole world height. Optionally can take `x,y,z` instead of `x,z` as coordinates. `y` defaults to 0.
 * `//expand vert` - uses `default-vertical-size` instead of full world height by default, optionally can take size as parameter (I'm not sure if that's the right way to do it, it appears to go a bit against the intention of that command)
 * `//removeabove` and `//removebelow` use `default-vertical-size` instead of world height limit. Optionally, user can provide a value for it.
 * gravity brush will use `default-vertical-size` when using full height requested
 * Removed previous hacky code to get minY. Cubic chunks will transform the `getMinY` method instead.

To be done:
 * More testing, especially without cubic chunks installed
 * Verify that command's help output is still actually helpful
 * Verify that there are no breaking api changes
 * Better name for the config option?
