### PR TITLE
Add compatibility handlers for beds and banners for MCEdit Schematics

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/MCEditSchematicReader.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/MCEditSchematicReader.java
@@ -33,6 +33,8 @@ import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.extent.clipboard.BlockArrayClipboard;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
+import com.sk89q.worldedit.extent.clipboard.io.legacycompat.BannerBlockCompatibilityHandler;
+import com.sk89q.worldedit.extent.clipboard.io.legacycompat.BedBlockCompatibilityHandler;
 import com.sk89q.worldedit.extent.clipboard.io.legacycompat.EntityNBTCompatibilityHandler;
 import com.sk89q.worldedit.extent.clipboard.io.legacycompat.FlowerPotCompatibilityHandler;
 import com.sk89q.worldedit.extent.clipboard.io.legacycompat.NBTCompatibilityHandler;
@@ -77,7 +79,9 @@ public class MCEditSchematicReader extends NBTSchematicReader {
                 new SignCompatibilityHandler(),
                 new FlowerPotCompatibilityHandler(),
                 new NoteBlockCompatibilityHandler(),
-                new SkullBlockCompatibilityHandler()
+                new SkullBlockCompatibilityHandler(),
+                new BannerBlockCompatibilityHandler(),
+                new BedBlockCompatibilityHandler()
     );
     private static final ImmutableList<EntityNBTCompatibilityHandler> ENTITY_COMPATIBILITY_HANDLERS
             = ImmutableList.of(

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/BannerBlockCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/BannerBlockCompatibilityHandler.java
@@ -109,10 +109,7 @@ public class BannerBlockCompatibilityHandler implements NBTCompatibilityHandler 
         return block;
     }
 
-    private static String convertBannerType(Integer oldType, boolean isWall) {
-        if (oldType == null) {
-            return null;
-        }
+    private static String convertBannerType(int oldType, boolean isWall) {
         String color;
         switch (oldType) {
             case 0:

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/BannerBlockCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/BannerBlockCompatibilityHandler.java
@@ -1,0 +1,171 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.extent.clipboard.io.legacycompat;
+
+import com.sk89q.jnbt.CompoundTag;
+import com.sk89q.jnbt.CompoundTagBuilder;
+import com.sk89q.jnbt.IntTag;
+import com.sk89q.jnbt.ListTag;
+import com.sk89q.jnbt.Tag;
+import com.sk89q.worldedit.registry.state.DirectionalProperty;
+import com.sk89q.worldedit.registry.state.IntegerProperty;
+import com.sk89q.worldedit.registry.state.Property;
+import com.sk89q.worldedit.world.block.BlockState;
+import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BlockType;
+import com.sk89q.worldedit.world.block.BlockTypes;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class BannerBlockCompatibilityHandler implements NBTCompatibilityHandler {
+
+    private static final DirectionalProperty FacingProperty;
+    private static final IntegerProperty RotationProperty;
+
+    static {
+        DirectionalProperty tempFacing;
+        IntegerProperty tempRotation;
+        try {
+            tempFacing = (DirectionalProperty) (Property<?>) BlockTypes.WHITE_WALL_BANNER.getProperty("facing");
+            tempRotation = (IntegerProperty) (Property<?>) BlockTypes.WHITE_BANNER.getProperty("rotation");
+        } catch (NullPointerException | IllegalArgumentException | ClassCastException e) {
+            tempFacing = null;
+            tempRotation = null;
+        }
+        FacingProperty = tempFacing;
+        RotationProperty = tempRotation;
+    }
+
+    @Override
+    public <B extends BlockStateHolder<B>> boolean isAffectedBlock(B block) {
+        return block.getBlockType() == BlockTypes.WHITE_BANNER
+                || block.getBlockType() == BlockTypes.WHITE_WALL_BANNER;
+    }
+
+    @Override
+    public <B extends BlockStateHolder<B>> B updateNBT(B block, Map<String, Tag> values) {
+        Tag typeTag = values.get("Base");
+        if (typeTag instanceof IntTag) {
+            boolean isWall = block.getBlockType() == BlockTypes.WHITE_WALL_BANNER;
+            String bannerType = convertBannerType(((IntTag) typeTag).getValue(), isWall);
+            if (bannerType != null) {
+                BlockType type = BlockTypes.get("minecraft:" + bannerType);
+                if (type != null) {
+                    BlockState state = type.getDefaultState();
+
+                    if (isWall) {
+                        Property facingProp = type.getProperty("facing");
+                        state = state.with(facingProp, block.getState(FacingProperty));
+                    } else {
+                        Property rotationProp = type.getProperty("rotation");
+                        state = state.with(rotationProp, block.getState(RotationProperty));
+                    }
+
+                    values.remove("Base");
+
+                    Tag patternsTag = values.get("Patterns");
+                    if (patternsTag instanceof ListTag) {
+                        List<Tag> tempList = new ArrayList<>();
+                        for (Tag pattern : ((ListTag) patternsTag).getValue()) {
+                            if (pattern instanceof CompoundTag) {
+                                Map<String, Tag> patternMap = ((CompoundTag) pattern).getValue();
+                                Tag colorTag = patternMap.get("Color");
+
+                                CompoundTagBuilder builder = CompoundTagBuilder.create();
+                                builder.putAll(patternMap);
+                                if (colorTag instanceof IntTag) {
+                                    builder.putInt("Color", 15 - ((IntTag) colorTag).getValue());
+                                }
+                                tempList.add(builder.build());
+                            } else {
+                                tempList.add(pattern);
+                            }
+                        }
+                        values.put("Patterns", new ListTag(((ListTag) patternsTag).getType(), tempList));
+                    }
+                    return (B) state;
+                }
+            }
+        }
+        return block;
+    }
+
+    private static String convertBannerType(Integer oldType, boolean isWall) {
+        if (oldType == null) {
+            return null;
+        }
+        String color;
+        switch (oldType) {
+            case 0:
+                color = "black";
+                break;
+            case 1:
+                color = "red";
+                break;
+            case 2:
+                color = "green";
+                break;
+            case 3:
+                color = "brown";
+                break;
+            case 4:
+                color = "blue";
+                break;
+            case 5:
+                color = "purple";
+                break;
+            case 6:
+                color = "cyan";
+                break;
+            case 7:
+                color = "light_gray";
+                break;
+            case 8:
+                color = "gray";
+                break;
+            case 9:
+                color = "pink";
+                break;
+            case 10:
+                color = "lime";
+                break;
+            case 11:
+                color = "yellow";
+                break;
+            case 12:
+                color = "light_blue";
+                break;
+            case 13:
+                color = "magenta";
+                break;
+            case 14:
+                color = "orange";
+                break;
+            case 15:
+                color = "white";
+                break;
+            default:
+                return null;
+        }
+        return color + (isWall ? "_wall_banner" : "_banner");
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/BedBlockCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/BedBlockCompatibilityHandler.java
@@ -82,10 +82,7 @@ public class BedBlockCompatibilityHandler implements NBTCompatibilityHandler {
         return block;
     }
 
-    private String convertBedType(Integer oldType) {
-        if (oldType == null) {
-            return null;
-        }
+    private String convertBedType(int oldType) {
         String color;
         switch (oldType) {
             case 0:

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/BedBlockCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/BedBlockCompatibilityHandler.java
@@ -1,0 +1,144 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.extent.clipboard.io.legacycompat;
+
+import com.sk89q.jnbt.IntTag;
+import com.sk89q.jnbt.Tag;
+import com.sk89q.worldedit.registry.state.DirectionalProperty;
+import com.sk89q.worldedit.registry.state.EnumProperty;
+import com.sk89q.worldedit.registry.state.Property;
+import com.sk89q.worldedit.world.block.BlockState;
+import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BlockType;
+import com.sk89q.worldedit.world.block.BlockTypes;
+
+import java.util.Map;
+
+public class BedBlockCompatibilityHandler implements NBTCompatibilityHandler {
+
+    private static final DirectionalProperty FacingProperty;
+    private static final EnumProperty PartProperty;
+
+    static {
+        DirectionalProperty tempFacing;
+        EnumProperty tempPart;
+        try {
+            tempFacing = (DirectionalProperty) (Property<?>) BlockTypes.RED_BED.getProperty("facing");
+            tempPart = (EnumProperty) (Property<?>) BlockTypes.RED_BED.getProperty("part");
+        } catch (NullPointerException | IllegalArgumentException | ClassCastException e) {
+            tempFacing = null;
+            tempPart = null;
+        }
+        FacingProperty = tempFacing;
+        PartProperty = tempPart;
+    }
+
+    @Override
+    public <B extends BlockStateHolder<B>> boolean isAffectedBlock(B block) {
+        return block.getBlockType() == BlockTypes.RED_BED;
+    }
+
+    @Override
+    public <B extends BlockStateHolder<B>> B updateNBT(B block, Map<String, Tag> values) {
+        Tag typeTag = values.get("color");
+        if (typeTag instanceof IntTag) {
+            String bedType = convertBedType(((IntTag) typeTag).getValue());
+            if (bedType != null) {
+                BlockType type = BlockTypes.get("minecraft:" + bedType);
+                if (type != null) {
+                    BlockState state = type.getDefaultState();
+
+                    Property facingProp = type.getProperty("facing");
+                    state = state.with(facingProp, block.getState(FacingProperty));
+
+                    Property occupiedProp = type.getProperty("occupied");
+                    state = state.with(occupiedProp, false);
+
+                    Property partProp = type.getProperty("part");
+                    state = state.with(partProp, block.getState(PartProperty));
+
+                    values.remove("color");
+                    return (B) state;
+                }
+            }
+        }
+        return block;
+    }
+
+    private String convertBedType(Integer oldType) {
+        if (oldType == null) {
+            return null;
+        }
+        String color;
+        switch (oldType) {
+            case 0:
+                color = "white";
+                break;
+            case 1:
+                color = "orange";
+                break;
+            case 2:
+                color = "magenta";
+                break;
+            case 3:
+                color = "light_blue";
+                break;
+            case 4:
+                color = "yellow";
+                break;
+            case 5:
+                color = "lime";
+                break;
+            case 6:
+                color = "pink";
+                break;
+            case 7:
+                color = "gray";
+                break;
+            case 8:
+                color = "light_gray";
+                break;
+            case 9:
+                color = "cyan";
+                break;
+            case 10:
+                color = "purple";
+                break;
+            case 11:
+                color = "blue";
+                break;
+            case 12:
+                color = "brown";
+                break;
+            case 13:
+                color = "green";
+                break;
+            case 14:
+                color = "red";
+                break;
+            case 15:
+                color = "black";
+                break;
+            default:
+                return null;
+        }
+        return color + "_bed";
+    }
+}


### PR DESCRIPTION
These handlers are tested to work for a schematic saved in 1.12.2. Then loaded in 1.15.2.
Overall class layout used from SkullBlockCompatibilityHandler.

Prior to this PR. All schematic beds load as red beds. And all banners load as white banners. It is worth noting that for some crazy reason, mojang inverted the color integer values. That is handled as well.

I am not aware of any TileEntity blockstate conversion issues past these. Feel free to ping me on Discord if you want me to add more of these Compatibility handlers; I am willing.