### PR TITLE
Improve versioning

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,6 @@ if (!project.hasProperty("gitCommitHash")) {
     } catch (e: Exception) {
         logger.warn("Error getting commit hash", e)
 
-        "no_git_id"
+        "no.git.id"
     }
 }

--- a/buildSrc/src/main/kotlin/PlatformConfig.kt
+++ b/buildSrc/src/main/kotlin/PlatformConfig.kt
@@ -28,7 +28,7 @@ fun Project.applyPlatformAndCoreConfiguration() {
     apply(plugin = "com.jfrog.artifactory")
     apply(plugin = "net.minecrell.licenser")
 
-    ext["internalVersion"] = "$version;${rootProject.ext["gitCommitHash"]}"
+    ext["internalVersion"] = "$version+${rootProject.ext["gitCommitHash"]}"
 
     configure<JavaPluginConvention> {
         sourceCompatibility = JavaVersion.VERSION_1_8

--- a/buildSrc/src/main/kotlin/PlatformConfig.kt
+++ b/buildSrc/src/main/kotlin/PlatformConfig.kt
@@ -115,7 +115,19 @@ fun Project.applyShadowConfiguration() {
     }
 }
 
-val CLASSPATH = listOf("truezip", "truevfs", "js")
-    .map { "$it.jar" }
-    .flatMap { listOf(it, "WorldEdit/$it") }
-    .joinToString(separator = " ")
+private val CLASSPATH = listOf("truezip", "truevfs", "js")
+        .map { "$it.jar" }
+        .flatMap { listOf(it, "WorldEdit/$it") }
+        .joinToString(separator = " ")
+
+fun Project.addJarManifest(includeClasspath: Boolean = false) {
+    tasks.named<Jar>("jar") {
+        val attributes = mutableMapOf(
+                "WorldEdit-Version" to project(":worldedit-core").version
+        )
+        if (includeClasspath) {
+            attributes["Class-Path"] = CLASSPATH
+        }
+        manifest.attributes(attributes)
+    }
+}

--- a/worldedit-bukkit/build.gradle.kts
+++ b/worldedit-bukkit/build.gradle.kts
@@ -43,12 +43,7 @@ tasks.named<Copy>("processResources") {
     exclude("**/worldedit-adapters.jar")
 }
 
-tasks.named<Jar>("jar") {
-    manifest {
-        attributes("Class-Path" to CLASSPATH,
-                "WorldEdit-Version" to project.version)
-    }
-}
+addJarManifest(includeClasspath = true)
 
 tasks.named<ShadowJar>("shadowJar") {
     dependencies {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -739,23 +739,9 @@ public final class WorldEdit {
             return version;
         }
 
-        Package p = WorldEdit.class.getPackage();
+        WorldEditManifest manifest = WorldEditManifest.load();
 
-        if (p == null) {
-            p = Package.getPackage("com.sk89q.worldedit");
-        }
-
-        if (p == null) {
-            version = "(unknown)";
-        } else {
-            version = p.getImplementationVersion();
-
-            if (version == null) {
-                version = "(unknown)";
-            }
-        }
-
-        return version;
+        return version = manifest.getWorldEditVersion();
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEditManifest.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEditManifest.java
@@ -1,0 +1,81 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.JarURLConnection;
+import java.net.URL;
+import java.util.function.Supplier;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+/**
+ * Represents WorldEdit info from the MANIFEST.MF file.
+ */
+public class WorldEditManifest {
+
+    public static final String WORLD_EDIT_VERSION = "WorldEdit-Version";
+
+    public static WorldEditManifest load() {
+        Attributes attributes = readAttributes();
+        return new WorldEditManifest(
+            readAttribute(attributes, WORLD_EDIT_VERSION, () -> "(unknown)")
+        );
+    }
+
+    private static @Nullable Attributes readAttributes() {
+        Class<WorldEditManifest> clazz = WorldEditManifest.class;
+        String className = clazz.getSimpleName() + ".class";
+        String classPath = clazz.getResource(className).toString();
+        if (!classPath.startsWith("jar")) {
+            return null;
+        }
+
+        try {
+            URL url = new URL(classPath);
+            JarURLConnection jarConnection = (JarURLConnection) url.openConnection();
+            Manifest manifest = jarConnection.getManifest();
+            return manifest.getMainAttributes();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static String readAttribute(@Nullable Attributes attributes, String name,
+                                        Supplier<String> defaultAction) {
+        if (attributes == null) {
+            return defaultAction.get();
+        }
+        String value = attributes.getValue(name);
+        return value != null ? value : defaultAction.get();
+    }
+
+    private final String worldEditVersion;
+
+    private WorldEditManifest(String worldEditVersion) {
+        this.worldEditVersion = worldEditVersion;
+    }
+
+    public String getWorldEditVersion() {
+        return worldEditVersion;
+    }
+}

--- a/worldedit-fabric/build.gradle.kts
+++ b/worldedit-fabric/build.gradle.kts
@@ -61,12 +61,7 @@ tasks.named<Copy>("processResources") {
     }
 }
 
-tasks.named<Jar>("jar") {
-    manifest {
-        attributes("Class-Path" to CLASSPATH,
-                   "WorldEdit-Version" to project.version)
-    }
-}
+addJarManifest(includeClasspath = true)
 
 tasks.named<ShadowJar>("shadowJar") {
     archiveClassifier.set("dist-dev")

--- a/worldedit-forge/build.gradle.kts
+++ b/worldedit-forge/build.gradle.kts
@@ -80,11 +80,7 @@ tasks.named<Copy>("processResources") {
     from(project(":worldedit-core").tasks.named("processResources"))
 }
 
-tasks.named<Jar>("jar") {
-    manifest {
-        attributes("WorldEdit-Version" to project.version)
-    }
-}
+addJarManifest(includeClasspath = false)
 
 tasks.named<ShadowJar>("shadowJar") {
     dependencies {

--- a/worldedit-sponge/build.gradle.kts
+++ b/worldedit-sponge/build.gradle.kts
@@ -25,12 +25,7 @@ sponge {
     }
 }
 
-tasks.named<Jar>("jar") {
-    manifest {
-        attributes("Class-Path" to CLASSPATH,
-                "WorldEdit-Version" to project.version)
-    }
-}
+addJarManifest(includeClasspath = true)
 
 tasks.named<ShadowJar>("shadowJar") {
     dependencies {


### PR DESCRIPTION
This sets our internal version to a semver-conforming value, using `+` instead of `;`. It also updates the code to load the core version information from the manifest, though in a bit of a hacky way.