### PR TITLE
Make missing Bukkit impl adapter more user-friendly.

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
@@ -20,7 +20,6 @@
 package com.sk89q.worldedit.bukkit;
 
 import com.sk89q.util.StringUtil;
-import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
@@ -35,7 +34,11 @@ import com.sk89q.worldedit.util.HandSide;
 import com.sk89q.worldedit.util.formatting.WorldEditText;
 import com.sk89q.worldedit.util.formatting.component.TextUtils;
 import com.sk89q.worldedit.util.formatting.text.Component;
+import com.sk89q.worldedit.util.formatting.text.TextComponent;
+import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.formatting.text.adapter.bukkit.TextAdapter;
+import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
+import com.sk89q.worldedit.util.formatting.text.format.TextColor;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
@@ -221,6 +224,15 @@ public class BukkitPlayer extends AbstractPlayerActor {
     @Override
     public Locale getLocale() {
         return TextUtils.getLocaleByMinecraftTag(player.getLocale());
+    }
+
+    @Override
+    public void sendAnnouncements() {
+        if (WorldEditPlugin.getInstance().getBukkitImplAdapter() == null) {
+            printError(TranslatableComponent.of("worldedit.version.bukkit.unsupported-adapter",
+                    TextComponent.of("https://www.enginehub.org/worldedit/#downloads", TextColor.AQUA)
+                        .clickEvent(ClickEvent.openUrl("https://www.enginehub.org/worldedit/#downloads"))));
+        }
     }
 
     @Nullable

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -106,6 +106,7 @@ public class LocalSession {
     private transient List<Countable<BlockState>> lastDistribution;
     private transient World worldOverride;
     private transient boolean tickingWatchdog = false;
+    private transient boolean hasBeenToldVersion;
 
     // Saved properties
     private String lastScript;
@@ -728,6 +729,9 @@ public class LocalSession {
      * @param actor the actor
      */
     public void tellVersion(Actor actor) {
+        if (hasBeenToldVersion) return;
+        hasBeenToldVersion = true;
+        actor.sendAnnouncements();
     }
 
     public boolean shouldUseServerCUI() {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultBlockParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultBlockParser.java
@@ -173,7 +173,7 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
                         if (context.getActor() != null) {
                             throw new NoMatchException("Unknown property " + parts[0] + " for block " + type.getId());
                         } else {
-                            WorldEdit.logger.warn("Unknown property " + parts[0] + " for block " + type.getId());
+                            WorldEdit.logger.debug("Unknown property " + parts[0] + " for block " + type.getId());
                         }
                         return Maps.newHashMap();
                     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/Actor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/Actor.java
@@ -163,4 +163,10 @@ public interface Actor extends Identifiable, SessionOwner, Subject {
      * @return The locale
      */
     Locale getLocale();
+
+    /**
+     * Sends any relevant notices to the user when they first use WorldEdit in a session.
+     */
+    default void sendAnnouncements() {
+    }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlayerProxy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlayerProxy.java
@@ -155,6 +155,11 @@ class PlayerProxy extends AbstractPlayerActor {
         cuiActor.dispatchCUIEvent(event);
     }
 
+    @Override
+    public void sendAnnouncements() {
+        basePlayer.sendAnnouncements();
+    }
+
     @Nullable
     @Override
     public <T> T getFacet(Class<? extends T> cls) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/LegacyMapper.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/LegacyMapper.java
@@ -119,7 +119,7 @@ public final class LegacyMapper {
 
             // if it's still null, both fixer and default failed
             if (state == null) {
-                log.warn("Unknown block: " + value);
+                log.debug("Unknown block: " + value);
             } else {
                 // it's not null so one of them succeeded, now use it
                 blockToStringMap.put(state, id);
@@ -136,7 +136,7 @@ public final class LegacyMapper {
                 type = ItemTypes.get(value);
             }
             if (type == null) {
-                log.warn("Unknown item: " + value);
+                log.debug("Unknown item: " + value);
             } else {
                 itemToStringMap.put(type, id);
                 stringToItemMap.put(id, type);

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -228,6 +228,7 @@
     "worldedit.timezone.set": "Timezone set for this session to: {0}",
     "worldedit.timezone.current": "The current time in that timezone is: {0}",
     "worldedit.version.version": "WorldEdit version {0}",
+    "worldedit.version.bukkit.unsupported-adapter": "This WorldEdit version does not fully support your version of Bukkit. Block entities (e.g. chests) will be empty, block properties (e.g. rotation) will be missing, and other things may not work. Update WorldEdit to restore this functionality:\n{0}",
 
     "worldedit.command.time-elapsed": "{0}s elapsed (history: {1} changed; {2} blocks/sec).",
     "worldedit.command.permissions": "You are not permitted to do that. Are you in the right mode?",


### PR DESCRIPTION
* 100s of "Unknown property" warnings in log aren't useful, only drown
  out the actual adapter warning
* Most people aren't looking at their console anyway, so hijack the old
  Actor#tellVersion to warn of missing adapters.


example when first running a command (per session):
![](https://i.imgur.com/TgoDfXr.png)