### PR TITLE
Support date/world snapshot directories

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/snapshot/SnapshotRepository.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/snapshot/SnapshotRepository.java
@@ -92,11 +92,13 @@ public class SnapshotRepository {
                     detectDate(snapshot);
                     list.add(snapshot);
                 }
-            } else if (file.isDirectory() && file.getName().equalsIgnoreCase(worldName)) {
+            } else if (file.isDirectory()) {
                 for (String name : file.list(filter)) {
-                    Snapshot snapshot = new Snapshot(this, file.getName() + "/" + name);
-                    detectDate(snapshot);
-                    list.add(snapshot);
+                    if (file.getName().equalsIgnoreCase(worldName) || name.equalsIgnoreCase(worldName)) {
+                        Snapshot snapshot = new Snapshot(this, file.getName() + "/" + name);
+                        detectDate(snapshot);
+                        list.add(snapshot);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This supersedes #208, building upon the original commit to strictly verify that there is a date in the snapshot path, rather than accepting any name in the above folder (would mis-match with a world named "region", for example).