### PR TITLE
Expose legacy data value.

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/QueryTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/QueryTool.java
@@ -34,6 +34,7 @@ import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
 import com.sk89q.worldedit.util.formatting.text.format.TextColor;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BaseBlock;
+import com.sk89q.worldedit.world.registry.LegacyMapper;
 
 import java.util.OptionalInt;
 
@@ -63,10 +64,16 @@ public class QueryTool implements BlockTool {
         final OptionalInt internalId = BlockStateIdAccess.getBlockStateId(block.toImmutableState());
         if (internalId.isPresent()) {
             builder.append(TextComponent.of(" (" + internalId.getAsInt() + ") ", TextColor.DARK_GRAY)
-                .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TranslatableComponent.of("worldedit.tool.info.internalid.hover"))));
+                    .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TranslatableComponent.of("worldedit.tool.info.internalid.hover"))));
         }
+        final int[] legacy = LegacyMapper.getInstance().getLegacyFromBlock(block.toImmutableState());
+        if (legacy != null) {
+            builder.append(TextComponent.of(" (" + legacy[0] + ":" + legacy[1] + ") ", TextColor.DARK_GRAY)
+                    .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TranslatableComponent.of("worldedit.tool.info.legacy.hover"))));
+        }
+
         builder.append(TextComponent.of(" (" + world.getBlockLightLevel(blockPoint) + "/"
-                    + world.getBlockLightLevel(blockPoint.add(0, 1, 0)) + ")", TextColor.WHITE)
+                + world.getBlockLightLevel(blockPoint.add(0, 1, 0)) + ")", TextColor.WHITE)
                 .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TranslatableComponent.of("worldedit.tool.info.light.hover"))));
 
         player.print(builder.build());

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/WorldEditExpressionEnvironment.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/WorldEditExpressionEnvironment.java
@@ -53,7 +53,7 @@ public class WorldEditExpressionEnvironment implements ExpressionEnvironment {
 
     @Override
     public int getBlockData(double x, double y, double z) {
-        return 0;
+        return extent.getBlock(toWorld(x, y, z)).getBlockType().getLegacyData();
     }
 
     @Override
@@ -63,7 +63,7 @@ public class WorldEditExpressionEnvironment implements ExpressionEnvironment {
 
     @Override
     public int getBlockDataAbs(double x, double y, double z) {
-        return 0;
+        return extent.getBlock(BlockVector3.at(x, y, z)).getBlockType().getLegacyData();
     }
 
     @Override
@@ -73,7 +73,7 @@ public class WorldEditExpressionEnvironment implements ExpressionEnvironment {
 
     @Override
     public int getBlockDataRel(double x, double y, double z) {
-        return 0;
+        return extent.getBlock(toWorldRel(x, y, z).toBlockPoint()).getBlockType().getLegacyData();
     }
 
     public void setCurrentBlock(Vector3 current) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockType.java
@@ -59,6 +59,9 @@ public class BlockType implements Keyed {
     private final LazyReference<Map<Map<Property<?>, Object>, BlockState>> blockStatesMap
         = LazyReference.from(() -> BlockState.generateStateMap(this));
 
+    private final LazyReference<Integer> legacyId = LazyReference.from(() -> computeLegacy(0));
+    private final LazyReference<Integer> legacyData = LazyReference.from(() -> computeLegacy(1));
+
     public BlockType(String id) {
         this(id, null);
     }
@@ -210,12 +213,24 @@ public class BlockType implements Keyed {
      */
     @Deprecated
     public int getLegacyId() {
-        int[] id = LegacyMapper.getInstance().getLegacyFromBlock(this.getDefaultState());
-        if (id != null) {
-            return id[0];
-        } else {
-            return 0;
-        }
+        return legacyId.getValue();
+    }
+
+    /**
+     * Gets the legacy data. Needed for legacy reasons.
+     *
+     * DO NOT USE THIS.
+     *
+     * @return legacy data or 0, if unknown
+     */
+    @Deprecated
+    public int getLegacyData() {
+        return legacyData.getValue();
+    }
+
+    private int computeLegacy(int index) {
+        int[] legacy = LegacyMapper.getInstance().getLegacyFromBlock(this.getDefaultState());
+        return legacy != null ? legacy[index] : 0;
     }
 
     @Override

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -254,6 +254,7 @@
     "worldedit.tool.info.equip": "Info tool bound to {0}.",
     "worldedit.tool.info.blockstate.hover": "Block state",
     "worldedit.tool.info.internalid.hover": "Internal ID",
+    "worldedit.tool.info.legacy.hover": "Legacy id:data",
     "worldedit.tool.info.light.hover": "Block Light/Light Above",
     "worldedit.tool.none.equip": "Tool unbound from your current item.",
     "worldedit.tool.selwand.equip": "Selection wand bound to {0}.",


### PR DESCRIPTION
Fixes [WORLDEDIT-4010](https://dev.enginehub.org/youtrack/issue/WORLDEDIT-4010).


This is kinda supposed to be a temp workaround til we have proper blockstate/string support in expressions I guess.