### PR TITLE
BukkitAdapter: Add Bukkit CommandSender --> WorldEdit Actor

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitAdapter.java
@@ -142,6 +142,16 @@ public class BukkitAdapter {
     }
 
     /**
+     * Create a Bukkit CommandSender from a WorldEdit Actor.
+     *
+     * @param actor The WorldEdit actor
+     * @return The Bukkit command sender
+     */
+    public static CommandSender adapt(Actor actor) {
+        return ((BukkitCommandSender) actor).getSender();
+    }
+
+    /**
      * Create a Bukkit Player from a WorldEdit Player.
      *
      * @param player The WorldEdit player

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitAdapter.java
@@ -28,6 +28,7 @@ import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.entity.Entity;
 import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.ParserContext;
+import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.internal.block.BlockStateIdAccess;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
@@ -51,6 +52,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Biome;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -117,6 +119,16 @@ public class BukkitAdapter {
     public static World adapt(org.bukkit.World world) {
         checkNotNull(world);
         return new BukkitWorld(world);
+    }
+
+    /**
+     * Create a WorldEdit Actor from a Bukkit CommandSender
+     *
+     * @param sender The Bukkit CommandSender
+     * @return The WorldEdit Actor
+     */
+    public static Actor adapt(CommandSender sender) {
+        return WorldEditPlugin.getInstance().wrapCommandSender(sender);
     }
 
     /**

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitCommandSender.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitCommandSender.java
@@ -118,6 +118,10 @@ public class BukkitCommandSender extends AbstractNonPlayerActor {
         return WorldEdit.getInstance().getConfiguration().defaultLocale;
     }
 
+    public CommandSender getSender() {
+        return this.sender;
+    }
+
     @Override
     public SessionKey getSessionKey() {
         return new SessionKey() {


### PR DESCRIPTION
I want to use patterns in my plugin for the console.
There is no nice way to adapt a Bukkit CommandSender to a WorldEdit Actor.