### PR TITLE
feat(tool): added stack tool

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitAdapter.java
@@ -32,6 +32,7 @@ import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.internal.block.BlockStateIdAccess;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
+import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.biome.BiomeType;
@@ -51,6 +52,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Biome;
+import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -164,6 +166,28 @@ public class BukkitAdapter {
      */
     public static Player adapt(com.sk89q.worldedit.entity.Player player) {
         return ((BukkitPlayer) player).getPlayer();
+    }
+
+    /**
+     * Create a WorldEdit Direction from a Bukkit BlockFace.
+     *
+     * @param face the Bukkit BlockFace
+     * @return a WorldEdit direction
+     */
+    public static Direction adapt(@Nullable BlockFace face) {
+        if (face == null) {
+            return null;
+        }
+        switch (face) {
+            case NORTH: return Direction.NORTH;
+            case SOUTH: return Direction.SOUTH;
+            case WEST: return Direction.WEST;
+            case EAST: return Direction.EAST;
+            case DOWN: return Direction.DOWN;
+            case UP:
+            default:
+                return Direction.UP;
+        }
     }
 
     /**

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditListener.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditListener.java
@@ -24,6 +24,7 @@ package com.sk89q.worldedit.bukkit;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.platform.Actor;
+import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.world.World;
 import org.bukkit.block.Block;
@@ -105,13 +106,14 @@ public class WorldEditListener implements Listener {
         final Player player = plugin.wrapPlayer(event.getPlayer());
         final World world = player.getWorld();
         final WorldEdit we = plugin.getWorldEdit();
+        final Direction direction = BukkitAdapter.adapt(event.getBlockFace());
 
         Action action = event.getAction();
         if (action == Action.LEFT_CLICK_BLOCK) {
             final Block clickedBlock = event.getClickedBlock();
             final Location pos = new Location(world, clickedBlock.getX(), clickedBlock.getY(), clickedBlock.getZ());
 
-            if (we.handleBlockLeftClick(player, pos)) {
+            if (we.handleBlockLeftClick(player, pos, direction)) {
                 event.setCancelled(true);
             }
 
@@ -129,7 +131,7 @@ public class WorldEditListener implements Listener {
             final Block clickedBlock = event.getClickedBlock();
             final Location pos = new Location(world, clickedBlock.getX(), clickedBlock.getY(), clickedBlock.getZ());
 
-            if (we.handleBlockRightClick(player, pos)) {
+            if (we.handleBlockRightClick(player, pos, direction)) {
                 event.setCancelled(true);
             }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -616,8 +616,21 @@ public final class WorldEdit {
      * @param clicked the clicked block
      * @return false if you want the action to go through
      */
+    @Deprecated
     public boolean handleBlockRightClick(Player player, Location clicked) {
-        BlockInteractEvent event = new BlockInteractEvent(player, clicked, OPEN);
+        return handleBlockRightClick(player, clicked, null);
+    }
+
+    /**
+     * Called on right click.
+     *
+     * @param player the player
+     * @param clicked the clicked block
+     * @param face The clicked face
+     * @return false if you want the action to go through
+     */
+    public boolean handleBlockRightClick(Player player, Location clicked, @Nullable Direction face) {
+        BlockInteractEvent event = new BlockInteractEvent(player, clicked, face, OPEN);
         getEventBus().post(event);
         return event.isCancelled();
     }
@@ -629,8 +642,21 @@ public final class WorldEdit {
      * @param clicked the clicked block
      * @return false if you want the action to go through
      */
+    @Deprecated
     public boolean handleBlockLeftClick(Player player, Location clicked) {
-        BlockInteractEvent event = new BlockInteractEvent(player, clicked, HIT);
+        return handleBlockLeftClick(player, clicked, null);
+    }
+
+    /**
+     * Called on left click.
+     *
+     * @param player the player
+     * @param clicked the clicked block
+     * @param face The clicked face
+     * @return false if you want the action to go through
+     */
+    public boolean handleBlockLeftClick(Player player, Location clicked, @Nullable Direction face) {
+        BlockInteractEvent event = new BlockInteractEvent(player, clicked, face, HIT);
         getEventBus().post(event);
         return event.isCancelled();
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
@@ -91,6 +91,12 @@ public class ToolCommands {
                     Collections2.filter(command.getAliases(), alias -> !"unbind".equals(alias))
                 ).build();
             }
+            if (command.getAliases().contains("stacker")) {
+                // Don't register new /tool unbind alias
+                command = command.toBuilder().aliases(
+                        Collections2.filter(command.getAliases(), alias -> !"stacker".equals(alias))
+                ).build();
+            }
             commandManager.register(CommandUtil.deprecate(
                 command, "Global tool names cause conflicts " +
                 "and will be removed in WorldEdit 8", ToolCommands::asNonGlobal

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
@@ -209,10 +209,10 @@ public class ToolCommands {
     )
     @CommandPermissions("worldedit.tool.stack")
     public void stacker(Player player, LocalSession session,
-                      @Arg(desc = "The max range of the stack", def = "10")
-                          int range,
-                      @Arg(desc = "The mask to stack until", def = "!#existing")
-                          Mask mask) throws WorldEditException {
+                        @Arg(desc = "The max range of the stack", def = "10")
+                            int range,
+                        @Arg(desc = "The mask to stack until", def = "!#existing")
+                            Mask mask) throws WorldEditException {
         setTool(player, session, new StackTool(range, mask), "worldedit.tool.stack.equip");
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
@@ -35,12 +35,14 @@ import com.sk89q.worldedit.command.tool.LongRangeBuildTool;
 import com.sk89q.worldedit.command.tool.NavigationWand;
 import com.sk89q.worldedit.command.tool.QueryTool;
 import com.sk89q.worldedit.command.tool.SelectionWand;
+import com.sk89q.worldedit.command.tool.StackTool;
 import com.sk89q.worldedit.command.tool.Tool;
 import com.sk89q.worldedit.command.tool.TreePlanter;
 import com.sk89q.worldedit.command.util.CommandPermissions;
 import com.sk89q.worldedit.command.util.CommandPermissionsConditionGenerator;
 import com.sk89q.worldedit.command.util.SubCommandPermissionCondition;
 import com.sk89q.worldedit.entity.Player;
+import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.internal.command.CommandRegistrationHandler;
 import com.sk89q.worldedit.internal.command.CommandUtil;
@@ -195,6 +197,19 @@ public class ToolCommands {
     }
 
     @Command(
+        name = "stacker",
+        desc = "Block stacker tool"
+    )
+    @CommandPermissions("worldedit.tool.stack")
+    public void stacker(Player player, LocalSession session,
+                      @Arg(desc = "The max range of the stack", def = "10")
+                        int range,
+                      @Arg(desc = "The mask to replace until", def = "!#existing")
+                        Mask mask) throws WorldEditException {
+        setTool(player, session, new StackTool(range, mask), "worldedit.tool.stack.equip");
+    }
+
+    @Command(
         name = "repl",
         desc = "Block replacer tool"
     )
@@ -229,7 +244,7 @@ public class ToolCommands {
         LocalConfiguration config = we.getConfiguration();
 
         if (range > config.maxSuperPickaxeSize) {
-            player.printError(TranslatableComponent.of("worldedit.superpickaxe.max-range", TextComponent.of(config.maxSuperPickaxeSize)));
+            player.printError(TranslatableComponent.of("worldedit.tool.superpickaxe.max-range", TextComponent.of(config.maxSuperPickaxeSize)));
             return;
         }
         setTool(player, session, new FloodFillTool(range, pattern), "worldedit.tool.floodfill.equip");

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
@@ -20,7 +20,6 @@
 package com.sk89q.worldedit.command;
 
 import com.google.common.collect.Collections2;
-import com.google.common.collect.Lists;
 import com.sk89q.worldedit.LocalConfiguration;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;
@@ -62,7 +61,6 @@ import org.enginehub.piston.annotation.CommandContainer;
 import org.enginehub.piston.annotation.param.Arg;
 import org.enginehub.piston.part.SubCommandPart;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
@@ -70,7 +70,6 @@ import java.util.stream.Collectors;
 @CommandContainer(superTypes = CommandPermissionsConditionGenerator.Registration.class)
 public class ToolCommands {
 
-
     public static void register(CommandRegistrationHandler registration,
                                 CommandManager commandManager,
                                 CommandManagerService commandManagerService,

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
@@ -20,6 +20,7 @@
 package com.sk89q.worldedit.command;
 
 import com.google.common.collect.Collections2;
+import com.google.common.collect.Lists;
 import com.sk89q.worldedit.LocalConfiguration;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;
@@ -61,12 +62,15 @@ import org.enginehub.piston.annotation.CommandContainer;
 import org.enginehub.piston.annotation.param.Arg;
 import org.enginehub.piston.part.SubCommandPart;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 @CommandContainer(superTypes = CommandPermissionsConditionGenerator.Registration.class)
 public class ToolCommands {
+
+    private static final List<String> IGNORED_GLOBAL_ALIASES = Lists.newArrayList("unbind", "stacker");
 
     public static void register(CommandRegistrationHandler registration,
                                 CommandManager commandManager,
@@ -85,17 +89,13 @@ public class ToolCommands {
         Set<org.enginehub.piston.Command> commands = collect.getAllCommands()
             .collect(Collectors.toSet());
         for (org.enginehub.piston.Command command : commands) {
-            if (command.getAliases().contains("unbind")) {
-                // Don't register new /tool unbind alias
-                command = command.toBuilder().aliases(
-                    Collections2.filter(command.getAliases(), alias -> !"unbind".equals(alias))
-                ).build();
-            }
-            if (command.getAliases().contains("stacker")) {
-                // Don't register new /tool unbind alias
-                command = command.toBuilder().aliases(
-                        Collections2.filter(command.getAliases(), alias -> !"stacker".equals(alias))
-                ).build();
+            for (String ignoredAlias : IGNORED_GLOBAL_ALIASES) {
+                if (command.getAliases().contains(ignoredAlias)) {
+                    // Don't register new /tool <whatever> alias
+                    command = command.toBuilder().aliases(
+                            Collections2.filter(command.getAliases(), alias -> !ignoredAlias.equals(alias))
+                    ).build();
+                }
             }
             commandManager.register(CommandUtil.deprecate(
                 command, "Global tool names cause conflicts " +
@@ -209,9 +209,9 @@ public class ToolCommands {
     @CommandPermissions("worldedit.tool.stack")
     public void stacker(Player player, LocalSession session,
                       @Arg(desc = "The max range of the stack", def = "10")
-                        int range,
+                          int range,
                       @Arg(desc = "The mask to stack until", def = "!#existing")
-                        Mask mask) throws WorldEditException {
+                          Mask mask) throws WorldEditException {
         setTool(player, session, new StackTool(range, mask), "worldedit.tool.stack.equip");
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
@@ -70,7 +70,6 @@ import java.util.stream.Collectors;
 @CommandContainer(superTypes = CommandPermissionsConditionGenerator.Registration.class)
 public class ToolCommands {
 
-    private static final List<String> IGNORED_GLOBAL_ALIASES = Lists.newArrayList("unbind", "stacker");
 
     public static void register(CommandRegistrationHandler registration,
                                 CommandManager commandManager,
@@ -89,13 +88,15 @@ public class ToolCommands {
         Set<org.enginehub.piston.Command> commands = collect.getAllCommands()
             .collect(Collectors.toSet());
         for (org.enginehub.piston.Command command : commands) {
-            for (String ignoredAlias : IGNORED_GLOBAL_ALIASES) {
-                if (command.getAliases().contains(ignoredAlias)) {
-                    // Don't register new /tool <whatever> alias
-                    command = command.toBuilder().aliases(
-                            Collections2.filter(command.getAliases(), alias -> !ignoredAlias.equals(alias))
-                    ).build();
-                }
+            if (command.getAliases().contains("unbind")) {
+                // Don't register new /tool <whatever> alias
+                command = command.toBuilder().aliases(
+                        Collections2.filter(command.getAliases(), alias -> !"unbind".equals(alias))
+                ).build();
+            }
+            if (command.getName().equals("stacker")) {
+                // Don't register /stacker
+                continue;
             }
             commandManager.register(CommandUtil.deprecate(
                 command, "Global tool names cause conflicts " +

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
@@ -204,7 +204,7 @@ public class ToolCommands {
     public void stacker(Player player, LocalSession session,
                       @Arg(desc = "The max range of the stack", def = "10")
                         int range,
-                      @Arg(desc = "The mask to replace until", def = "!#existing")
+                      @Arg(desc = "The mask to stack until", def = "!#existing")
                         Mask mask) throws WorldEditException {
         setTool(player, session, new StackTool(range, mask), "worldedit.tool.stack.equip");
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
@@ -91,7 +91,7 @@ public class ToolCommands {
             if (command.getAliases().contains("unbind")) {
                 // Don't register new /tool <whatever> alias
                 command = command.toBuilder().aliases(
-                        Collections2.filter(command.getAliases(), alias -> !"unbind".equals(alias))
+                    Collections2.filter(command.getAliases(), alias -> !"unbind".equals(alias))
                 ).build();
             }
             if (command.getName().equals("stacker")) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockTool.java
@@ -42,7 +42,7 @@ public interface BlockTool extends Tool {
      */
     @Deprecated
     default boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked) {
-        return false;
+        throw new AssertionError("actPrimary must be overridden");
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockTool.java
@@ -48,6 +48,8 @@ public interface BlockTool extends Tool {
     /**
      * Perform the primary action of this tool.
      *
+     * <p>Note: This will not be default in WorldEdit 8</p>
+     *
      * @param server The platform
      * @param config The config instance
      * @param player The player

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockTool.java
@@ -23,7 +23,10 @@ import com.sk89q.worldedit.LocalConfiguration;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.platform.Platform;
+import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.Location;
+
+import javax.annotation.Nullable;
 
 public interface BlockTool extends Tool {
 
@@ -37,5 +40,23 @@ public interface BlockTool extends Tool {
      * @param clicked
      * @return true to cancel the original event which triggered this action (if possible)
      */
-    boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked);
+    @Deprecated
+    default boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked) {
+        return false;
+    }
+
+    /**
+     * Perform the primary action of this tool.
+     *
+     * @param server The platform
+     * @param config The config instance
+     * @param player The player
+     * @param session The local session
+     * @param clicked The location that was clicked
+     * @param face The face that was clicked
+     * @return true to cancel the original event which triggered this action (if possible)
+     */
+    default boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked, @Nullable Direction face) {
+        return actPrimary(server, config, player, session, clicked);
+    }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/DoubleActionBlockTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/DoubleActionBlockTool.java
@@ -45,7 +45,7 @@ public interface DoubleActionBlockTool extends BlockTool {
      */
     @Deprecated
     default boolean actSecondary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked) {
-        return false;
+        throw new AssertionError("actPrimary must be overridden");
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/DoubleActionBlockTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/DoubleActionBlockTool.java
@@ -51,6 +51,8 @@ public interface DoubleActionBlockTool extends BlockTool {
     /**
      * Perform the secondary action of this block tool.
      *
+     * <p>Note: This will not be default in WorldEdit 8</p>
+     *
      * @param server The platform
      * @param config The config instance
      * @param player The player

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/DoubleActionBlockTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/DoubleActionBlockTool.java
@@ -23,7 +23,10 @@ import com.sk89q.worldedit.LocalConfiguration;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.platform.Platform;
+import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.Location;
+
+import javax.annotation.Nullable;
 
 /**
  * Represents a block tool that also has a secondary/primary function.
@@ -40,6 +43,24 @@ public interface DoubleActionBlockTool extends BlockTool {
      * @param clicked
      * @return true to cancel the original event which triggered this action (if possible)
      */
-    boolean actSecondary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked);
+    @Deprecated
+    default boolean actSecondary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked) {
+        return false;
+    }
+
+    /**
+     * Perform the secondary action of this block tool.
+     *
+     * @param server The platform
+     * @param config The config instance
+     * @param player The player
+     * @param session The local session
+     * @param clicked The location that was clicked
+     * @param face The face that was clicked
+     * @return true to cancel the original event which triggered this action (if possible)
+     */
+    default boolean actSecondary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked, @Nullable Direction face) {
+        return actSecondary(server, config, player, session, clicked);
+    }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/StackTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/StackTool.java
@@ -1,0 +1,85 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.command.tool;
+
+import com.sk89q.worldedit.EditSession;
+import com.sk89q.worldedit.LocalConfiguration;
+import com.sk89q.worldedit.LocalSession;
+import com.sk89q.worldedit.MaxChangedBlocksException;
+import com.sk89q.worldedit.entity.Player;
+import com.sk89q.worldedit.extension.platform.Actor;
+import com.sk89q.worldedit.extension.platform.Platform;
+import com.sk89q.worldedit.extent.inventory.BlockBag;
+import com.sk89q.worldedit.function.mask.Mask;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.util.Direction;
+import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldedit.world.block.BlockStateHolder;
+
+import javax.annotation.Nullable;
+
+public class StackTool implements BlockTool {
+
+    private final int range;
+    private final Mask mask;
+
+    public StackTool(int range, Mask mask) {
+        this.range = range;
+        this.mask = mask;
+    }
+
+    @Override
+    public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked, @Nullable Direction face) {
+        if (face == null) {
+            return false;
+        }
+        BlockBag bag = session.getBlockBag(player);
+
+        try (EditSession editSession = session.createEditSession(player)) {
+            BlockStateHolder<?> block = editSession.getFullBlock(clicked.toVector().toBlockPoint());
+
+            try {
+                editSession.disableBuffering();
+                BlockVector3 position = clicked.toVector().toBlockPoint();
+                for (int i = 0; i < range; i++) {
+                    position = position.add(face.toBlockVector());
+                    if (!mask.test(position)) {
+                        break;
+                    }
+                    editSession.setBlock(position, block);
+                }
+            } catch (MaxChangedBlocksException ignored) {
+            } finally {
+                session.remember(editSession);
+            }
+        } finally {
+            if (bag != null) {
+                bag.flushChanges();
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean canUse(Actor actor) {
+        return actor.hasPermission("worldedit.tool.stack");
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/event/platform/BlockInteractEvent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/event/platform/BlockInteractEvent.java
@@ -57,6 +57,7 @@ public class BlockInteractEvent extends Event implements Cancellable {
      *
      * @param cause the causing actor
      * @param location the location of the block
+     * @param face the face of the block
      * @param type the type of interaction
      */
     public BlockInteractEvent(Actor cause, Location location, @Nullable Direction face, Interaction type) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/event/platform/BlockInteractEvent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/event/platform/BlockInteractEvent.java
@@ -24,7 +24,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.sk89q.worldedit.event.Cancellable;
 import com.sk89q.worldedit.event.Event;
 import com.sk89q.worldedit.extension.platform.Actor;
+import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.Location;
+
+import javax.annotation.Nullable;
 
 /**
  * Called when a block is interacted with.
@@ -34,6 +37,7 @@ public class BlockInteractEvent extends Event implements Cancellable {
     private final Actor cause;
     private final Location location;
     private final Interaction type;
+    private final Direction face;
     private boolean cancelled;
 
     /**
@@ -43,12 +47,25 @@ public class BlockInteractEvent extends Event implements Cancellable {
      * @param location the location of the block
      * @param type the type of interaction
      */
+    @Deprecated
     public BlockInteractEvent(Actor cause, Location location, Interaction type) {
+        this(cause, location, null, type);
+    }
+
+    /**
+     * Create a new event.
+     *
+     * @param cause the causing actor
+     * @param location the location of the block
+     * @param type the type of interaction
+     */
+    public BlockInteractEvent(Actor cause, Location location, @Nullable Direction face, Interaction type) {
         checkNotNull(cause);
         checkNotNull(location);
         checkNotNull(type);
         this.cause = cause;
         this.location = location;
+        this.face = face;
         this.type = type;
     }
 
@@ -68,6 +85,16 @@ public class BlockInteractEvent extends Event implements Cancellable {
      */
     public Location getLocation() {
         return location;
+    }
+
+    /**
+     * Get the face of the block that was interacted with.
+     *
+     * @return The interacted face
+     */
+    @Nullable
+    public Direction getFace() {
+        return face;
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/event/platform/BlockInteractEvent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/event/platform/BlockInteractEvent.java
@@ -57,7 +57,7 @@ public class BlockInteractEvent extends Event implements Cancellable {
      *
      * @param cause the causing actor
      * @param location the location of the block
-     * @param face the face of the block
+     * @param face the face of the block that was interacted with
      * @param type the type of interaction
      */
     public BlockInteractEvent(Actor cause, Location location, @Nullable Direction face, Interaction type) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformManager.java
@@ -330,7 +330,7 @@ public class PlatformManager {
                     final BlockTool superPickaxe = session.getSuperPickaxe();
                     if (superPickaxe != null && superPickaxe.canUse(player)) {
                         if (superPickaxe.actPrimary(queryCapability(Capability.WORLD_EDITING),
-                                getConfiguration(), player, session, location)) {
+                                getConfiguration(), player, session, location, event.getFace())) {
                             event.setCancelled(true);
                         }
                         return;
@@ -340,7 +340,7 @@ public class PlatformManager {
                 Tool tool = session.getTool(player.getItemInHand(HandSide.MAIN_HAND).getType());
                 if (tool instanceof DoubleActionBlockTool && tool.canUse(player)) {
                     if (((DoubleActionBlockTool) tool).actSecondary(queryCapability(Capability.WORLD_EDITING),
-                            getConfiguration(), player, session, location)) {
+                            getConfiguration(), player, session, location, event.getFace())) {
                         event.setCancelled(true);
                     }
                 }
@@ -349,7 +349,7 @@ public class PlatformManager {
                 Tool tool = session.getTool(player.getItemInHand(HandSide.MAIN_HAND).getType());
                 if (tool instanceof BlockTool && tool.canUse(player)) {
                     if (((BlockTool) tool).actPrimary(queryCapability(Capability.WORLD_EDITING),
-                            getConfiguration(), player, session, location)) {
+                            getConfiguration(), player, session, location, event.getFace())) {
                         event.setCancelled(true);
                     }
                 }

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -268,6 +268,7 @@
     "worldedit.tool.farwand.equip": "Far wand tool bound to {0}.",
     "worldedit.tool.lrbuild.equip": "Long-range building tool bound to {0}.",
     "worldedit.tool.lrbuild.set": "Left-click set to {0}; right-click set to {1}.",
+    "worldedit.tool.stack.equip": "Stack tool bound to {0}.",
 
     "worldedit.tool.superpickaxe.mode.single": "Mode is now single. Left click with a pickaxe. // to disable.",
     "worldedit.tool.superpickaxe.mode.area": "Mode is now area. Left click with a pickaxe. // to disable.",

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricAdapter.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricAdapter.java
@@ -60,6 +60,8 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
+
 public final class FabricAdapter {
 
     private FabricAdapter() {
@@ -102,7 +104,10 @@ public final class FabricAdapter {
         }
     }
 
-    public static Direction adaptEnumFacing(net.minecraft.util.math.Direction face) {
+    public static Direction adaptEnumFacing(@Nullable net.minecraft.util.math.Direction face) {
+        if (face == null) {
+            return null;
+        }
         switch (face) {
             case NORTH: return Direction.NORTH;
             case SOUTH: return Direction.SOUTH;

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorldEdit.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorldEdit.java
@@ -200,8 +200,9 @@ public class FabricWorldEdit implements ModInitializer {
                 blockPos.getY(),
                 blockPos.getZ()
         );
+        com.sk89q.worldedit.util.Direction weDirection = FabricAdapter.adaptEnumFacing(direction);
 
-        if (we.handleBlockLeftClick(player, pos)) {
+        if (we.handleBlockLeftClick(player, pos, weDirection)) {
             return ActionResult.SUCCESS;
         }
 
@@ -231,8 +232,9 @@ public class FabricWorldEdit implements ModInitializer {
                 blockHitResult.getBlockPos().getY(),
                 blockHitResult.getBlockPos().getZ()
         );
+        com.sk89q.worldedit.util.Direction direction = FabricAdapter.adaptEnumFacing(blockHitResult.getSide());
 
-        if (we.handleBlockRightClick(player, pos)) {
+        if (we.handleBlockRightClick(player, pos, direction)) {
             return ActionResult.SUCCESS;
         }
 

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeAdapter.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeAdapter.java
@@ -62,6 +62,8 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import javax.annotation.Nullable;
+
 public final class ForgeAdapter {
 
     private ForgeAdapter() {
@@ -104,7 +106,10 @@ public final class ForgeAdapter {
         }
     }
 
-    public static Direction adaptEnumFacing(net.minecraft.util.Direction face) {
+    public static Direction adaptEnumFacing(@Nullable net.minecraft.util.Direction face) {
+        if (face == null) {
+            return null;
+        }
         switch (face) {
             case NORTH: return Direction.NORTH;
             case SOUTH: return Direction.SOUTH;

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
@@ -32,6 +32,7 @@ import com.sk89q.worldedit.forge.proxy.ClientProxy;
 import com.sk89q.worldedit.forge.proxy.CommonProxy;
 import com.sk89q.worldedit.forge.proxy.ServerProxy;
 import com.sk89q.worldedit.internal.anvil.ChunkDeleter;
+import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockCategory;
@@ -246,13 +247,14 @@ public class ForgeWorldEdit {
         WorldEdit we = WorldEdit.getInstance();
         ForgePlayer player = adaptPlayer((ServerPlayerEntity) event.getPlayer());
         ForgeWorld world = getWorld(event.getPlayer().world);
+        Direction direction = ForgeAdapter.adaptEnumFacing(event.getFace());
 
         if (event instanceof PlayerInteractEvent.LeftClickEmpty) {
             we.handleArmSwing(player); // this event cannot be canceled
         } else if (event instanceof PlayerInteractEvent.LeftClickBlock) {
             Location pos = new Location(world, event.getPos().getX(), event.getPos().getY(), event.getPos().getZ());
 
-            if (we.handleBlockLeftClick(player, pos)) {
+            if (we.handleBlockLeftClick(player, pos, direction)) {
                 event.setCanceled(true);
             }
 
@@ -262,7 +264,7 @@ public class ForgeWorldEdit {
         } else if (event instanceof PlayerInteractEvent.RightClickBlock) {
             Location pos = new Location(world, event.getPos().getX(), event.getPos().getY(), event.getPos().getZ());
 
-            if (we.handleBlockRightClick(player, pos)) {
+            if (we.handleBlockRightClick(player, pos, direction)) {
                 event.setCanceled(true);
             }
 


### PR DESCRIPTION
This adds a new tool that acts similarly to stack but works by right-clicking a block.

You can configure the maximum range it will stack to, as well as set a mask that acts as an "endpoint" for the stacking. By default, it'll only replace air blocks.

https://gfycat.com/faithfulhardtofinddingo