### PR TITLE
Update to Piston 0.5.2 + Doctools/Deprecation improvements

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -3,7 +3,7 @@ import org.gradle.api.Project
 object Versions {
     const val TEXT = "3.0.1"
     const val TEXT_EXTRAS = "3.0.2"
-    const val PISTON = "0.4.3"
+    const val PISTON = "0.5.2"
     const val AUTO_VALUE = "1.6.5"
     const val JUNIT = "5.5.0"
     const val MOCKITO = "3.0.0"

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockCommandSender.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockCommandSender.java
@@ -27,6 +27,7 @@ import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.session.SessionKey;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.auth.AuthorizationException;
+import com.sk89q.worldedit.util.formatting.WorldEditText;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.util.formatting.text.adapter.bukkit.TextAdapter;
@@ -90,7 +91,7 @@ public class BukkitBlockCommandSender extends AbstractNonPlayerActor implements 
 
     @Override
     public void print(Component component) {
-        TextAdapter.sendComponent(sender, component);
+        TextAdapter.sendComponent(sender, WorldEditText.format(component));
     }
 
     @Override

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitCommandInspector.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitCommandInspector.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.sk89q.worldedit.bukkit.BukkitTextAdapter.reduceToText;
+import static com.sk89q.worldedit.util.formatting.WorldEditText.reduceToText;
 
 class BukkitCommandInspector implements CommandInspector {
 

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitCommandSender.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitCommandSender.java
@@ -25,6 +25,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.sk89q.worldedit.extension.platform.AbstractNonPlayerActor;
 import com.sk89q.worldedit.session.SessionKey;
 import com.sk89q.worldedit.util.auth.AuthorizationException;
+import com.sk89q.worldedit.util.formatting.WorldEditText;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.adapter.bukkit.TextAdapter;
 import org.bukkit.command.CommandSender;
@@ -93,7 +94,7 @@ public class BukkitCommandSender extends AbstractNonPlayerActor {
 
     @Override
     public void print(Component component) {
-        TextAdapter.sendComponent(sender, component);
+        TextAdapter.sendComponent(sender, WorldEditText.format(component));
     }
 
     @Override

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
@@ -31,6 +31,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.session.SessionKey;
 import com.sk89q.worldedit.util.HandSide;
+import com.sk89q.worldedit.util.formatting.WorldEditText;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BaseBlock;
@@ -129,7 +130,7 @@ public class BukkitPlayer extends AbstractPlayerActor {
 
     @Override
     public void print(Component component) {
-        TextAdapter.sendComponent(player, component);
+        TextAdapter.sendComponent(player, WorldEditText.format(component));
     }
 
     @Override

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitServerInterface.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitServerInterface.java
@@ -47,7 +47,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.sk89q.worldedit.bukkit.BukkitTextAdapter.reduceToText;
+import static com.sk89q.worldedit.util.formatting.WorldEditText.reduceToText;
 
 public class BukkitServerInterface implements MultiUserPlatform {
     public Server server;

--- a/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLICommandSender.java
+++ b/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLICommandSender.java
@@ -26,6 +26,7 @@ import com.sk89q.worldedit.internal.cui.CUIEvent;
 import com.sk89q.worldedit.session.SessionKey;
 import com.sk89q.worldedit.util.FileDialogUtil;
 import com.sk89q.worldedit.util.auth.AuthorizationException;
+import com.sk89q.worldedit.util.formatting.WorldEditText;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.serializer.plain.PlainComponentSerializer;
 import org.slf4j.Logger;
@@ -96,7 +97,7 @@ public class CLICommandSender implements Actor {
 
     @Override
     public void print(Component component) {
-        print(PlainComponentSerializer.INSTANCE.serialize(component));
+        print(PlainComponentSerializer.INSTANCE.serialize(WorldEditText.format(component)));
     }
 
     @Override

--- a/worldedit-core/doctools/src/main/kotlin/com/sk89q/worldedit/internal/util/DocumentationPrinter.kt
+++ b/worldedit-core/doctools/src/main/kotlin/com/sk89q/worldedit/internal/util/DocumentationPrinter.kt
@@ -24,7 +24,6 @@ import com.sk89q.worldedit.WorldEdit
 import com.sk89q.worldedit.command.BiomeCommands
 import com.sk89q.worldedit.command.ChunkCommands
 import com.sk89q.worldedit.command.ClipboardCommands
-import com.sk89q.worldedit.command.ExpandCommands
 import com.sk89q.worldedit.command.GeneralCommands
 import com.sk89q.worldedit.command.GenerationCommands
 import com.sk89q.worldedit.command.HistoryCommands
@@ -37,11 +36,12 @@ import com.sk89q.worldedit.command.ToolCommands
 import com.sk89q.worldedit.command.ToolUtilCommands
 import com.sk89q.worldedit.command.UtilityCommands
 import com.sk89q.worldedit.command.util.PermissionCondition
+import com.sk89q.worldedit.util.formatting.WorldEditText
 import com.sk89q.worldedit.util.formatting.text.TextComponent
 import com.sk89q.worldedit.util.formatting.text.TranslatableComponent
 import com.sk89q.worldedit.util.formatting.text.serializer.plain.PlainComponentSerializer
 import org.enginehub.piston.Command
-import org.enginehub.piston.TextConfig
+import org.enginehub.piston.config.TextConfig
 import org.enginehub.piston.part.SubCommandPart
 import org.enginehub.piston.util.HelpGenerator
 import java.nio.file.Files
@@ -216,7 +216,7 @@ Other Permissions
     private fun dumpSection(title: String, addCommandNames: suspend SequenceScope<String>.() -> Unit) {
         cmdOutput.append("\n").append(title).append("\n").append(Strings.repeat("~", title.length)).append("\n")
 
-        val prefix = TextConfig.getCommandPrefix()
+        val prefix = WorldEditText.reduceToText(TextConfig.commandPrefixValue())
         val commands = sequence(addCommandNames).map { this.commands.getValue(it) }.toList()
         matchedCommands.addAll(commands.map { it.name })
 

--- a/worldedit-core/doctools/src/main/kotlin/com/sk89q/worldedit/internal/util/RstWorldEditText.kt
+++ b/worldedit-core/doctools/src/main/kotlin/com/sk89q/worldedit/internal/util/RstWorldEditText.kt
@@ -1,0 +1,69 @@
+package com.sk89q.worldedit.internal.util
+
+import com.sk89q.worldedit.util.formatting.WorldEditText
+import com.sk89q.worldedit.util.formatting.text.Component
+import com.sk89q.worldedit.util.formatting.text.TextComponent
+import com.sk89q.worldedit.util.formatting.text.TranslatableComponent
+import com.sk89q.worldedit.util.formatting.text.event.ClickEvent
+import com.sk89q.worldedit.util.formatting.text.format.TextDecoration
+import org.enginehub.piston.util.TextHelper
+
+fun reduceToRst(component: Component): String {
+    val formatted = WorldEditText.format(component)
+    return formatAsRst(formatted).toString()
+}
+
+private fun formatAsRst(component: Component, currentDeco: String? = null): CharSequence {
+    return when (component) {
+        is TextComponent -> {
+            val content = StringBuilder(component.content())
+
+            val deco = when {
+                // Actions that suggest themselves as commands are marked as code
+                component.isSuggestingAsCommand(content.toString()) -> "``"
+                component.decorations().any { it == TextDecoration.BOLD } -> "**"
+                component.decorations().any { it == TextDecoration.ITALIC } -> "*"
+                else -> null
+            }
+
+            component.children().joinTo(content, separator = "") {
+                formatAsRst(it, deco ?: currentDeco)
+            }
+
+            deco?.let {
+                require(currentDeco == null) {
+                    "Nested decorations are hell in RST. \n" +
+                        "Existing: $currentDeco; New: $deco\n" +
+                        "Offender: ${TextHelper.reduceToText(component)}"
+                }
+                content.rstDeco(deco)
+            }
+
+            content
+        }
+        is TranslatableComponent -> {
+            val content = StringBuilder(component.key())
+            component.children().joinTo(content, separator = "") { formatAsRst(it, currentDeco) }
+            content
+        }
+        else -> component.children().joinToString(separator = "") { formatAsRst(it, currentDeco) }
+    }
+}
+
+private fun Component.isSuggestingAsCommand(text: String): Boolean {
+    val ce = clickEvent()
+    return when (ce?.action()) {
+        ClickEvent.Action.RUN_COMMAND,
+        ClickEvent.Action.SUGGEST_COMMAND ->
+            ce.value() == text
+        else -> false
+    }
+}
+
+private fun StringBuilder.rstDeco(deco: String): StringBuilder = apply {
+    ensureCapacity(length + deco.length * 2)
+    val insertionPoint = indexOfFirst { !it.isWhitespace() }.coerceAtLeast(0)
+    insert(insertionPoint, deco)
+    val insertionPointEnd = (indexOfLast { !it.isWhitespace() } + 1).takeUnless { it < 1 } ?: length
+    insert(insertionPointEnd, deco)
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
@@ -88,7 +88,7 @@ public class ToolCommands {
                 ).build();
             }
             commandManager.register(CommandUtil.deprecate(
-                command, "Using global tool names is deprecated " +
+                command, "Global tool names cause conflicts " +
                 "and will be removed in WorldEdit 8", ToolCommands::asNonGlobal
             ));
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
@@ -106,7 +106,8 @@ import com.sk89q.worldedit.util.logging.LogFormat;
 import com.sk89q.worldedit.world.World;
 import org.enginehub.piston.Command;
 import org.enginehub.piston.CommandManager;
-import org.enginehub.piston.TextConfig;
+import org.enginehub.piston.config.ConfigHolder;
+import org.enginehub.piston.config.TextConfig;
 import org.enginehub.piston.converter.ArgumentConverters;
 import org.enginehub.piston.exception.CommandException;
 import org.enginehub.piston.exception.CommandExecutionException;
@@ -151,10 +152,6 @@ public final class PlatformCommandManager {
     private static final Logger log = LoggerFactory.getLogger(PlatformCommandManager.class);
     private static final java.util.logging.Logger COMMAND_LOG =
         java.util.logging.Logger.getLogger("com.sk89q.worldedit.CommandLog");
-
-    static {
-        TextConfig.setCommandPrefix("/");
-    }
 
     private final WorldEdit worldEdit;
     private final PlatformManager platformManager;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/command/CommandUtil.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/command/CommandUtil.java
@@ -52,13 +52,14 @@ public class CommandUtil {
 
     private static final Component DEPRECATION_MARKER = TextComponent.of("This command is deprecated.");
 
-    private static Component makeDeprecatedFooter(Component newCommand) {
+    private static Component makeDeprecatedFooter(String reason, Component newCommand) {
         return TextComponent.builder()
             .append(DEPRECATION_MARKER)
-            .append(TextComponent.builder(" Use ", TextColor.GOLD)
-                .decoration(TextDecoration.ITALIC, true)
-                .append(newCommand)
-                .append(" instead."))
+            .append(" " + reason + ".")
+            .append(TextComponent.newline())
+            .append(TextComponent.of("Use ", TextColor.GOLD, TextDecoration.ITALIC))
+            .append(newCommand)
+            .append(TextComponent.of(" instead.", TextColor.GOLD, TextDecoration.ITALIC))
             .build();
     }
 
@@ -71,6 +72,7 @@ public class CommandUtil {
     public static Command deprecate(Command command, String reason,
                                     NewCommandGenerator newCommandGenerator) {
         Component deprecatedWarning = makeDeprecatedFooter(
+            reason,
             newCommandSuggestion(newCommandGenerator,
                 NoInputCommandParameters.builder().build(),
                 command)

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/WorldEditText.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/WorldEditText.java
@@ -17,32 +17,29 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.sk89q.worldedit.bukkit;
+package com.sk89q.worldedit.util.formatting;
 
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import org.enginehub.piston.config.ConfigHolder;
+import org.enginehub.piston.config.TextConfig;
+import org.enginehub.piston.util.TextHelper;
 
-public class BukkitTextAdapter {
+public class WorldEditText {
+    public static final ConfigHolder CONFIG_HOLDER = ConfigHolder.create();
+
+    static {
+        CONFIG_HOLDER.getConfig(TextConfig.commandPrefix()).setValue("/");
+    }
+
+    public static Component format(Component component) {
+        return CONFIG_HOLDER.replace(component);
+    }
 
     public static String reduceToText(Component component) {
-        StringBuilder text = new StringBuilder();
-        appendTextTo(text, component);
-        return text.toString();
+        return TextHelper.reduceToText(format(component));
     }
 
-    private static void appendTextTo(StringBuilder builder, Component component) {
-        if (component instanceof TextComponent) {
-            builder.append(((TextComponent) component).content());
-        } else if (component instanceof TranslatableComponent) {
-            builder.append(((TranslatableComponent) component).key());
-        }
-        for (Component child : component.children()) {
-            appendTextTo(builder, child);
-        }
-    }
-
-    private BukkitTextAdapter() {
+    private WorldEditText() {
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/CommandUsageBox.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/CommandUsageBox.java
@@ -24,9 +24,9 @@ import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
 import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
 import com.sk89q.worldedit.util.formatting.text.format.TextDecoration;
-import org.enginehub.piston.ColorConfig;
 import org.enginehub.piston.Command;
 import org.enginehub.piston.CommandParameters;
+import org.enginehub.piston.config.ColorConfig;
 import org.enginehub.piston.util.HelpGenerator;
 
 import javax.annotation.Nullable;
@@ -72,15 +72,13 @@ public class CommandUsageBox extends TextComponentProducer {
             .append(HelpGenerator.create(commands).getFullHelp());
         if (getSubCommands(Iterables.getLast(commands)).size() > 0) {
             boxContent.append(TextComponent.newline())
-                .append(TextComponent.builder("> ")
-                    .color(ColorConfig.getHelpText())
-                    .append(TextComponent.builder("List Subcommands")
-                        .color(ColorConfig.getMainText())
+                .append(ColorConfig.helpText().wrap(TextComponent.builder("> ")
+                    .append(ColorConfig.mainText().wrap(TextComponent.builder("List Subcommands")
                         .decoration(TextDecoration.ITALIC, true)
                         .clickEvent(ClickEvent.runCommand(helpRootCommand + " -s " + commandString))
                         .hoverEvent(HoverEvent.showText(TextComponent.of("List all subcommands of this command")))
-                        .build())
-                    .build());
+                        .build()))
+                    .build()));
         }
         MessageBox box = new MessageBox("Help for " + commandString,
             boxContent);

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricPlayer.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricPlayer.java
@@ -32,6 +32,7 @@ import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.session.SessionKey;
 import com.sk89q.worldedit.util.HandSide;
 import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldedit.util.formatting.WorldEditText;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.serializer.gson.GsonComponentSerializer;
 import com.sk89q.worldedit.world.World;
@@ -151,7 +152,7 @@ public class FabricPlayer extends AbstractPlayerActor {
 
     @Override
     public void print(Component component) {
-        this.player.sendMessage(Text.Serializer.fromJson(GsonComponentSerializer.INSTANCE.serialize(component)));
+        this.player.sendMessage(Text.Serializer.fromJson(GsonComponentSerializer.INSTANCE.serialize(WorldEditText.format(component))));
     }
 
     private void sendColorized(String msg, Formatting formatting) {

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePlayer.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePlayer.java
@@ -32,6 +32,7 @@ import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.session.SessionKey;
 import com.sk89q.worldedit.util.HandSide;
 import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldedit.util.formatting.WorldEditText;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.serializer.gson.GsonComponentSerializer;
 import com.sk89q.worldedit.world.World;
@@ -152,7 +153,7 @@ public class ForgePlayer extends AbstractPlayerActor {
 
     @Override
     public void print(Component component) {
-        this.player.sendMessage(ITextComponent.Serializer.fromJson(GsonComponentSerializer.INSTANCE.serialize(component)));
+        this.player.sendMessage(ITextComponent.Serializer.fromJson(GsonComponentSerializer.INSTANCE.serialize(WorldEditText.format(component))));
     }
 
     private void sendColorized(String msg, TextFormatting formatting) {

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeCommandSender.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeCommandSender.java
@@ -26,6 +26,7 @@ import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.internal.cui.CUIEvent;
 import com.sk89q.worldedit.session.SessionKey;
 import com.sk89q.worldedit.util.auth.AuthorizationException;
+import com.sk89q.worldedit.util.formatting.WorldEditText;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.adapter.spongeapi.TextAdapter;
 import org.spongepowered.api.command.CommandSource;
@@ -93,7 +94,7 @@ public class SpongeCommandSender implements Actor {
 
     @Override
     public void print(Component component) {
-        TextAdapter.sendComponent(sender, component);
+        TextAdapter.sendComponent(sender, WorldEditText.format(component));
     }
 
     private void sendColorized(String msg, TextColor formatting) {

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongePlayer.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongePlayer.java
@@ -31,6 +31,7 @@ import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.session.SessionKey;
 import com.sk89q.worldedit.util.HandSide;
 import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldedit.util.formatting.WorldEditText;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.adapter.spongeapi.TextAdapter;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
@@ -153,7 +154,7 @@ public class SpongePlayer extends AbstractPlayerActor {
 
     @Override
     public void print(Component component) {
-        TextAdapter.sendComponent(player, component);
+        TextAdapter.sendComponent(player, WorldEditText.format(component));
     }
 
     private void sendColorized(String msg, TextColor formatting) {

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeTextAdapter.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeTextAdapter.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit.sponge;
 
+import com.sk89q.worldedit.util.formatting.WorldEditText;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.serializer.gson.GsonComponentSerializer;
 import org.spongepowered.api.text.Text;
@@ -27,6 +28,7 @@ import org.spongepowered.api.text.serializer.TextSerializers;
 public class SpongeTextAdapter {
 
     public static Text convert(Component component) {
+        component = WorldEditText.format(component);
         return TextSerializers.JSON.deserialize(GsonComponentSerializer.INSTANCE.serialize(component));
     }
 


### PR DESCRIPTION
Did some reorganization of color configuration to allow Piston to be re-used in other projects without causing static state issues. Now `WorldEditText.format` is required to properly print Piston-sourced strings, as it applies the WorldEdit-specific formatting. Otherwise, you'll end up with hideous translation components in the output :).

`WorldEditText.format` is also designed to be a good hook for #478's translation processing, so we don't need to constantly track areas that we output our components.