### PR TITLE
Allow craftscripts to exit early + cleanly

### DIFF
--- a/buildSrc/src/main/kotlin/PlatformConfig.kt
+++ b/buildSrc/src/main/kotlin/PlatformConfig.kt
@@ -7,7 +7,7 @@ import org.gradle.api.plugins.quality.CheckstyleExtension
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.api.tasks.testing.Test
-import org.gradle.external.javadoc.CoreJavadocOptions
+import org.gradle.external.javadoc.StandardJavadocDocletOptions
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
@@ -54,7 +54,14 @@ fun Project.applyPlatformAndCoreConfiguration() {
 
     // Java 8 turns on doclint which we fail
     tasks.withType<Javadoc>().configureEach {
-        (options as CoreJavadocOptions).addStringOption("Xdoclint:none", "-quiet")
+        (options as StandardJavadocDocletOptions).apply {
+            addStringOption("Xdoclint:none", "-quiet")
+            tags(
+                "apiNote:a:API Note:",
+                "implSpec:a:Implementation Requirements:",
+                "implNote:a:Implementation Note:"
+            )
+        }
     }
 
     tasks.register<Jar>("javadocJar") {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -42,6 +43,7 @@ import com.sk89q.worldedit.extension.platform.PlatformManager;
 import com.sk89q.worldedit.extent.inventory.BlockBag;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.pattern.Pattern;
+import com.sk89q.worldedit.internal.expression.invoke.ReturnException;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.scripting.CraftScriptContext;
 import com.sk89q.worldedit.scripting.CraftScriptEngine;
@@ -696,8 +698,11 @@ public final class WorldEdit {
         try {
             engine.evaluate(script, filename, vars);
         } catch (ScriptException e) {
-            player.printError(TranslatableComponent.of("worldedit.script.failed", TextComponent.of(e.getMessage(), TextColor.WHITE)));
-            logger.warn("Failed to execute script", e);
+            // non-exceptional return check
+            if (!(Throwables.getRootCause(e) instanceof ReturnException)) {
+                player.printError(TranslatableComponent.of("worldedit.script.failed", TextComponent.of(e.getMessage(), TextColor.WHITE)));
+                logger.warn("Failed to execute script", e);
+            }
         } catch (NumberFormatException | WorldEditException e) {
             throw e;
         } catch (Throwable e) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/expression/invoke/ReturnException.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/expression/invoke/ReturnException.java
@@ -24,7 +24,7 @@ package com.sk89q.worldedit.internal.expression.invoke;
  *
  * Should be caught by the executor.
  */
-class ReturnException extends RuntimeException {
+public class ReturnException extends RuntimeException {
 
     private final Double result;
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/scripting/CraftScriptContext.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/scripting/CraftScriptContext.java
@@ -31,6 +31,7 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.input.ParserContext;
 import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.function.pattern.Pattern;
+import com.sk89q.worldedit.internal.expression.invoke.ReturnException;
 import com.sk89q.worldedit.session.request.Request;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.util.io.file.FilenameException;
@@ -60,7 +61,7 @@ public class CraftScriptContext extends CraftScriptEnvironment {
     /**
      * Get an edit session. Every subsequent call returns a new edit session.
      * Usually you only need to use one edit session.
-     * 
+     *
      * @return an edit session
      */
     public EditSession remember() {
@@ -75,7 +76,7 @@ public class CraftScriptContext extends CraftScriptEnvironment {
 
     /**
      * Get the player.
-     * 
+     *
      * @return the calling player
      */
     public Player getPlayer() {
@@ -84,7 +85,7 @@ public class CraftScriptContext extends CraftScriptEnvironment {
 
     /**
      * Get the player's session.
-     * 
+     *
      * @return a session
      */
     public LocalSession getSession() {
@@ -93,7 +94,7 @@ public class CraftScriptContext extends CraftScriptEnvironment {
 
     /**
      * Get the configuration for WorldEdit.
-     * 
+     *
      * @return the configuration
      */
     public LocalConfiguration getConfiguration() {
@@ -102,7 +103,7 @@ public class CraftScriptContext extends CraftScriptEnvironment {
 
     /**
      * Get a list of edit sessions that have been created.
-     * 
+     *
      * @return a list of created {@code EditSession}s
      */
     public List<EditSession> getEditSessions() {
@@ -111,7 +112,7 @@ public class CraftScriptContext extends CraftScriptEnvironment {
 
     /**
      * Print a regular message to the user.
-     * 
+     *
      * @param message a message
      */
     public void print(String message) {
@@ -120,7 +121,7 @@ public class CraftScriptContext extends CraftScriptEnvironment {
 
     /**
      * Print an error message to the user.
-     * 
+     *
      * @param message a message
      */
     public void error(String message) {
@@ -129,7 +130,7 @@ public class CraftScriptContext extends CraftScriptEnvironment {
 
     /**
      * Print a raw message to the user.
-     * 
+     *
      * @param message a message
      */
     public void printRaw(String message) {
@@ -149,6 +150,16 @@ public class CraftScriptContext extends CraftScriptEnvironment {
         if (args.length <= min || (max != -1 && args.length - 1 > max)) {
             throw new InsufficientArgumentsException("Usage: " + usage);
         }
+    }
+
+    /**
+     * Immediately terminate execution of the script, but without a failure message.
+     *
+     * @implNote This exits by throwing an exception, which if caught will prevent
+     *     the script from exiting
+     */
+    public void exit() {
+        throw new ReturnException(null);
     }
 
     /**
@@ -188,8 +199,8 @@ public class CraftScriptContext extends CraftScriptEnvironment {
      *
      * @param list the input
      * @return pattern
-     * @throws UnknownItemException 
-     * @throws DisallowedItemException 
+     * @throws UnknownItemException
+     * @throws DisallowedItemException
      */
     public Pattern getBlockPattern(String list) throws WorldEditException {
         ParserContext context = new ParserContext();
@@ -205,8 +216,8 @@ public class CraftScriptContext extends CraftScriptEnvironment {
      * @param list a list
      * @param allBlocksAllowed true if all blocks are allowed
      * @return set
-     * @throws UnknownItemException 
-     * @throws DisallowedItemException 
+     * @throws UnknownItemException
+     * @throws DisallowedItemException
      */
     public Set<BaseBlock> getBlocks(String list, boolean allBlocksAllowed) throws WorldEditException {
         ParserContext context = new ParserContext();
@@ -223,15 +234,15 @@ public class CraftScriptContext extends CraftScriptEnvironment {
      * directory traversal exploits by checking the root directory and the file
      * directory. On success, a {@code java.io.File} object will be
      * returned.
-     * 
+     *
      * <p>Use this method if you need to read a file from a directory.</p>
-     * 
+     *
      * @param folder sub-directory to look in
      * @param filename filename (user-submitted)
      * @param defaultExt default extension to append if there is none
      * @param exts list of extensions for file open dialog, null for no filter
      * @return a file
-     * @throws FilenameException 
+     * @throws FilenameException
      */
     public File getSafeOpenFile(String folder, String filename, String defaultExt, String... exts) throws FilenameException {
         File dir = controller.getWorkingDirectoryFile(folder);
@@ -244,15 +255,15 @@ public class CraftScriptContext extends CraftScriptEnvironment {
      * directory traversal exploits by checking the root directory and the file
      * directory. On success, a {@code java.io.File} object will be
      * returned.
-     * 
+     *
      * <p>Use this method if you need to read a file from a directory.</p>
-     * 
+     *
      * @param folder sub-directory to look in
      * @param filename filename (user-submitted)
      * @param defaultExt default extension to append if there is none
      * @param exts list of extensions for file save dialog, null for no filter
      * @return a file
-     * @throws FilenameException 
+     * @throws FilenameException
      */
     public File getSafeSaveFile(String folder, String filename, String defaultExt, String... exts) throws FilenameException {
         File dir = controller.getWorkingDirectoryFile(folder);


### PR DESCRIPTION
Early return is a useful feature, and I even felt the need for this while reviewing a [PR](https://github.com/EngineHub/WorldEdit/pull/545#discussion_r370960942).

Intended usage is to call `context.exit();`.