### PR TITLE
Precompile deform operation

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -2139,7 +2139,11 @@ public class EditSession implements Extent, AutoCloseable {
                             final int timeout) throws ExpressionException, MaxChangedBlocksException {
         final Expression expression = Expression.compile(expressionString, "x", "y", "z");
         expression.optimize();
+        return deformRegion(region, zero, unit, expression, timeout);
+    }
 
+    public int deformRegion(final Region region, final Vector3 zero, final Vector3 unit, final Expression expression,
+                            final int timeout) throws ExpressionException, MaxChangedBlocksException {
         final Variable x = expression.getSlots().getVariable("x")
             .orElseThrow(IllegalStateException::new);
         final Variable y = expression.getSlots().getVariable("y")

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -2070,10 +2070,23 @@ public class EditSession implements Extent, AutoCloseable {
      * @throws MaxChangedBlocksException
      */
     public int makeShape(final Region region, final Vector3 zero, final Vector3 unit,
-                        final Pattern pattern, final String expressionString, final boolean hollow, final int timeout)
+                         final Pattern pattern, final String expressionString, final boolean hollow, final int timeout)
             throws ExpressionException, MaxChangedBlocksException {
         final Expression expression = Expression.compile(expressionString, "x", "y", "z", "type", "data");
         expression.optimize();
+        return makeShape(region, zero, unit, pattern, expression, hollow, timeout);
+    }
+
+    public int makeShape(final Region region, final Vector3 zero, final Vector3 unit,
+                         final Pattern pattern, final Expression expression, final boolean hollow, final int timeout)
+            throws ExpressionException, MaxChangedBlocksException {
+
+        expression.getSlots().getVariable("x")
+            .orElseThrow(IllegalStateException::new);
+        expression.getSlots().getVariable("y")
+            .orElseThrow(IllegalStateException::new);
+        expression.getSlots().getVariable("z")
+            .orElseThrow(IllegalStateException::new);
 
         final Variable typeVariable = expression.getSlots().getVariable("type")
             .orElseThrow(IllegalStateException::new);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -2077,6 +2077,11 @@ public class EditSession implements Extent, AutoCloseable {
         return makeShape(region, zero, unit, pattern, expression, hollow, timeout);
     }
 
+    /**
+     * Internal version of {@link EditSession#makeShape(Region, Vector3, Vector3, Pattern, String, boolean, int)}.
+     *
+     * The Expression class is subject to change. Expressions should be provided via the string overload.
+     */
     public int makeShape(final Region region, final Vector3 zero, final Vector3 unit,
                          final Pattern pattern, final Expression expression, final boolean hollow, final int timeout)
             throws ExpressionException, MaxChangedBlocksException {
@@ -2143,11 +2148,42 @@ public class EditSession implements Extent, AutoCloseable {
         return changed;
     }
 
+    /**
+     * Deforms the region by a given expression. A deform provides a block's x, y, and z coordinates (possibly scaled)
+     * to an expression, and then sets the block to the block given by the resulting values of the variables, if they
+     * have changed.
+     *
+     * @param region the region to deform
+     * @param zero the origin of the coordinate system
+     * @param unit the scale of the coordinate system
+     * @param expressionString the expression to evaluate for each block
+     *
+     * @return number of blocks changed
+     *
+     * @throws ExpressionException thrown on invalid expression input
+     * @throws MaxChangedBlocksException thrown if too many blocks are changed
+     */
     public int deformRegion(final Region region, final Vector3 zero, final Vector3 unit, final String expressionString)
             throws ExpressionException, MaxChangedBlocksException {
         return deformRegion(region, zero, unit, expressionString, WorldEdit.getInstance().getConfiguration().calculationTimeout);
     }
 
+    /**
+     * Deforms the region by a given expression. A deform provides a block's x, y, and z coordinates (possibly scaled)
+     * to an expression, and then sets the block to the block given by the resulting values of the variables, if they
+     * have changed.
+     *
+     * @param region the region to deform
+     * @param zero the origin of the coordinate system
+     * @param unit the scale of the coordinate system
+     * @param expressionString the expression to evaluate for each block
+     * @param timeout maximum time for the expression to evaluate for each block. -1 for unlimited.
+     *
+     * @return number of blocks changed
+     *
+     * @throws ExpressionException thrown on invalid expression input
+     * @throws MaxChangedBlocksException thrown if too many blocks are changed
+     */
     public int deformRegion(final Region region, final Vector3 zero, final Vector3 unit, final String expressionString,
                             final int timeout) throws ExpressionException, MaxChangedBlocksException {
         final Expression expression = Expression.compile(expressionString, "x", "y", "z");
@@ -2155,6 +2191,11 @@ public class EditSession implements Extent, AutoCloseable {
         return deformRegion(region, zero, unit, expression, timeout);
     }
 
+    /**
+     * Internal version of {@link EditSession#deformRegion(Region, Vector3, Vector3, String, int)}.
+     *
+     * The Expression class is subject to change. Expressions should be provided via the string overload.
+     */
     public int deformRegion(final Region region, final Vector3 zero, final Vector3 unit, final Expression expression,
                             final int timeout) throws ExpressionException, MaxChangedBlocksException {
         final Variable x = expression.getSlots().getVariable("x")

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/factory/Deform.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/factory/Deform.java
@@ -47,7 +47,6 @@ public class Deform implements Contextual<Operation> {
 
     private Extent destination;
     private Region region;
-    private String expressionString;
     private Expression expression;
     private Mode mode;
     private Vector3 offset = Vector3.ZERO;
@@ -68,17 +67,12 @@ public class Deform implements Contextual<Operation> {
         checkNotNull(destination, "destination");
         checkNotNull(region, "region");
         checkNotNull(mode, "mode");
-        checkAndSetExpression(expression);
+        checkNotNull(expression, "expression");
+        this.expression = Expression.compile(expression, "x", "y", "z");
+        this.expression.optimize();
         this.destination = destination;
         this.region = region;
         this.mode = mode;
-    }
-
-    private void checkAndSetExpression(String expressionString) {
-        checkNotNull(expressionString, "expression");
-        this.expression = Expression.compile(expressionString, "x", "y", "z");
-        this.expression.optimize();
-        this.expressionString = expressionString;
     }
 
     public Extent getDestination() {
@@ -97,14 +91,6 @@ public class Deform implements Contextual<Operation> {
     public void setRegion(Region region) {
         checkNotNull(region, "region");
         this.region = region;
-    }
-
-    public String getExpressionString() {
-        return expressionString;
-    }
-
-    public void setExpressionString(String expressionString) {
-        checkAndSetExpression(expressionString);
     }
 
     public Mode getMode() {
@@ -127,7 +113,7 @@ public class Deform implements Contextual<Operation> {
 
     @Override
     public String toString() {
-        return "deformation of " + expressionString;
+        return "deformation of " + expression.getSource();
     }
 
     @Override
@@ -160,7 +146,7 @@ public class Deform implements Contextual<Operation> {
         }
 
         LocalSession session = context.getSession();
-        return new DeformOperation(context.getDestination(), region, zero, unit, expression, expressionString,
+        return new DeformOperation(context.getDestination(), region, zero, unit, expression,
                 session == null ? WorldEdit.getInstance().getConfiguration().calculationTimeout : session.getTimeout());
     }
 
@@ -170,17 +156,15 @@ public class Deform implements Contextual<Operation> {
         private final Vector3 zero;
         private final Vector3 unit;
         private final Expression expression;
-        private final String expressionString;
         private final int timeout;
 
         private DeformOperation(Extent destination, Region region, Vector3 zero, Vector3 unit, Expression expression,
-                                String expressionString, int timeout) {
+                                int timeout) {
             this.destination = destination;
             this.region = region;
             this.zero = zero;
             this.unit = unit;
             this.expression = expression;
-            this.expressionString = expressionString;
             this.timeout = timeout;
         }
 
@@ -203,7 +187,7 @@ public class Deform implements Contextual<Operation> {
         @Override
         public Iterable<Component> getStatusMessages() {
             return ImmutableList.of(TranslatableComponent.of("worldedit.operation.deform.expression",
-                    TextComponent.of(expressionString).color(TextColor.LIGHT_PURPLE)));
+                    TextComponent.of(expression.getSource()).color(TextColor.LIGHT_PURPLE)));
         }
 
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/expression/Expression.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/expression/Expression.java
@@ -34,6 +34,9 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * Compiles and evaluates expressions.
  *
@@ -62,6 +65,7 @@ import java.util.Objects;
  */
 public class Expression {
 
+    private final String source;
     private final SlotTable slots = new SlotTable();
     private final List<String> providedSlots;
     private final ExpressionParser.AllStatementsContext root;
@@ -73,6 +77,9 @@ public class Expression {
     }
 
     private Expression(String expression, String... variableNames) throws ExpressionException {
+        checkNotNull(expression, "Expression cannot be null.");
+        checkArgument(!expression.isEmpty(), "Expression cannot be empty string.");
+        this.source = expression;
         slots.putSlot("e", new LocalSlot.Constant(Math.E));
         slots.putSlot("pi", new LocalSlot.Constant(Math.PI));
         slots.putSlot("true", new LocalSlot.Constant(1));
@@ -128,6 +135,10 @@ public class Expression {
 
     public void optimize() {
         // TODO optimizing
+    }
+
+    public String getSource() {
+        return source;
     }
 
     @Override


### PR DESCRIPTION
Prevents invalid expressions from going unnoticed til the user starts spamming right click with their brush.