### PR TITLE
Add //line support for convex polyhedral selections

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -19,7 +19,7 @@
 
 package com.sk89q.worldedit;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.entity.Entity;
 import com.sk89q.worldedit.event.extent.EditSessionEvent;
@@ -2187,12 +2187,12 @@ public class EditSession implements Extent, AutoCloseable {
      *
      * @return number of blocks affected
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
-     * 
-     * @see #drawLine(Pattern, List, double, boolean) 
+     *
+     * @see #drawLine(Pattern, List, double, boolean)
      */
     public int drawLine(Pattern pattern, BlockVector3 pos1, BlockVector3 pos2, double radius, boolean filled)
             throws MaxChangedBlocksException {
-        return drawLine(pattern, Lists.newArrayList(pos1,pos2), radius, filled);
+        return drawLine(pattern, ImmutableList.of(pos1, pos2), radius, filled);
     }
 
     /**
@@ -2212,9 +2212,6 @@ public class EditSession implements Extent, AutoCloseable {
         Set<BlockVector3> vset = new HashSet<>();
 
         for (int i = 0; vectors.size() != 0 && i < vectors.size() - 1; i++) {
-
-            boolean notdrawn = true;
-
             BlockVector3 pos1 = vectors.get(i);
             BlockVector3 pos2 = vectors.get(i + 1);
 
@@ -2225,10 +2222,11 @@ public class EditSession implements Extent, AutoCloseable {
 
             if (dx + dy + dz == 0) {
                 vset.add(BlockVector3.at(tipx, tipy, tipz));
-                notdrawn = false;
+                continue;
             }
 
-            if (Math.max(Math.max(dx, dy), dz) == dx && notdrawn) {
+            int dMax = Math.max(Math.max(dx, dy), dz);
+            if (dMax == dx) {
                 for (int domstep = 0; domstep <= dx; domstep++) {
                     tipx = x1 + domstep * (x2 - x1 > 0 ? 1 : -1);
                     tipy = (int) Math.round(y1 + domstep * ((double) dy) / ((double) dx) * (y2 - y1 > 0 ? 1 : -1));
@@ -2236,10 +2234,7 @@ public class EditSession implements Extent, AutoCloseable {
 
                     vset.add(BlockVector3.at(tipx, tipy, tipz));
                 }
-                notdrawn = false;
-            }
-
-            if (Math.max(Math.max(dx, dy), dz) == dy && notdrawn) {
+            } else if (dMax == dy) {
                 for (int domstep = 0; domstep <= dy; domstep++) {
                     tipy = y1 + domstep * (y2 - y1 > 0 ? 1 : -1);
                     tipx = (int) Math.round(x1 + domstep * ((double) dx) / ((double) dy) * (x2 - x1 > 0 ? 1 : -1));
@@ -2247,10 +2242,7 @@ public class EditSession implements Extent, AutoCloseable {
 
                     vset.add(BlockVector3.at(tipx, tipy, tipz));
                 }
-                notdrawn = false;
-            }
-
-            if (Math.max(Math.max(dx, dy), dz) == dz && notdrawn) {
+            } else /* if (dMax == dz) */ {
                 for (int domstep = 0; domstep <= dz; domstep++) {
                     tipz = z1 + domstep * (z2 - z1 > 0 ? 1 : -1);
                     tipy = (int) Math.round(y1 + domstep * ((double) dy) / ((double) dz) * (y2-y1>0 ? 1 : -1));
@@ -2258,7 +2250,6 @@ public class EditSession implements Extent, AutoCloseable {
 
                     vset.add(BlockVector3.at(tipx, tipy, tipz));
                 }
-                notdrawn = false;
             }
         }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit;
 
+import com.google.common.collect.Lists;
 import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.entity.Entity;
 import com.sk89q.worldedit.event.extent.EditSessionEvent;
@@ -2173,6 +2174,25 @@ public class EditSession implements Extent, AutoCloseable {
         }
 
         return affected;
+    }
+
+    /**
+     * Draws a line (out of blocks) between two vectors.
+     *
+     * @param pattern The block pattern used to draw the line.
+     * @param pos1 One of the points that define the line.
+     * @param pos2 The other point that defines the line.
+     * @param radius The radius (thickness) of the line.
+     * @param filled If false, only a shell will be generated.
+     *
+     * @return number of blocks affected
+     * @throws MaxChangedBlocksException thrown if too many blocks are changed
+     * 
+     * @see #drawLine(Pattern, List, double, boolean) 
+     */
+    public int drawLine(Pattern pattern, BlockVector3 pos1, BlockVector3 pos2, double radius, boolean filled)
+            throws MaxChangedBlocksException {
+        return drawLine(pattern, Lists.newArrayList(pos1,pos2), radius, filled);
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -2176,64 +2176,70 @@ public class EditSession implements Extent, AutoCloseable {
     }
 
     /**
-     * Draws a line (out of blocks) between two vectors.
+     * Draws a line (out of blocks) between two or more vectors.
      *
      * @param pattern The block pattern used to draw the line.
-     * @param pos1 One of the points that define the line.
-     * @param pos2 The other point that defines the line.
+     * @param vectors the list of vectors to draw the line between
      * @param radius The radius (thickness) of the line.
      * @param filled If false, only a shell will be generated.
      *
      * @return number of blocks affected
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */
-    public int drawLine(Pattern pattern, BlockVector3 pos1, BlockVector3 pos2, double radius, boolean filled)
+    public int drawLine(Pattern pattern, List<BlockVector3> vectors, double radius, boolean filled)
             throws MaxChangedBlocksException {
 
         Set<BlockVector3> vset = new HashSet<>();
-        boolean notdrawn = true;
 
-        int x1 = pos1.getBlockX(), y1 = pos1.getBlockY(), z1 = pos1.getBlockZ();
-        int x2 = pos2.getBlockX(), y2 = pos2.getBlockY(), z2 = pos2.getBlockZ();
-        int tipx = x1, tipy = y1, tipz = z1;
-        int dx = Math.abs(x2 - x1), dy = Math.abs(y2 - y1), dz = Math.abs(z2 - z1);
+        for (int i = 0; vectors.size() != 0 && i < vectors.size() - 1; i++) {
 
-        if (dx + dy + dz == 0) {
-            vset.add(BlockVector3.at(tipx, tipy, tipz));
-            notdrawn = false;
-        }
+            boolean notdrawn = true;
 
-        if (Math.max(Math.max(dx, dy), dz) == dx && notdrawn) {
-            for (int domstep = 0; domstep <= dx; domstep++) {
-                tipx = x1 + domstep * (x2 - x1 > 0 ? 1 : -1);
-                tipy = (int) Math.round(y1 + domstep * ((double) dy) / ((double) dx) * (y2 - y1 > 0 ? 1 : -1));
-                tipz = (int) Math.round(z1 + domstep * ((double) dz) / ((double) dx) * (z2 - z1 > 0 ? 1 : -1));
+            BlockVector3 pos1 = vectors.get(i);
+            BlockVector3 pos2 = vectors.get(i + 1);
 
+            int x1 = pos1.getBlockX(), y1 = pos1.getBlockY(), z1 = pos1.getBlockZ();
+            int x2 = pos2.getBlockX(), y2 = pos2.getBlockY(), z2 = pos2.getBlockZ();
+            int tipx = x1, tipy = y1, tipz = z1;
+            int dx = Math.abs(x2 - x1), dy = Math.abs(y2 - y1), dz = Math.abs(z2 - z1);
+
+            if (dx + dy + dz == 0) {
                 vset.add(BlockVector3.at(tipx, tipy, tipz));
+                notdrawn = false;
             }
-            notdrawn = false;
-        }
 
-        if (Math.max(Math.max(dx, dy), dz) == dy && notdrawn) {
-            for (int domstep = 0; domstep <= dy; domstep++) {
-                tipy = y1 + domstep * (y2 - y1 > 0 ? 1 : -1);
-                tipx = (int) Math.round(x1 + domstep * ((double) dx) / ((double) dy) * (x2 - x1 > 0 ? 1 : -1));
-                tipz = (int) Math.round(z1 + domstep * ((double) dz) / ((double) dy) * (z2 - z1 > 0 ? 1 : -1));
+            if (Math.max(Math.max(dx, dy), dz) == dx && notdrawn) {
+                for (int domstep = 0; domstep <= dx; domstep++) {
+                    tipx = x1 + domstep * (x2 - x1 > 0 ? 1 : -1);
+                    tipy = (int) Math.round(y1 + domstep * ((double) dy) / ((double) dx) * (y2 - y1 > 0 ? 1 : -1));
+                    tipz = (int) Math.round(z1 + domstep * ((double) dz) / ((double) dx) * (z2 - z1 > 0 ? 1 : -1));
 
-                vset.add(BlockVector3.at(tipx, tipy, tipz));
+                    vset.add(BlockVector3.at(tipx, tipy, tipz));
+                }
+                notdrawn = false;
             }
-            notdrawn = false;
-        }
 
-        if (Math.max(Math.max(dx, dy), dz) == dz && notdrawn) {
-            for (int domstep = 0; domstep <= dz; domstep++) {
-                tipz = z1 + domstep * (z2 - z1 > 0 ? 1 : -1);
-                tipy = (int) Math.round(y1 + domstep * ((double) dy) / ((double) dz) * (y2-y1>0 ? 1 : -1));
-                tipx = (int) Math.round(x1 + domstep * ((double) dx) / ((double) dz) * (x2-x1>0 ? 1 : -1));
+            if (Math.max(Math.max(dx, dy), dz) == dy && notdrawn) {
+                for (int domstep = 0; domstep <= dy; domstep++) {
+                    tipy = y1 + domstep * (y2 - y1 > 0 ? 1 : -1);
+                    tipx = (int) Math.round(x1 + domstep * ((double) dx) / ((double) dy) * (x2 - x1 > 0 ? 1 : -1));
+                    tipz = (int) Math.round(z1 + domstep * ((double) dz) / ((double) dy) * (z2 - z1 > 0 ? 1 : -1));
 
-                vset.add(BlockVector3.at(tipx, tipy, tipz));
+                    vset.add(BlockVector3.at(tipx, tipy, tipz));
+                }
+                notdrawn = false;
             }
-            notdrawn = false;
+
+            if (Math.max(Math.max(dx, dy), dz) == dz && notdrawn) {
+                for (int domstep = 0; domstep <= dz; domstep++) {
+                    tipz = z1 + domstep * (z2 - z1 > 0 ? 1 : -1);
+                    tipy = (int) Math.round(y1 + domstep * ((double) dy) / ((double) dz) * (y2-y1>0 ? 1 : -1));
+                    tipx = (int) Math.round(x1 + domstep * ((double) dx) / ((double) dz) * (x2-x1>0 ? 1 : -1));
+
+                    vset.add(BlockVector3.at(tipx, tipy, tipz));
+                }
+                notdrawn = false;
+            }
         }
 
         vset = getBallooned(vset, radius);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -112,7 +112,7 @@ public class RegionCommands {
 
     @Command(
         name = "/line",
-        desc = "Draws a line between cuboid selection corners or convex polyhedral selection vertices",
+        desc = "Draws line segments between cuboid selection corners or convex polyhedral selection vertices",
         descFooter = "Can only be used with a cuboid selection or a convex polyhedral selection"
     )
     @CommandPermissions("worldedit.region.line")

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -134,11 +134,10 @@ public class RegionCommands {
 
         List<BlockVector3> vectors;
 
-        if(region instanceof CuboidRegion) {
+        if (region instanceof CuboidRegion) {
             CuboidRegion cuboidregion = (CuboidRegion) region;
             vectors = Lists.newArrayList(cuboidregion.getPos1(), cuboidregion.getPos2());
-        }
-        else {
+        } else {
             ConvexPolyhedralRegion convexregion = (ConvexPolyhedralRegion) region;
             vectors = new ArrayList<>(convexregion.getVertices());
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -20,6 +20,7 @@
 package com.sk89q.worldedit.command;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.LocalSession;
@@ -135,11 +136,11 @@ public class RegionCommands {
         List<BlockVector3> vectors;
 
         if (region instanceof CuboidRegion) {
-            CuboidRegion cuboidregion = (CuboidRegion) region;
-            vectors = Lists.newArrayList(cuboidregion.getPos1(), cuboidregion.getPos2());
+            CuboidRegion cuboidRegion = (CuboidRegion) region;
+            vectors = ImmutableList.of(cuboidRegion.getPos1(), cuboidRegion.getPos2());
         } else {
-            ConvexPolyhedralRegion convexregion = (ConvexPolyhedralRegion) region;
-            vectors = new ArrayList<>(convexregion.getVertices());
+            ConvexPolyhedralRegion convexRegion = (ConvexPolyhedralRegion) region;
+            vectors = ImmutableList.copyOf(convexRegion.getVertices());
         }
 
         int blocksChanged = editSession.drawLine(pattern, vectors, thickness, !shell);


### PR DESCRIPTION
This PR adds support for convex polyhedral selections to the `//line` command.

It allows connecting the vertices of a convex polyhedral selection with lines, making it work similar to `//curve` but instead of a spline all vertices are connected with lines. The old functionality with connecting the two corner positions of a cuboid selection is preserved.

`EditSession.drawLine(...)` was modified to take a `BlockVector3` list, just like `EditSession.drawSpline(...)`

![screenshot displaying generated lines](https://s.put.re/p8SyHeDH.59.png)