### PR TITLE
Fix stack command diagonal shifting with -s flag

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -373,9 +373,9 @@ public class RegionCommands {
 
         if (moveSelection) {
             try {
-                final BlockVector3 size = region.getMaximumPoint().subtract(region.getMinimumPoint());
+                final BlockVector3 size = region.getMaximumPoint().subtract(region.getMinimumPoint()).add(1, 1, 1);
 
-                final BlockVector3 shiftVector = direction.toVector3().multiply(count * (Math.abs(direction.dot(size)) + 1)).toBlockPoint();
+                final BlockVector3 shiftVector = direction.multiply(size).multiply(count);
                 region.shift(shiftVector);
 
                 session.getRegionSelector(world).learnChanges();


### PR DESCRIPTION
Fix `//stack -s [num]` shifting the selection to unexpected places. This fix causes `//stack -s [num]` behavior in diagonal directions to be consistent with the behavior in non-diagonal directions, which means that the last stack will be selected.