### PR TITLE
Fix legacy import

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/LegacyMapper.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/LegacyMapper.java
@@ -83,7 +83,8 @@ public final class LegacyMapper {
             throw new IOException("Could not find legacy.json");
         }
         String data = Resources.toString(url, Charset.defaultCharset());
-        LegacyDataFile dataFile = gson.fromJson(data, new TypeToken<LegacyDataFile>() {}.getType());
+        LegacyDataFile dataFile = gson.fromJson(data, new TypeToken<LegacyDataFile>() {
+        }.getType());
 
         DataFixer fixer = WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.WORLD_EDITING).getDataFixer();
         ParserContext parserContext = new ParserContext();
@@ -95,25 +96,20 @@ public final class LegacyMapper {
             String id = blockEntry.getKey();
             final String value = blockEntry.getValue();
             blockEntries.put(id, value);
+
             try {
-                BlockState state = WorldEdit.getInstance().getBlockFactory().parseFromInput(value, parserContext).toImmutableState();
-                blockToStringMap.put(state, id);
-                stringToBlockMap.put(id, state);
-            } catch (InputParseException e) {
-                boolean fixed = false;
                 if (fixer != null) {
                     String newEntry = fixer.fixUp(DataFixer.FixTypes.BLOCK_STATE, value, 1631);
-                    try {
-                        BlockState state = WorldEdit.getInstance().getBlockFactory().parseFromInput(newEntry, parserContext).toImmutableState();
-                        blockToStringMap.put(state, id);
-                        stringToBlockMap.put(id, state);
-                        fixed = true;
-                    } catch (InputParseException ignored) {
-                    }
+                    BlockState state = WorldEdit.getInstance().getBlockFactory().parseFromInput(newEntry, parserContext).toImmutableState();
+                    blockToStringMap.put(state, id);
+                    stringToBlockMap.put(id, state);
+                } else {
+                    BlockState state = WorldEdit.getInstance().getBlockFactory().parseFromInput(value, parserContext).toImmutableState();
+                    blockToStringMap.put(state, id);
+                    stringToBlockMap.put(id, state);
                 }
-                if (!fixed) {
-                    log.warn("Unknown block: " + value);
-                }
+            } catch (InputParseException e) {
+                log.warn("Unknown block: " + value);
             }
         }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/LegacyMapper.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/LegacyMapper.java
@@ -26,6 +26,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.extension.factory.BlockFactory;
 import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.ParserContext;
 import com.sk89q.worldedit.extension.platform.Capability;
@@ -97,12 +98,13 @@ public final class LegacyMapper {
             blockEntries.put(id, value);
 
             BlockState state = null;
+            BlockFactory blockFactory = WorldEdit.getInstance().getBlockFactory();
 
             // if fixer is available, try using that first, as some old blocks that were renamed share names with new blocks
             if (fixer != null) {
                 try {
                     String newEntry = fixer.fixUp(DataFixer.FixTypes.BLOCK_STATE, value, 1631);
-                    state = WorldEdit.getInstance().getBlockFactory().parseFromInput(newEntry, parserContext).toImmutableState();
+                    state = blockFactory.parseFromInput(newEntry, parserContext).toImmutableState();
                 } catch (InputParseException e) {
                 }
             }
@@ -110,7 +112,7 @@ public final class LegacyMapper {
             // if it's still null, the fixer was unavailable or failed
             if (state == null) {
                 try {
-                    state = WorldEdit.getInstance().getBlockFactory().parseFromInput(value, parserContext).toImmutableState();
+                    state = blockFactory.parseFromInput(value, parserContext).toImmutableState();
                 } catch (InputParseException e) {
                 }
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/LegacyMapper.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/LegacyMapper.java
@@ -83,8 +83,7 @@ public final class LegacyMapper {
             throw new IOException("Could not find legacy.json");
         }
         String data = Resources.toString(url, Charset.defaultCharset());
-        LegacyDataFile dataFile = gson.fromJson(data, new TypeToken<LegacyDataFile>() {
-        }.getType());
+        LegacyDataFile dataFile = gson.fromJson(data, new TypeToken<LegacyDataFile>() {}.getType());
 
         DataFixer fixer = WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.WORLD_EDITING).getDataFixer();
         ParserContext parserContext = new ParserContext();


### PR DESCRIPTION
At least one old block which was renamed (stone slab -> smooth stone slab) shared names with a new block with the same name (stone slab). Since it previously only used the data fixer to set up the legacy map if there was no matching one for the old name in the new names, it would use the new block in the map, even though blocks on that version with that id were referring to the old block. This PR changes the order it tries it in from fixer if available, to default if that didn't work, to fail. 