### PR TITLE
Add image brush

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -53,6 +53,7 @@ import com.sk89q.worldedit.scripting.RhinoCraftScriptEngine;
 import com.sk89q.worldedit.session.SessionManager;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldedit.util.assets.ImageManager;
 import com.sk89q.worldedit.util.concurrency.EvenMoreExecutors;
 import com.sk89q.worldedit.util.concurrency.LazyReference;
 import com.sk89q.worldedit.util.eventbus.EventBus;
@@ -126,6 +127,7 @@ public final class WorldEdit {
             LazyReference.from(() -> new TranslationManager(
                     WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.CONFIGURATION).getResourceLoader()
             ));
+    private final ImageManager imageManager = new ImageManager(this);
 
     private final BlockFactory blockFactory = new BlockFactory(this);
     private final ItemFactory itemFactory = new ItemFactory(this);
@@ -249,6 +251,15 @@ public final class WorldEdit {
      */
     public TranslationManager getTranslationManager() {
         return translationManager.getValue();
+    }
+
+    /**
+     * Return the image manager.
+     *
+     * @return the image manager
+     */
+    public ImageManager getImageManager() {
+        return imageManager;
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/ImageBrush.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/ImageBrush.java
@@ -1,0 +1,112 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.command.tool.brush;
+
+import com.sk89q.worldedit.EditSession;
+import com.sk89q.worldedit.MaxChangedBlocksException;
+import com.sk89q.worldedit.function.pattern.Pattern;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.world.block.BaseBlock;
+import com.sk89q.worldedit.world.block.BlockTypes;
+
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.util.Random;
+
+public class ImageBrush implements Brush {
+
+    private static final Random RANDOM = new Random();
+    private final BufferedImage image;
+    private final double intensity;
+    private final boolean erase;
+    private final boolean flatten;
+    private final boolean randomize;
+
+    public ImageBrush(BufferedImage image, double intensity, boolean erase, boolean flatten, boolean randomize) {
+        this.image = image;
+        this.intensity = intensity;
+        this.erase = erase;
+        this.flatten = flatten;
+        this.randomize = randomize;
+    }
+
+    @Override
+    public void build(EditSession editSession, BlockVector3 position, Pattern pattern, double doubleSize) throws MaxChangedBlocksException {
+        // Resize the image
+        int size = (int) Math.ceil(doubleSize);
+        int diameter = size * 2 + 1;
+        BufferedImage resizedPattern = new BufferedImage(diameter, diameter, 1);
+        Graphics2D graphic = null;
+        try {
+            graphic = resizedPattern.createGraphics();
+            graphic.drawImage(this.image, 0, 0, diameter, diameter, null);
+        } finally {
+            graphic.dispose();
+        }
+
+        double random = randomize ? RANDOM.nextDouble() : 0;
+        for (int offX = -size; offX <= size; offX++) {
+            for (int offZ = -size; offZ <= size; offZ++) {
+                int posX = position.getX() + offX;
+                int posZ = position.getZ() + offZ;
+                int posY = editSession.getHighestTerrainBlock(posX, posZ, 0, 255, editSession.getMask());
+                BlockVector3 block = BlockVector3.at(posX, posY, posZ);
+                if (editSession.getMask() != null && !editSession.getMask().test(block)) {
+                    continue;
+                }
+
+                double height = getHeightAt(resizedPattern, offX + size, resizedPattern.getHeight() - 1 - (offZ + size));
+                // Add a bit of variation
+                if (randomize && random > 1 - height % 1) {
+                    height += 1;
+                }
+
+                BaseBlock baseBlock = erase ? null : editSession.getBlock(block).toBaseBlock();
+                for (int y = 0; y < height; y++) {
+                    if (erase) {
+                        // Remove blocks if using the erase flag
+                        editSession.setBlock(block.withY(block.getY() - y), BlockTypes.AIR.getDefaultState());
+                    } else if ((!flatten || block.getY() - y > position.getY()) && block.getY() - y >= 0) {
+                        // Only go up to the origin's level if flat mode is enabled
+                        if (!flatten || block.getY() + y <= position.getY()) {
+                            editSession.setBlock(block.withY(block.getY() + y), baseBlock);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private double getHeightAt(BufferedImage image, int x, int y) {
+        int rgb = image.getRGB(x, y);
+        if (rgb == 0) {
+            return 0;
+        }
+
+        int red = rgb >>> 16 & 0xFF;
+        int green = rgb >>> 8 & 0xFF;
+        int blue = rgb & 0xFF;
+
+        double scale = (red + blue + green) / 3D / 255D;
+        return scale * intensity;
+    }
+
+}
+

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/assets/AssetManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/assets/AssetManager.java
@@ -1,0 +1,127 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.util.assets;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.util.io.file.FilenameException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Abstract manager to lazy-load and temporarily cache custom assets.
+ *
+ * @param <T> type the be loaded
+ */
+public abstract class AssetManager<T> {
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Cache<String, T> assets = CacheBuilder.newBuilder().expireAfterAccess(5, TimeUnit.MINUTES).build();
+    private final WorldEdit worldEdit;
+    private final String[] assetExtensions;
+    private final String defaultExtension;
+    private final String assetDirectoryName;
+
+    /**
+     * Creates a new AssetManager to load and cache custom assets.
+     *
+     * @param worldEdit          worldedit instance
+     * @param assetDirectoryName subdirectory of the platform's WorldEdit dir
+     * @param defaultExtension   standard file extension associated with the asset
+     * @param assetExtensions    all possible file extentions associated with the asset
+     */
+    protected AssetManager(WorldEdit worldEdit, String assetDirectoryName, String defaultExtension, String... assetExtensions) {
+        this.worldEdit = worldEdit;
+        this.assetDirectoryName = assetDirectoryName;
+        this.defaultExtension = defaultExtension;
+        this.assetExtensions = assetExtensions;
+    }
+
+    /**
+     * Loads an asset.
+     *
+     * @param path path in assets directory, can be with and without its file extension
+     * @return asset if successfully loaded, null otherwise
+     */
+    @Nullable
+    public T getAsset(String path) {
+        // Remove file extension from mapped name
+        int extensionIndex = path.lastIndexOf('.');
+        String assetName = extensionIndex != -1 ? path.substring(0, extensionIndex) : path;
+        assetName = assetName.toLowerCase(Locale.ROOT);
+
+        T cached = assets.getIfPresent(assetName);
+        if (cached != null) {
+            return cached;
+        }
+
+        File assetsDir = new File(worldEdit.getPlatformManager().getConfiguration().getWorkingDirectory(), assetDirectoryName);
+        if (!assetsDir.exists() || !assetsDir.isDirectory()) {
+            return null;
+        }
+
+        File file;
+        try {
+            file = worldEdit.getSafeOpenFile(null, assetsDir, path, defaultExtension, assetExtensions);
+        } catch (FilenameException e) {
+            return null;
+        }
+
+        T asset = null;
+        try {
+            asset = loadAssetFromFile(file);
+        } catch (Exception e) {
+            logger.error("Error reading file from brushes directory", e);
+        }
+        if (asset == null) {
+            return null;
+        }
+
+        assets.put(assetName, asset);
+        return asset;
+    }
+
+    /**
+     * Returns an immutable set of asset keys.
+     *
+     * @return immutable set of asset keys
+     */
+    public Set<String> getCachedAssetKeys() {
+        return Collections.unmodifiableSet(assets.asMap().keySet());
+    }
+
+    /**
+     * Loads an asset from the given file if possible.
+     *
+     * @param file file to load
+     * @return loaded asset, or null otherwise
+     */
+    @Nullable
+    protected abstract T loadAssetFromFile(File file) throws Exception;
+
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/assets/ImageManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/assets/ImageManager.java
@@ -1,0 +1,45 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.util.assets;
+
+import com.sk89q.worldedit.WorldEdit;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import javax.annotation.Nullable;
+import javax.imageio.ImageIO;
+
+/**
+ * Loads and caches image files from WorldEdit's assets directory.
+ */
+public class ImageManager extends AssetManager<BufferedImage> {
+
+    public ImageManager(WorldEdit worldEdit) {
+        super(worldEdit, "assets", "png", "png", "jpg", "jpeg");
+    }
+
+    @Nullable
+    public BufferedImage loadAssetFromFile(File file) throws Exception {
+        if (!file.exists()) {
+            return null;
+        }
+        return ImageIO.read(file);
+    }
+}

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -27,6 +27,8 @@
     "worldedit.brush.gravity.equip": "Gravity brush equipped ({0}).",
     "worldedit.brush.butcher.equip": "Butcher brush equipped ({0}).",
     "worldedit.brush.operation.equip": "Set brush to {0}.",
+    "worldedit.brush.image.equip": "Image brush equipped ({0}).",
+    "worldedit.brush.image.unknown": "Unknown image brush: {0}.\nList of available brushes: {1}",
     "worldedit.brush.none.equip": "Brush unbound from your current item.",
 
     "worldedit.setbiome.changed": "Biomes were changed for approximately {0} blocks.",


### PR DESCRIPTION
As per Wiz' request, copied over goBrush's image brush functionality.

Since goBrush has insultingly bad code, doesn't publish 1.15 builds publicly, and since I thought WorldEdit might benefit from such a functionality, this pr exists. :>

Using the ImageBrush, a bufferedimage is resized and put at the highest point of the clicked location. The intensity influences the brushes height, fill sets block above or removes block from below, flat flattens surrounding blocks at max to the the origin's height.
https://streamable.com/x0r400

Todo:
- tabcompletion for the imagenames (not familiar with your command lib, how can this be achieved?)
- ~~a manager for loading and getting the images (where to put the manager in structurally?)~~
- ~~brush manager holding (just threw it somewhere, also couldn't find _one_ center point to call the load from)~~
- ship default image brushes
- ~~(approach to image loading and resizing in general?)~~
- Rebase and squash when done
