### PR TITLE
Improve speed of BSIA, clean up Int2BaseBlockMap

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitAdapter.java
@@ -453,7 +453,10 @@ public class BukkitAdapter {
     public static <B extends BlockStateHolder<B>> BlockData adapt(B block) {
         checkNotNull(block);
         // Should never not have an ID for this BlockState.
-        int cacheKey = BlockStateIdAccess.getBlockStateId(block.toImmutableState()).orElseGet(block::hashCode);
+        int cacheKey = BlockStateIdAccess.getBlockStateId(block.toImmutableState());
+        if (cacheKey == BlockStateIdAccess.invalidId()) {
+            cacheKey = block.hashCode();
+        }
         return blockDataCache.computeIfAbsent(cacheKey, input -> Bukkit.createBlockData(block.getAsString())).clone();
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/QueryTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/QueryTool.java
@@ -36,8 +36,6 @@ import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.registry.LegacyMapper;
 
-import java.util.OptionalInt;
-
 /**
  * Looks up information about a block.
  */
@@ -61,9 +59,9 @@ public class QueryTool implements BlockTool {
         builder.append(TextComponent.of(block.getBlockType().getName(), TextColor.YELLOW));
         builder.append(TextComponent.of(" (" + block + ") ", TextColor.GRAY)
                 .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TranslatableComponent.of("worldedit.tool.info.blockstate.hover"))));
-        final OptionalInt internalId = BlockStateIdAccess.getBlockStateId(block.toImmutableState());
-        if (internalId.isPresent()) {
-            builder.append(TextComponent.of(" (" + internalId.getAsInt() + ") ", TextColor.DARK_GRAY)
+        final int internalId = BlockStateIdAccess.getBlockStateId(block.toImmutableState());
+        if (BlockStateIdAccess.isValidInternalId(internalId)) {
+            builder.append(TextComponent.of(" (" + internalId+ ") ", TextColor.DARK_GRAY)
                     .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TranslatableComponent.of("worldedit.tool.info.internalid.hover"))));
         }
         final int[] legacy = LegacyMapper.getInstance().getLegacyFromBlock(block.toImmutableState());

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/Capability.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/Capability.java
@@ -84,7 +84,9 @@ public enum Capability {
             BlockRegistry blockRegistry = platform.getRegistries().getBlockRegistry();
             for (BlockType type : BlockType.REGISTRY) {
                 for (BlockState state : type.getAllStates()) {
-                    BlockStateIdAccess.register(state, blockRegistry.getInternalBlockStateId(state));
+                    BlockStateIdAccess.register(state,
+                        blockRegistry.getInternalBlockStateId(state)
+                            .orElse(BlockStateIdAccess.invalidId()));
                 }
             }
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/collection/Int2BaseBlockMap.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/collection/Int2BaseBlockMap.java
@@ -123,7 +123,7 @@ class Int2BaseBlockMap extends AbstractInt2ObjectMap<BaseBlock> {
     @Override
     public BaseBlock get(int key) {
         int oldId = commonMap.get(key);
-        if (oldId == Integer.MIN_VALUE) {
+        if (!BlockStateIdAccess.isValidInternalId(oldId)) {
             return uncommonMap.get(key);
         }
         return assumeAsBlock(oldId);
@@ -163,7 +163,7 @@ class Int2BaseBlockMap extends AbstractInt2ObjectMap<BaseBlock> {
     @Override
     public BaseBlock remove(int key) {
         int removed = commonMap.remove(key);
-        if (removed == Integer.MIN_VALUE) {
+        if (!BlockStateIdAccess.isValidInternalId(removed)) {
             return uncommonMap.remove(key);
         }
         return assumeAsBlock(removed);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockState.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockState.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Table;
 import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.internal.block.BlockStateIdAccess;
 import com.sk89q.worldedit.registry.state.Property;
 
 import java.util.Collections;
@@ -43,6 +44,20 @@ import java.util.Set;
 @SuppressWarnings("unchecked")
 public class BlockState implements BlockStateHolder<BlockState> {
 
+    static {
+        BlockStateIdAccess.setBlockStateInternalId(new BlockStateIdAccess.BlockStateInternalId() {
+            @Override
+            public int getInternalId(BlockState blockState) {
+                return blockState.internalId;
+            }
+
+            @Override
+            public void setInternalId(BlockState blockState, int internalId) {
+                blockState.internalId = internalId;
+            }
+        });
+    }
+
     private final BlockType blockType;
     private final Map<Property<?>, Object> values;
 
@@ -50,6 +65,11 @@ public class BlockState implements BlockStateHolder<BlockState> {
 
     // Neighbouring state table.
     private Table<Property<?>, Object, BlockState> states;
+
+    /**
+     * The internal ID of the block state.
+     */
+    private int internalId = BlockStateIdAccess.invalidId();
 
     BlockState(BlockType blockType) {
         this.blockType = blockType;

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorld.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorld.java
@@ -87,7 +87,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
@@ -180,8 +179,11 @@ public class FabricWorld extends AbstractWorld {
         Chunk chunk = world.getChunk(x >> 4, z >> 4);
         BlockPos pos = new BlockPos(x, y, z);
         net.minecraft.block.BlockState old = chunk.getBlockState(pos);
-        OptionalInt stateId = BlockStateIdAccess.getBlockStateId(block.toImmutableState());
-        net.minecraft.block.BlockState newState = stateId.isPresent() ? Block.getStateFromRawId(stateId.getAsInt()) : FabricAdapter.adapt(block.toImmutableState());
+        int stateId = BlockStateIdAccess.getBlockStateId(block.toImmutableState());
+        net.minecraft.block.BlockState newState =
+            BlockStateIdAccess.isValidInternalId(stateId)
+                ? Block.getStateFromRawId(stateId)
+                : FabricAdapter.adapt(block.toImmutableState());
         net.minecraft.block.BlockState successState = chunk.setBlockState(pos, newState, false);
         boolean successful = successState != null;
 

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java
@@ -103,7 +103,6 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
@@ -198,8 +197,11 @@ public class ForgeWorld extends AbstractWorld {
         Chunk chunk = world.getChunk(x >> 4, z >> 4);
         BlockPos pos = new BlockPos(x, y, z);
         net.minecraft.block.BlockState old = chunk.getBlockState(pos);
-        OptionalInt stateId = BlockStateIdAccess.getBlockStateId(block.toImmutableState());
-        net.minecraft.block.BlockState newState = stateId.isPresent() ? Block.getStateById(stateId.getAsInt()) : ForgeAdapter.adapt(block.toImmutableState());
+        int stateId = BlockStateIdAccess.getBlockStateId(block.toImmutableState());
+        net.minecraft.block.BlockState newState =
+            BlockStateIdAccess.isValidInternalId(stateId)
+                ? Block.getStateById(stateId)
+                : ForgeAdapter.adapt(block.toImmutableState());
         net.minecraft.block.BlockState successState = chunk.setBlockState(pos, newState, false);
         boolean successful = successState != null;
 


### PR DESCRIPTION
This drops the BiMap in `BlockStateIdAccess` for a `Int2ObjectOpenHashMap<BlockState>` & a field in `BlockState`. The hash computation is relatively slow vs. a field read, so this improves the speed of putting blocks into a `BlockMap` significantly (~20s over 50 million puts).

I also cleaned up Int2BaseBlockMap to have no repeated reads to BSIA, but according to timing data, it's likely that the JVM was optimizing those out already! This just ensures that it happens before JIT kicks in.