### PR TITLE
Bundle required fabric api jars.

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     `kotlin-dsl`
     kotlin("jvm") version embeddedKotlinVersion
@@ -9,6 +11,14 @@ repositories {
     maven {
         name = "Forge Maven"
         url = uri("https://files.minecraftforge.net/maven")
+    }
+    maven {
+        name = "Fabric"
+        url = uri("https://maven.fabricmc.net/")
+    }
+    maven {
+        name = "sponge"
+        url = uri("https://repo.spongepowered.org/maven")
     }
 }
 
@@ -23,6 +33,14 @@ configurations.all {
     }
 }
 
+val properties = Properties().also { props ->
+    project.projectDir.resolveSibling("gradle.properties").bufferedReader().use {
+        props.load(it)
+    }
+}
+val loomVersion: String = properties.getProperty("loom.version")
+val mixinVersion: String = properties.getProperty("mixin.version")
+
 dependencies {
     implementation(gradleApi())
     implementation("gradle.plugin.net.minecrell:licenser:0.4.1")
@@ -33,4 +51,6 @@ dependencies {
     implementation("org.jfrog.buildinfo:build-info-extractor-gradle:4.9.7")
     implementation("gradle.plugin.org.spongepowered:spongegradle:0.9.0")
     implementation("net.minecraftforge.gradle:ForgeGradle:3.0.141")
+    implementation("net.fabricmc:fabric-loom:$loomVersion")
+    implementation("net.fabricmc:sponge-mixin:$mixinVersion")
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,3 +1,5 @@
+import org.gradle.api.Project
+
 object Versions {
     const val TEXT = "3.0.1"
     const val TEXT_EXTRAS = "3.0.2"
@@ -6,3 +8,12 @@ object Versions {
     const val JUNIT = "5.5.0"
     const val MOCKITO = "3.0.0"
 }
+
+// Properties that need a project reference to resolve:
+class ProjectVersions(project: Project) {
+    val loom = project.rootProject.property("loom.version")
+    val mixin = project.rootProject.property("mixin.version")
+}
+
+val Project.versions
+    get() = ProjectVersions(this)

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,6 @@ group=com.sk89q.worldedit
 version=7.1.0-SNAPSHOT
 
 org.gradle.jvmargs=-Xmx1G
+
+loom.version=0.2.5-20190906.190953-30
+mixin.version=0.7.11.38

--- a/worldedit-fabric/build.gradle.kts
+++ b/worldedit-fabric/build.gradle.kts
@@ -1,25 +1,6 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import net.fabricmc.loom.task.RemapJarTask
 
-buildscript {
-    repositories {
-        jcenter()
-        maven {
-            name = "Fabric"
-            url = uri("https://maven.fabricmc.net/")
-        }
-        maven {
-            name = "sponge"
-            url = uri("https://repo.spongepowered.org/maven")
-        }
-    }
-
-    dependencies {
-        "classpath"("net.fabricmc:fabric-loom:0.2.5-SNAPSHOT")
-        "classpath"("org.spongepowered:mixin:0.7.11-SNAPSHOT")
-    }
-}
-
 applyPlatformAndCoreConfiguration()
 applyShadowConfiguration()
 
@@ -52,6 +33,11 @@ dependencies {
         "include"(it)
         "modImplementation"(it)
     }
+
+    // Hook these up manually, because Fabric doesn't seem to quite do it properly.
+    "compileClasspath"("net.fabricmc:sponge-mixin:${project.versions.mixin}")
+    "annotationProcessor"("net.fabricmc:sponge-mixin:${project.versions.mixin}")
+    "annotationProcessor"("net.fabricmc:fabric-loom:${project.versions.loom}")
 
     "testCompile"("org.mockito:mockito-core:1.9.0-rc1")
 }

--- a/worldedit-fabric/src/main/resources/fabric.mod.json
+++ b/worldedit-fabric/src/main/resources/fabric.mod.json
@@ -29,7 +29,10 @@
 
     "depends": {
         "fabricloader": ">=0.4.0",
-        "fabric": "*"
+        "fabric-api-base": "*",
+        "fabric-events-lifecycle-v0": "*",
+        "fabric-events-interaction-v0": "*",
+        "fabric-networking-v0": "*"
     },
     "mixins": [
         "worldedit.mixins.json"


### PR DESCRIPTION
File size: +225kb
Users not reading instructions and missing Fabric API: -100%<sup><sup>when it gets to CF</sup></sup>

@kenzierocks feel free to re-add the intellij remapjar task hack. No clue what it was supposed to do or how it worked but it doesn't seem to work with the new task. (`RemapJarTask` now extends `Jar`, not `Task` directly)