### PR TITLE
Add tracing feature to EditSessions

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -396,8 +396,11 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
         LocalSession session = WorldEdit.getInstance().getSessionManager().get(wePlayer);
         BlockBag blockBag = session.getBlockBag(wePlayer);
 
-        EditSession editSession = WorldEdit.getInstance().getEditSessionFactory()
-                .getEditSession(wePlayer.getWorld(), session.getBlockChangeLimit(), blockBag, wePlayer);
+        EditSession editSession = WorldEdit.getInstance().newEditSessionBuilder()
+            .locatableActor(wePlayer)
+            .maxBlocks(session.getBlockChangeLimit())
+            .blockBag(blockBag)
+            .build();
         editSession.enableStandardMode();
 
         return editSession;

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -417,7 +417,7 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
         LocalSession session = WorldEdit.getInstance().getSessionManager().get(wePlayer);
 
         session.remember(editSession);
-        editSession.flushSession();
+        editSession.close();
 
         WorldEdit.getInstance().flushBlockBag(wePlayer, editSession);
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -339,10 +339,9 @@ public class EditSession implements Extent, AutoCloseable {
     /**
      * Get the current list of active tracing extents.
      */
-    @Nullable
     private List<TracingExtent> getActiveTracingExtents() {
         if (tracingExtents == null) {
-            return null;
+            return ImmutableList.of();
         }
         return tracingExtents.stream()
             .filter(TracingExtent::isActive)
@@ -885,10 +884,10 @@ public class EditSession implements Extent, AutoCloseable {
     }
 
     private void dumpTracingInformation() {
-        List<TracingExtent> tracingExtents = getActiveTracingExtents();
-        if (tracingExtents == null) {
+        if (this.tracingExtents == null) {
             return;
         }
+        List<TracingExtent> tracingExtents = getActiveTracingExtents();
         assert actor != null;
         if (tracingExtents.isEmpty()) {
             actor.printError(TranslatableComponent.of("worldedit.trace.no-tracing-extents"));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -915,8 +915,8 @@ public class EditSession implements Extent, AutoCloseable {
             TracingExtent failure = stack.get(0);
             actor.printDebug(TranslatableComponent.builder("worldedit.trace.action-failed")
                 .args(
-                    TextComponent.of(position.toString()),
                     TextComponent.of(failure.getFailedActions().get(position).toString()),
+                    TextComponent.of(position.toString()),
                     TextComponent.of(failure.getExtent().getClass().getName())
                 )
                 .build());

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -29,6 +29,7 @@ import com.sk89q.worldedit.extent.ChangeSetExtent;
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.extent.MaskingExtent;
 import com.sk89q.worldedit.extent.NullExtent;
+import com.sk89q.worldedit.extent.TracingExtent;
 import com.sk89q.worldedit.extent.buffer.ForgetfulExtentBuffer;
 import com.sk89q.worldedit.extent.cache.LastAccessExtentCache;
 import com.sk89q.worldedit.extent.inventory.BlockBag;
@@ -128,6 +129,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -201,6 +203,8 @@ public class EditSession implements Extent, AutoCloseable {
     private final Extent bypassHistory;
     private final Extent bypassNone;
 
+    private final @Nullable List<TracingExtent> tracingExtents;
+
     private ReorderMode reorderMode = ReorderMode.MULTI_STAGE;
 
     private Mask oldMask;
@@ -214,10 +218,17 @@ public class EditSession implements Extent, AutoCloseable {
      * @param blockBag an optional {@link BlockBag} to use, otherwise null
      * @param event the event to call with the extent
      */
-    EditSession(EventBus eventBus, World world, int maxBlocks, @Nullable BlockBag blockBag, EditSessionEvent event) {
+    EditSession(EventBus eventBus, World world, int maxBlocks, @Nullable BlockBag blockBag, EditSessionEvent event,
+                boolean tracing) {
         checkNotNull(eventBus);
         checkArgument(maxBlocks >= -1, "maxBlocks >= -1 required");
         checkNotNull(event);
+
+        if (tracing) {
+            this.tracingExtents = new ArrayList<>();
+        } else {
+            this.tracingExtents = null;
+        }
 
         this.world = world;
 
@@ -227,48 +238,48 @@ public class EditSession implements Extent, AutoCloseable {
             Extent extent;
 
             // These extents are ALWAYS used
-            extent = sideEffectExtent = new SideEffectExtent(world);
+            extent = traceIfNeeded(sideEffectExtent = new SideEffectExtent(world));
             if (watchdog != null) {
                 // Reset watchdog before world placement
                 WatchdogTickingExtent watchdogExtent = new WatchdogTickingExtent(extent, watchdog);
-                extent = watchdogExtent;
+                extent = traceIfNeeded(watchdogExtent);
                 watchdogExtents.add(watchdogExtent);
             }
-            extent = survivalExtent = new SurvivalModeExtent(extent, world);
-            extent = new BlockQuirkExtent(extent, world);
-            extent = new BiomeQuirkExtent(extent);
-            extent = new ChunkLoadingExtent(extent, world);
-            extent = new LastAccessExtentCache(extent);
-            extent = blockBagExtent = new BlockBagExtent(extent, blockBag);
+            extent = traceIfNeeded(survivalExtent = new SurvivalModeExtent(extent, world));
+            extent = traceIfNeeded(new BlockQuirkExtent(extent, world));
+            extent = traceIfNeeded(new BiomeQuirkExtent(extent));
+            extent = traceIfNeeded(new ChunkLoadingExtent(extent, world));
+            extent = traceIfNeeded(new LastAccessExtentCache(extent));
+            extent = traceIfNeeded(blockBagExtent = new BlockBagExtent(extent, blockBag));
             extent = wrapExtent(extent, eventBus, event, Stage.BEFORE_CHANGE);
-            this.bypassReorderHistory = new DataValidatorExtent(extent, world);
+            this.bypassReorderHistory = traceIfNeeded(new DataValidatorExtent(extent, world));
 
             // This extent can be skipped by calling rawSetBlock()
-            extent = reorderExtent = new MultiStageReorder(extent, false);
-            extent = chunkBatchingExtent = new ChunkBatchingExtent(extent);
+            extent = traceIfNeeded(reorderExtent = new MultiStageReorder(extent, false));
+            extent = traceIfNeeded(chunkBatchingExtent = new ChunkBatchingExtent(extent));
             extent = wrapExtent(extent, eventBus, event, Stage.BEFORE_REORDER);
             if (watchdog != null) {
                 // reset before buffering extents, since they may buffer all changes
                 // before the world-placement reset can happen, and still cause halts
                 WatchdogTickingExtent watchdogExtent = new WatchdogTickingExtent(extent, watchdog);
-                extent = watchdogExtent;
+                extent = traceIfNeeded(watchdogExtent);
                 watchdogExtents.add(watchdogExtent);
             }
-            this.bypassHistory = new DataValidatorExtent(extent, world);
+            this.bypassHistory = traceIfNeeded(new DataValidatorExtent(extent, world));
 
             // These extents can be skipped by calling smartSetBlock()
-            extent = new ChangeSetExtent(extent, changeSet);
-            extent = maskingExtent = new MaskingExtent(extent, Masks.alwaysTrue());
-            extent = changeLimiter = new BlockChangeLimiter(extent, maxBlocks);
+            extent = traceIfNeeded(new ChangeSetExtent(extent, changeSet));
+            extent = traceIfNeeded(maskingExtent = new MaskingExtent(extent, Masks.alwaysTrue()));
+            extent = traceIfNeeded(changeLimiter = new BlockChangeLimiter(extent, maxBlocks));
             extent = wrapExtent(extent, eventBus, event, Stage.BEFORE_HISTORY);
-            this.bypassNone = new DataValidatorExtent(extent, world);
+            this.bypassNone = traceIfNeeded(new DataValidatorExtent(extent, world));
         } else {
             Extent extent = new NullExtent();
-            extent = survivalExtent = new SurvivalModeExtent(extent, NullWorld.getInstance());
-            extent = blockBagExtent = new BlockBagExtent(extent, blockBag);
-            extent = reorderExtent = new MultiStageReorder(extent, false);
-            extent = maskingExtent = new MaskingExtent(extent, Masks.alwaysTrue());
-            extent = changeLimiter = new BlockChangeLimiter(extent, maxBlocks);
+            extent = traceIfNeeded(survivalExtent = new SurvivalModeExtent(extent, NullWorld.getInstance()));
+            extent = traceIfNeeded(blockBagExtent = new BlockBagExtent(extent, blockBag));
+            extent = traceIfNeeded(reorderExtent = new MultiStageReorder(extent, false));
+            extent = traceIfNeeded(maskingExtent = new MaskingExtent(extent, Masks.alwaysTrue()));
+            extent = traceIfNeeded(changeLimiter = new BlockChangeLimiter(extent, maxBlocks));
             this.bypassReorderHistory = extent;
             this.bypassHistory = extent;
             this.bypassNone = extent;
@@ -277,10 +288,26 @@ public class EditSession implements Extent, AutoCloseable {
         setReorderMode(this.reorderMode);
     }
 
+    private Extent traceIfNeeded(Extent input) {
+        Extent output = input;
+        if (tracingExtents != null) {
+            TracingExtent newExtent = new TracingExtent(input);
+            output = newExtent;
+            tracingExtents.add(newExtent);
+        }
+        return output;
+    }
+
     private Extent wrapExtent(Extent extent, EventBus eventBus, EditSessionEvent event, Stage stage) {
+        // NB: the event does its own tracing
         event = event.clone(stage);
         event.setExtent(extent);
+        boolean tracing = tracingExtents != null;
+        event.setTracing(tracing);
         eventBus.post(event);
+        if (tracing) {
+            tracingExtents.addAll(event.getTracingExtents());
+        }
         return event.getExtent();
     }
 
@@ -296,6 +323,21 @@ public class EditSession implements Extent, AutoCloseable {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Get the current list of active tracing extents.
+     *
+     * <em>Internal use only.</em>
+     */
+    @Nullable
+    public List<TracingExtent> getTracingExtents() {
+        if (tracingExtents == null) {
+            return null;
+        }
+        return tracingExtents.stream()
+            .filter(TracingExtent::isActive)
+            .collect(Collectors.toList());
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSessionBuilder.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSessionBuilder.java
@@ -22,7 +22,6 @@ package com.sk89q.worldedit;
 import javax.annotation.Nullable;
 
 import com.google.common.base.Preconditions;
-import com.sk89q.worldedit.event.extent.EditSessionEvent;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extension.platform.Locatable;
 import com.sk89q.worldedit.extent.Extent;
@@ -36,20 +35,17 @@ import com.sk89q.worldedit.world.World;
 public final class EditSessionBuilder {
 
     private final EventBus eventBus;
-    @Nullable
-    private World world;
+    private @Nullable World world;
     private int maxBlocks = -1;
-    private Actor actor;
-    @Nullable
-    private BlockBag blockBag;
+    private @Nullable Actor actor;
+    private @Nullable BlockBag blockBag;
     private boolean tracing;
 
     EditSessionBuilder(EventBus eventBus) {
         this.eventBus = eventBus;
     }
 
-    @Nullable
-    public World getWorld() {
+    public @Nullable World getWorld() {
         return world;
     }
 
@@ -79,7 +75,7 @@ public final class EditSessionBuilder {
         return this;
     }
 
-    public Actor getActor() {
+    public @Nullable Actor getActor() {
         return actor;
     }
 
@@ -89,13 +85,12 @@ public final class EditSessionBuilder {
      * @param actor the actor
      * @return this builder
      */
-    public EditSessionBuilder actor(Actor actor) {
+    public EditSessionBuilder actor(@Nullable Actor actor) {
         this.actor = actor;
         return this;
     }
 
-    @Nullable
-    public BlockBag getBlockBag() {
+    public @Nullable BlockBag getBlockBag() {
         return blockBag;
     }
 
@@ -142,10 +137,9 @@ public final class EditSessionBuilder {
      * @return the new EditSession
      */
     public EditSession build() {
-        EditSessionEvent event = new EditSessionEvent(world, actor, maxBlocks, null);
         if (WorldEdit.getInstance().getConfiguration().traceUnflushedSessions) {
-            return new TracedEditSession(eventBus, world, maxBlocks, blockBag, event, tracing);
+            return new TracedEditSession(eventBus, world, maxBlocks, blockBag, actor, tracing);
         }
-        return new EditSession(eventBus, world, maxBlocks, blockBag, event, tracing);
+        return new EditSession(eventBus, world, maxBlocks, blockBag, actor, tracing);
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSessionBuilder.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSessionBuilder.java
@@ -19,8 +19,6 @@
 
 package com.sk89q.worldedit;
 
-import javax.annotation.Nullable;
-
 import com.google.common.base.Preconditions;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extension.platform.Locatable;
@@ -28,6 +26,8 @@ import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.extent.inventory.BlockBag;
 import com.sk89q.worldedit.util.eventbus.EventBus;
 import com.sk89q.worldedit.world.World;
+
+import javax.annotation.Nullable;
 
 /**
  * A builder-style factory for {@link EditSession EditSessions}.
@@ -106,7 +106,7 @@ public final class EditSessionBuilder {
     }
 
     /**
-     * Is tracing enabled?
+     * Check if tracing is enabled.
      *
      * <em>Internal use only.</em>
      */

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSessionBuilder.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSessionBuilder.java
@@ -1,0 +1,151 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit;
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.Preconditions;
+import com.sk89q.worldedit.event.extent.EditSessionEvent;
+import com.sk89q.worldedit.extension.platform.Actor;
+import com.sk89q.worldedit.extension.platform.Locatable;
+import com.sk89q.worldedit.extent.Extent;
+import com.sk89q.worldedit.extent.inventory.BlockBag;
+import com.sk89q.worldedit.util.eventbus.EventBus;
+import com.sk89q.worldedit.world.World;
+
+/**
+ * A builder-style factory for {@link EditSession EditSessions}.
+ */
+public final class EditSessionBuilder {
+
+    private final EventBus eventBus;
+    @Nullable
+    private World world;
+    private int maxBlocks = -1;
+    private Actor actor;
+    @Nullable
+    private BlockBag blockBag;
+    private boolean tracing;
+
+    EditSessionBuilder(EventBus eventBus) {
+        this.eventBus = eventBus;
+    }
+
+    @Nullable
+    public World getWorld() {
+        return world;
+    }
+
+    /**
+     * Set the world for the {@link EditSession}.
+     *
+     * @param world the world
+     * @return this builder
+     */
+    public EditSessionBuilder world(@Nullable World world) {
+        this.world = world;
+        return this;
+    }
+
+    public int getMaxBlocks() {
+        return maxBlocks;
+    }
+
+    /**
+     * Set the maximum blocks to change for the {@link EditSession}.
+     *
+     * @param maxBlocks the maximum blocks to change
+     * @return this builder
+     */
+    public EditSessionBuilder maxBlocks(int maxBlocks) {
+        this.maxBlocks = maxBlocks;
+        return this;
+    }
+
+    public Actor getActor() {
+        return actor;
+    }
+
+    /**
+     * Set the actor who owns the {@link EditSession}.
+     *
+     * @param actor the actor
+     * @return this builder
+     */
+    public EditSessionBuilder actor(Actor actor) {
+        this.actor = actor;
+        return this;
+    }
+
+    @Nullable
+    public BlockBag getBlockBag() {
+        return blockBag;
+    }
+
+    /**
+     * Set the block bag for the {@link EditSession}.
+     *
+     * @param blockBag the block bag
+     * @return this builder
+     */
+    public EditSessionBuilder blockBag(@Nullable BlockBag blockBag) {
+        this.blockBag = blockBag;
+        return this;
+    }
+
+    /**
+     * Is tracing enabled?
+     *
+     * <em>Internal use only.</em>
+     */
+    public boolean isTracing() {
+        return tracing;
+    }
+
+    /**
+     * Set tracing enabled/disabled.
+     *
+     * <em>Internal use only.</em>
+     */
+    public EditSessionBuilder tracing(boolean tracing) {
+        this.tracing = tracing;
+        return this;
+    }
+
+    // Extended methods
+    public <A extends Actor & Locatable> EditSessionBuilder locatableActor(A locatable) {
+        Extent extent = locatable.getExtent();
+        Preconditions.checkArgument(extent instanceof World, "%s is not located in a World", locatable);
+        return world(((World) extent)).actor(locatable);
+    }
+
+    /**
+     * Build the {@link EditSession} using properties described in this builder.
+     *
+     * @return the new EditSession
+     */
+    public EditSession build() {
+        EditSessionEvent event = new EditSessionEvent(world, actor, maxBlocks, null);
+        if (WorldEdit.getInstance().getConfiguration().traceUnflushedSessions) {
+            return new TracedEditSession(eventBus, world, maxBlocks, blockBag, event, tracing);
+        }
+        return new EditSession(eventBus, world, maxBlocks, blockBag, event, tracing);
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSessionFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSessionFactory.java
@@ -22,7 +22,6 @@ package com.sk89q.worldedit;
 import com.sk89q.worldedit.event.extent.EditSessionEvent;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extent.inventory.BlockBag;
-import com.sk89q.worldedit.util.eventbus.EventBus;
 import com.sk89q.worldedit.world.World;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -34,7 +33,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * <p>It is no longer possible to replace the instance of this in WorldEdit
  * with a custom one. Use {@link EditSessionEvent} to override
  * the creation of {@link EditSession}s.</p>
+ *
+ * @deprecated Using the ever-extending factory methods is deprecated. Replace with {@link EditSessionBuilder},
+ * which in most cases will be as simple as calling {@code builder.world(world).build()}.
  */
+@Deprecated
 public class EditSessionFactory {
 
     /**
@@ -138,16 +141,10 @@ public class EditSessionFactory {
      */
     static final class EditSessionFactoryImpl extends EditSessionFactory {
 
-        private final EventBus eventBus;
-
         /**
          * Create a new factory.
-         *
-         * @param eventBus the event bus
          */
-        EditSessionFactoryImpl(EventBus eventBus) {
-            checkNotNull(eventBus);
-            this.eventBus = eventBus;
+        EditSessionFactoryImpl() {
         }
 
         @Override
@@ -167,10 +164,12 @@ public class EditSessionFactory {
 
         @Override
         public EditSession getEditSession(World world, int maxBlocks, BlockBag blockBag, Actor actor) {
-            if (WorldEdit.getInstance().getConfiguration().traceUnflushedSessions) {
-                return new TracedEditSession(eventBus, world, maxBlocks, blockBag, new EditSessionEvent(world, actor, maxBlocks, null));
-            }
-            return new EditSession(eventBus, world, maxBlocks, blockBag, new EditSessionEvent(world, actor, maxBlocks, null));
+            return WorldEdit.getInstance().newEditSessionBuilder()
+                .world(world)
+                .maxBlocks(maxBlocks)
+                .blockBag(blockBag)
+                .actor(actor)
+                .build();
         }
 
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSessionFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSessionFactory.java
@@ -35,7 +35,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * the creation of {@link EditSession}s.</p>
  *
  * @deprecated Using the ever-extending factory methods is deprecated. Replace with {@link EditSessionBuilder},
- * which in most cases will be as simple as calling {@code builder.world(world).build()}.
+ *     which in most cases will be as simple as calling {@code builder.world(world).build()}.
  */
 @Deprecated
 public class EditSessionFactory {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -109,6 +109,7 @@ public class LocalSession {
     private transient World worldOverride;
     private transient boolean tickingWatchdog = true;
     private transient boolean hasBeenToldVersion;
+    private transient boolean tracingActions;
 
     // Saved properties
     private String lastScript;
@@ -303,6 +304,14 @@ public class LocalSession {
 
     public void setTickingWatchdog(boolean tickingWatchdog) {
         this.tickingWatchdog = tickingWatchdog;
+    }
+
+    public boolean isTracingActions() {
+        return tracingActions;
+    }
+
+    public void setTracingActions(boolean tracingActions) {
+        this.tracingActions = tracingActions;
     }
 
     /**
@@ -979,19 +988,6 @@ public class LocalSession {
      * @return an edit session
      */
     public EditSession createEditSession(Actor actor) {
-        return createEditSession(actor, false);
-    }
-
-    /**
-     * Construct a new edit session, optionally with tracing.
-     *
-     * <em>Internal use only.</em>
-     *
-     * @param actor the actor
-     * @param tracing if tracing is enabled
-     * @return an edit session
-     */
-    public EditSession createEditSession(Actor actor, boolean tracing) {
         checkNotNull(actor);
 
         World world = null;
@@ -1006,7 +1002,7 @@ public class LocalSession {
             .world(world)
             .actor(actor)
             .maxBlocks(getBlockChangeLimit())
-            .tracing(tracing);
+            .tracing(isTracingActions());
         if (actor.isPlayer() && actor instanceof Player) {
             builder.blockBag(getBlockBag((Player) actor));
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/TracedEditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/TracedEditSession.java
@@ -19,7 +19,10 @@
 
 package com.sk89q.worldedit;
 
+import javax.annotation.Nullable;
+
 import com.sk89q.worldedit.event.extent.EditSessionEvent;
+import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extent.inventory.BlockBag;
 import com.sk89q.worldedit.util.eventbus.EventBus;
 import com.sk89q.worldedit.world.World;
@@ -29,9 +32,10 @@ import com.sk89q.worldedit.world.World;
  */
 class TracedEditSession extends EditSession {
 
-    TracedEditSession(EventBus eventBus, World world, int maxBlocks, BlockBag blockBag, EditSessionEvent event,
+    TracedEditSession(EventBus eventBus, @Nullable World world, int maxBlocks, @Nullable BlockBag blockBag,
+                      @Nullable Actor actor,
                       boolean tracing) {
-        super(eventBus, world, maxBlocks, blockBag, event, tracing);
+        super(eventBus, world, maxBlocks, blockBag, actor, tracing);
     }
 
     private final Throwable stacktrace = new Throwable("Creation trace.");

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/TracedEditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/TracedEditSession.java
@@ -24,10 +24,14 @@ import com.sk89q.worldedit.extent.inventory.BlockBag;
 import com.sk89q.worldedit.util.eventbus.EventBus;
 import com.sk89q.worldedit.world.World;
 
-public class TracedEditSession extends EditSession {
+/**
+ * Internal use only.
+ */
+class TracedEditSession extends EditSession {
 
-    TracedEditSession(EventBus eventBus, World world, int maxBlocks, BlockBag blockBag, EditSessionEvent event) {
-        super(eventBus, world, maxBlocks, blockBag, event);
+    TracedEditSession(EventBus eventBus, World world, int maxBlocks, BlockBag blockBag, EditSessionEvent event,
+                      boolean tracing) {
+        super(eventBus, world, maxBlocks, blockBag, event, tracing);
     }
 
     private final Throwable stacktrace = new Throwable("Creation trace.");

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/TracedEditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/TracedEditSession.java
@@ -19,13 +19,12 @@
 
 package com.sk89q.worldedit;
 
-import javax.annotation.Nullable;
-
-import com.sk89q.worldedit.event.extent.EditSessionEvent;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extent.inventory.BlockBag;
 import com.sk89q.worldedit.util.eventbus.EventBus;
 import com.sk89q.worldedit.world.World;
+
+import javax.annotation.Nullable;
 
 /**
  * Internal use only.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -38,6 +38,7 @@ import com.sk89q.worldedit.extension.factory.MaskFactory;
 import com.sk89q.worldedit.extension.factory.PatternFactory;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extension.platform.Capability;
+import com.sk89q.worldedit.extension.platform.Locatable;
 import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.extension.platform.PlatformManager;
 import com.sk89q.worldedit.extent.inventory.BlockBag;
@@ -64,6 +65,7 @@ import com.sk89q.worldedit.util.io.file.InvalidFilenameException;
 import com.sk89q.worldedit.util.task.SimpleSupervisor;
 import com.sk89q.worldedit.util.task.Supervisor;
 import com.sk89q.worldedit.util.translation.TranslationManager;
+import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.registry.BundledBlockData;
@@ -113,7 +115,8 @@ public final class WorldEdit {
 
     private final EventBus eventBus = new EventBus();
     private final PlatformManager platformManager = new PlatformManager(this);
-    private final EditSessionFactory editSessionFactory = new EditSessionFactory.EditSessionFactoryImpl(eventBus);
+    @Deprecated
+    private final EditSessionFactory editSessionFactory = new EditSessionFactory.EditSessionFactoryImpl();
     private final SessionManager sessions = new SessionManager(this);
     private final ListeningExecutorService executorService = MoreExecutors.listeningDecorator(
             EvenMoreExecutors.newBoundedCachedThreadPool(0, 1, 20, "WorldEdit Task Executor - %s"));
@@ -761,9 +764,39 @@ public final class WorldEdit {
 
     /**
      * Get a factory for {@link EditSession}s.
+     *
+     * @deprecated Use {@link #newEditSessionBuilder()} instead. See {@link EditSessionFactory} for details.
      */
+    @Deprecated
     public EditSessionFactory getEditSessionFactory() {
         return editSessionFactory;
+    }
+
+    /**
+     * Create a builder for {@link EditSession}s.
+     */
+    public EditSessionBuilder newEditSessionBuilder() {
+        return new EditSessionBuilder(eventBus);
+    }
+
+    /**
+     * Shorthand for {@code newEditSessionBuilder().world(world).build()}.
+     *
+     * @param world the world
+     * @return the new {@link EditSession}
+     */
+    public EditSession newEditSession(@Nullable World world) {
+        return newEditSessionBuilder().world(world).build();
+    }
+
+    /**
+     * Shorthand for {@code newEditSessionBuilder().locatableActor(locatableActor).build()}.
+     *
+     * @param locatableActor the actor
+     * @return the new {@link EditSession}
+     */
+    public <A extends Actor & Locatable> EditSession newEditSession(A locatableActor) {
+        return newEditSessionBuilder().locatableActor(locatableActor).build();
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -747,7 +747,7 @@ public final class WorldEdit {
             logger.warn("Failed to execute script", e);
         } finally {
             for (EditSession editSession : scriptContext.getEditSessions()) {
-                editSession.flushSession();
+                editSession.close();
                 session.remember(editSession);
             }
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/UtilityCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/UtilityCommands.java
@@ -504,7 +504,7 @@ public class UtilityCommands {
         }
 
         session.remember(editSession);
-        editSession.flushSession();
+        editSession.close();
         return killed;
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/WorldEditCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/WorldEditCommands.java
@@ -19,16 +19,6 @@
 
 package com.sk89q.worldedit.command;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.TextStyle;
-import java.time.zone.ZoneRulesException;
-import java.util.List;
-
 import com.google.common.io.Files;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;
@@ -57,6 +47,16 @@ import org.enginehub.piston.annotation.CommandContainer;
 import org.enginehub.piston.annotation.param.Arg;
 import org.enginehub.piston.annotation.param.ArgFlag;
 import org.enginehub.piston.annotation.param.Switch;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.TextStyle;
+import java.time.zone.ZoneRulesException;
+import java.util.List;
 
 @CommandContainer(superTypes = CommandPermissionsConditionGenerator.Registration.class)
 public class WorldEditCommands {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/EnumConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/EnumConverter.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit.command.argument;
 import com.google.common.collect.ImmutableSet;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.command.util.HookMode;
+import com.sk89q.worldedit.extent.TracingExtent;
 import com.sk89q.worldedit.util.SideEffect;
 import com.sk89q.worldedit.util.TreeGenerator;
 import org.enginehub.piston.CommandManager;
@@ -55,6 +56,8 @@ public final class EnumConverter {
                     null));
         commandManager.registerConverter(Key.of(HookMode.class),
             basic(HookMode.class));
+        commandManager.registerConverter(Key.of(TracingExtent.Action.class),
+            basic(TracingExtent.Action.class));
     }
 
     private static <E extends Enum<E>> ArgumentConverter<E> basic(Class<E> enumClass) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/event/extent/EditSessionEvent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/event/extent/EditSessionEvent.java
@@ -28,9 +28,9 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.sk89q.worldedit.EditSession.Stage;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/event/extent/EditSessionEvent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/event/extent/EditSessionEvent.java
@@ -23,11 +23,14 @@ import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.event.Event;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extent.Extent;
+import com.sk89q.worldedit.extent.TracingExtent;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.sk89q.worldedit.EditSession.Stage;
@@ -65,7 +68,9 @@ public class EditSessionEvent extends Event {
     private final Actor actor;
     private final int maxBlocks;
     private final Stage stage;
+    private final List<TracingExtent> tracingExtents = new ArrayList<>();
     private Extent extent;
+    private boolean tracing;
 
     /**
      * Create a new event.
@@ -135,7 +140,31 @@ public class EditSessionEvent extends Event {
      */
     public void setExtent(Extent extent) {
         checkNotNull(extent);
+        if (tracing && extent != this.extent) {
+            TracingExtent tracingExtent = new TracingExtent(extent);
+            extent = tracingExtent;
+            tracingExtents.add(tracingExtent);
+        }
         this.extent = extent;
+    }
+
+    /**
+     * Set tracing enabled, with the current extent as the "base".
+     *
+     * <em>Internal use only.</em>
+     * @param tracing if tracing is enabled
+     */
+    public void setTracing(boolean tracing) {
+        this.tracing = tracing;
+    }
+
+    /**
+     * Get the current list of tracing extents.
+     *
+     * <em>Internal use only.</em>
+     */
+    public List<TracingExtent> getTracingExtents() {
+        return tracingExtents;
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
@@ -321,8 +321,7 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
             BlockVector3 spot = BlockVector3.at(x, y - 1, z);
             final World world = getWorld();
             if (!world.getBlock(spot).getBlockType().getMaterial().isMovementBlocker()) {
-                try (EditSession session =
-                         WorldEdit.getInstance().newEditSession(this)) {
+                try (EditSession session = WorldEdit.getInstance().newEditSession(this)) {
                     session.setBlock(spot, BlockTypes.GLASS.getDefaultState());
                 } catch (MaxChangedBlocksException ignored) {
                 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
@@ -321,7 +321,8 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
             BlockVector3 spot = BlockVector3.at(x, y - 1, z);
             final World world = getWorld();
             if (!world.getBlock(spot).getBlockType().getMaterial().isMovementBlocker()) {
-                try (EditSession session = WorldEdit.getInstance().getEditSessionFactory().getEditSession(world, 1, this)) {
+                try (EditSession session =
+                         WorldEdit.getInstance().newEditSession(this)) {
                     session.setBlock(spot, BlockTypes.GLASS.getDefaultState());
                 } catch (MaxChangedBlocksException ignored) {
                 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
@@ -534,7 +534,7 @@ public final class PlatformCommandManager {
             if (editSessionOpt.isPresent()) {
                 EditSession editSession = editSessionOpt.get();
                 session.remember(editSession);
-                editSession.flushSession();
+                editSession.close();
 
                 if (config.profile) {
                     long time = System.currentTimeMillis() - start;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/TracingExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/TracingExtent.java
@@ -19,28 +19,21 @@
 
 package com.sk89q.worldedit.extent;
 
-import javax.annotation.Nullable;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.Set;
-import java.util.function.BiPredicate;
-
-import com.google.common.collect.Collections2;
-import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.entity.Entity;
-import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.collection.BlockMap;
 import com.sk89q.worldedit.world.biome.BiomeType;
-import com.sk89q.worldedit.world.biome.BiomeTypes;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
-import com.sk89q.worldedit.world.block.BlockTypes;
-import com.sk89q.worldedit.world.entity.EntityTypes;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * An extent that can report back if an operation fails due to the extent(s) below it.
@@ -50,26 +43,9 @@ import com.sk89q.worldedit.world.entity.EntityTypes;
 public class TracingExtent extends AbstractDelegateExtent {
 
     public enum Action {
-        SET_BLOCK((extent, loc) -> {
-            try {
-                return extent.setBlock(loc, BlockTypes.STICKY_PISTON.getDefaultState());
-            } catch (WorldEditException e) {
-                throw new RuntimeException(e);
-            }
-        }),
-        SET_BIOME((extent, loc) ->
-            extent.setBiome(loc.toBlockVector2(), BiomeTypes.DESERT)
-        ),
-        CREATE_ENTITY((extent, loc) ->
-            extent.createEntity(new Location(extent, loc.toVector3()), new BaseEntity(EntityTypes.COW)) != null
-        ),
-        ;
-
-        public final BiPredicate<Extent, BlockVector3> test;
-
-        Action(BiPredicate<Extent, BlockVector3> test) {
-            this.test = test;
-        }
+        SET_BLOCK,
+        SET_BIOME,
+        CREATE_ENTITY,
     }
 
     private final Set<BlockVector3> touchedLocations = Collections.newSetFromMap(BlockMap.create());
@@ -109,12 +85,11 @@ public class TracingExtent extends AbstractDelegateExtent {
     }
 
     @Override
-    public boolean setBiome(BlockVector2 position, BiomeType biome) {
-        BlockVector3 blockVector3 = position.toBlockVector3();
-        touchedLocations.add(blockVector3);
+    public boolean setBiome(BlockVector3 position, BiomeType biome) {
+        touchedLocations.add(position);
         boolean result = super.setBiome(position, biome);
         if (!result) {
-            failedActions.put(blockVector3, Action.SET_BIOME);
+            failedActions.put(position, Action.SET_BIOME);
         }
         return result;
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/TracingExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/TracingExtent.java
@@ -1,0 +1,125 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.extent;
+
+import javax.annotation.Nullable;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.function.BiPredicate;
+
+import com.google.common.collect.ImmutableSet;
+import com.sk89q.worldedit.WorldEditException;
+import com.sk89q.worldedit.entity.BaseEntity;
+import com.sk89q.worldedit.entity.Entity;
+import com.sk89q.worldedit.math.BlockVector2;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldedit.world.biome.BiomeType;
+import com.sk89q.worldedit.world.biome.BiomeTypes;
+import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BlockTypes;
+import com.sk89q.worldedit.world.entity.EntityTypes;
+
+/**
+ * An extent that can report back if an operation fails due to the extent(s) below it.
+ *
+ * <em>Internal use only.</em>
+ */
+public class TracingExtent extends AbstractDelegateExtent {
+
+    public enum Action {
+        SET_BLOCK((extent, loc) -> {
+            try {
+                return extent.setBlock(loc, BlockTypes.STICKY_PISTON.getDefaultState());
+            } catch (WorldEditException e) {
+                throw new RuntimeException(e);
+            }
+        }),
+        SET_BIOME((extent, loc) ->
+            extent.setBiome(loc.toBlockVector2(), BiomeTypes.DESERT)
+        ),
+        CREATE_ENTITY((extent, loc) ->
+            extent.createEntity(new Location(extent, loc.toVector3()), new BaseEntity(EntityTypes.COW)) != null
+        ),
+        ;
+
+        public final BiPredicate<Extent, BlockVector3> test;
+
+        Action(BiPredicate<Extent, BlockVector3> test) {
+            this.test = test;
+        }
+    }
+
+    private final Set<Action> failedActions = EnumSet.noneOf(Action.class);
+    private boolean active;
+
+    /**
+     * Create a new instance.
+     *
+     * @param extent the extent
+     */
+    public TracingExtent(Extent extent) {
+        super(extent);
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public Set<Action> getFailedActions() {
+        return ImmutableSet.copyOf(failedActions);
+    }
+
+    @Override
+    public <T extends BlockStateHolder<T>> boolean setBlock(BlockVector3 location, T block) throws WorldEditException {
+        active = true;
+        boolean result = super.setBlock(location, block);
+        if (!result) {
+            failedActions.add(Action.SET_BLOCK);
+        }
+        return result;
+    }
+
+    @Override
+    public boolean setBiome(BlockVector2 position, BiomeType biome) {
+        active = true;
+        boolean result = super.setBiome(position, biome);
+        if (!result) {
+            failedActions.add(Action.SET_BIOME);
+        }
+        return result;
+    }
+
+    @Nullable
+    @Override
+    public Entity createEntity(Location location, BaseEntity entity) {
+        active = true;
+        Entity result = super.createEntity(location, entity);
+        if (result == null) {
+            failedActions.add(Action.CREATE_ENTITY);
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "TracingExtent{delegate=" + getExtent() + "}";
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/scripting/CraftScriptContext.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/scripting/CraftScriptContext.java
@@ -66,9 +66,11 @@ public class CraftScriptContext extends CraftScriptEnvironment {
      * @return an edit session
      */
     public EditSession remember() {
-        EditSession editSession = controller.getEditSessionFactory()
-                .getEditSession(player.getWorld(),
-                        session.getBlockChangeLimit(), session.getBlockBag(player), player);
+        EditSession editSession = controller.newEditSessionBuilder()
+            .locatableActor(player)
+            .maxBlocks(session.getBlockChangeLimit())
+            .blockBag(session.getBlockBag(player))
+            .build();
         Request.request().setEditSession(editSession);
         editSession.enableStandardMode();
         editSessions.add(editSession);

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -234,6 +234,10 @@
     "worldedit.version.version": "WorldEdit version {0}",
     "worldedit.version.bukkit.unsupported-adapter": "This WorldEdit version does not fully support your version of Bukkit. Block entities (e.g. chests) will be empty, block properties (e.g. rotation) will be missing, and other things may not work. Update WorldEdit to restore this functionality:\n{0}",
 
+    "worldedit.trace.success":  "The action {0} was successful.",
+    "worldedit.trace.no-tracing-extents":  "No extent was activated.",
+    "worldedit.trace.extent":  "Action failed: {0} - Extent: {1}",
+
     "worldedit.command.time-elapsed": "{0}s elapsed (history: {1} changed; {2} blocks/sec).",
     "worldedit.command.permissions": "You are not permitted to do that. Are you in the right mode?",
     "worldedit.command.player-only": "This command must be used with a player.",

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -234,9 +234,8 @@
     "worldedit.version.version": "WorldEdit version {0}",
     "worldedit.version.bukkit.unsupported-adapter": "This WorldEdit version does not fully support your version of Bukkit. Block entities (e.g. chests) will be empty, block properties (e.g. rotation) will be missing, and other things may not work. Update WorldEdit to restore this functionality:\n{0}",
 
-    "worldedit.trace.success":  "The action {0} was successful.",
     "worldedit.trace.no-tracing-extents":  "No extent was activated.",
-    "worldedit.trace.extent":  "Action failed: {0} - Extent: {1}",
+    "worldedit.trace.action-failed":  "Action failed at {0}: {1} - Extent: {2}",
 
     "worldedit.command.time-elapsed": "{0}s elapsed (history: {1} changed; {2} blocks/sec).",
     "worldedit.command.permissions": "You are not permitted to do that. Are you in the right mode?",

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -234,8 +234,12 @@
     "worldedit.version.version": "WorldEdit version {0}",
     "worldedit.version.bukkit.unsupported-adapter": "This WorldEdit version does not fully support your version of Bukkit. Block entities (e.g. chests) will be empty, block properties (e.g. rotation) will be missing, and other things may not work. Update WorldEdit to restore this functionality:\n{0}",
 
-    "worldedit.trace.no-tracing-extents":  "No extent was activated.",
-    "worldedit.trace.action-failed":  "Action failed at {0}: {1} - Extent: {2}",
+    "worldedit.trace.no-tracing-extents":  "Trace: No extent was used.",
+    "worldedit.trace.action-failed":  "Trace: Action(s) {0} at {1} discarded by extent {2}",
+    "worldedit.trace.active.already": "Trace mode already active.",
+    "worldedit.trace.inactive.already": "Trace mode already inactive.",
+    "worldedit.trace.active": "Trace mode now active.",
+    "worldedit.trace.inactive": "Trace mode now inactive.",
 
     "worldedit.command.time-elapsed": "{0}s elapsed (history: {1} changed; {2} blocks/sec).",
     "worldedit.command.permissions": "You are not permitted to do that. Are you in the right mode?",


### PR DESCRIPTION
This helps track down what plugin (or more specifically, extent) is blocking actions from happening.

Suggestions are welcome on every part of this, as it was just the simplest way I could see today. Maybe there's something smarter we can be doing.

I did wrap every extent, just in case we have a bug in one of our own extents. It's better to be safe than sorry.