### PR TITLE
Fix whitespace in worldedit.timeout.set

### DIFF
--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -39,7 +39,7 @@
     "worldedit.limit.set": "Block change limit set to {0}.",
     "worldedit.limit.return-to-default": "(Use //limit to go back to the default.)",
     "worldedit.timeout.too-high": "Your maximum allowable timeout is {0}ms.",
-    "worldedit.timeout.set": "Timeout time set to {0} ms.",
+    "worldedit.timeout.set": "Timeout time set to {0}ms.",
     "worldedit.timeout.return-to-default": " (Use //timeout to go back to the default.)",
     "worldedit.fast.disabled": "Fast mode disabled.",
     "worldedit.fast.enabled": "Fast mode enabled. Lighting in the affected chunks may be wrong and/or you may need to rejoin to see changes.",


### PR DESCRIPTION
Currently `worldedit.timeout.set` goes by {0} ms where `worldedit.timeout.too-high` goes by {0}ms.
This pr removes the space between the time and ms. Looks like octy prefers it without as well lul
![](https://i.imgur.com/GsQXfav.png)