### PR TITLE
Use a long to refer to the volume of a region to prevent overflow

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ExpandCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ExpandCommands.java
@@ -120,14 +120,14 @@ public class ExpandCommands {
                                    int height) throws IncompleteRegionException {
         Region region = session.getSelection(world);
         try {
-            int oldSize = region.getArea();
+            long oldSize = region.getVolume();
             region.expand(
                 BlockVector3.at(0, height, 0),
                 BlockVector3.at(0, -height, 0));
             session.getRegionSelector(world).learnChanges();
-            int newSize = region.getArea();
+            long newSize = region.getVolume();
             session.getRegionSelector(world).explainRegionAdjust(actor, session);
-            int changeSize = newSize - oldSize;
+            long changeSize = newSize - oldSize;
             actor.printInfo(
                 TranslatableComponent.of("worldedit.expand.expanded.vert", TextComponent.of(changeSize))
             );
@@ -150,7 +150,7 @@ public class ExpandCommands {
                        @MultiDirection
                            List<BlockVector3> direction) throws WorldEditException {
         Region region = session.getSelection(world);
-        int oldSize = region.getArea();
+        long oldSize = region.getVolume();
 
         if (reverseAmount == 0) {
             for (BlockVector3 dir : direction) {
@@ -163,11 +163,11 @@ public class ExpandCommands {
         }
 
         session.getRegionSelector(world).learnChanges();
-        int newSize = region.getArea();
+        long newSize = region.getVolume();
 
         session.getRegionSelector(world).explainRegionAdjust(actor, session);
 
-        int changeSize = newSize - oldSize;
+        long changeSize = newSize - oldSize;
         actor.printInfo(TranslatableComponent.of("worldedit.expand.expanded", TextComponent.of(changeSize)));
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SelectionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SelectionCommands.java
@@ -341,7 +341,7 @@ public class SelectionCommands {
                              List<BlockVector3> direction) throws WorldEditException {
         try {
             Region region = session.getSelection(world);
-            int oldSize = region.getArea();
+            long oldSize = region.getVolume();
             if (reverseAmount == 0) {
                 for (BlockVector3 dir : direction) {
                     region.contract(dir.multiply(amount));
@@ -352,7 +352,7 @@ public class SelectionCommands {
                 }
             }
             session.getRegionSelector(world).learnChanges();
-            int newSize = region.getArea();
+            long newSize = region.getVolume();
 
             session.getRegionSelector(world).explainRegionAdjust(actor, session);
 
@@ -480,7 +480,7 @@ public class SelectionCommands {
 
         actor.printInfo(TranslatableComponent.of("worldedit.size.size", TextComponent.of(size.toString())));
         actor.printInfo(TranslatableComponent.of("worldedit.size.distance", TextComponent.of(region.getMaximumPoint().distance(region.getMinimumPoint()))));
-        actor.printInfo(TranslatableComponent.of("worldedit.size.blocks", TextComponent.of(region.getArea())));
+        actor.printInfo(TranslatableComponent.of("worldedit.size.blocks", TextComponent.of(region.getVolume())));
     }
 
     @Command(

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/cui/SelectionPoint2DEvent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/cui/SelectionPoint2DEvent.java
@@ -27,8 +27,9 @@ public class SelectionPoint2DEvent implements CUIEvent {
     protected final int id;
     protected final int blockX;
     protected final int blockZ;
-    protected final int area;
+    protected final long area;
 
+    @Deprecated
     public SelectionPoint2DEvent(int id, BlockVector2 pos, int area) {
         this.id = id;
         this.blockX = pos.getX();
@@ -36,7 +37,22 @@ public class SelectionPoint2DEvent implements CUIEvent {
         this.area = area;
     }
 
+    @Deprecated
     public SelectionPoint2DEvent(int id, BlockVector3 pos, int area) {
+        this.id = id;
+        this.blockX = pos.getX();
+        this.blockZ = pos.getZ();
+        this.area = area;
+    }
+
+    public SelectionPoint2DEvent(int id, BlockVector2 pos, long area) {
+        this.id = id;
+        this.blockX = pos.getX();
+        this.blockZ = pos.getZ();
+        this.area = area;
+    }
+
+    public SelectionPoint2DEvent(int id, BlockVector3 pos, long area) {
         this.id = id;
         this.blockX = pos.getX();
         this.blockZ = pos.getZ();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/cui/SelectionPointEvent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/cui/SelectionPointEvent.java
@@ -25,9 +25,16 @@ public class SelectionPointEvent implements CUIEvent {
 
     protected final int id;
     protected final BlockVector3 pos;
-    protected final int area;
+    protected final long area;
 
+    @Deprecated
     public SelectionPointEvent(int id, BlockVector3 pos, int area) {
+        this.id = id;
+        this.pos = pos;
+        this.area = area;
+    }
+
+    public SelectionPointEvent(int id, BlockVector3 pos, long area) {
         this.id = id;
         this.pos = pos;
         this.area = area;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/AbstractRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/AbstractRegion.java
@@ -99,19 +99,14 @@ public abstract class AbstractRegion implements Region {
         return points;
     }
 
-    /**
-     * Get the number of blocks in the region.
-     *
-     * @return number of blocks
-     */
     @Override
-    public int getArea() {
+    public long getVolume() {
         BlockVector3 min = getMinimumPoint();
         BlockVector3 max = getMaximumPoint();
 
-        return (max.getX() - min.getX() + 1) *
-                (max.getY() - min.getY() + 1) *
-                (max.getZ() - min.getZ() + 1);
+        return (max.getX() - min.getX() + 1L) *
+                (max.getY() - min.getY() + 1L) *
+                (max.getZ() - min.getZ() + 1L);
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CylinderRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CylinderRegion.java
@@ -184,8 +184,8 @@ public class CylinderRegion extends AbstractRegion implements FlatRegion {
     }
 
     @Override
-    public int getArea() {
-        return (int) Math.floor(radius.getX() * radius.getZ() * Math.PI * getHeight());
+    public long getVolume() {
+        return (long) Math.floor(radius.getX() * radius.getZ() * Math.PI * getHeight());
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CylinderRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CylinderRegion.java
@@ -31,6 +31,7 @@ import com.sk89q.worldedit.regions.iterator.FlatRegion3DIterator;
 import com.sk89q.worldedit.regions.iterator.FlatRegionIterator;
 import com.sk89q.worldedit.world.World;
 
+import java.math.BigDecimal;
 import java.util.Iterator;
 import java.util.List;
 
@@ -183,9 +184,15 @@ public class CylinderRegion extends AbstractRegion implements FlatRegion {
         return minY;
     }
 
+    private static final BigDecimal PI = BigDecimal.valueOf(Math.PI);
+
     @Override
     public long getVolume() {
-        return (long) Math.floor(radius.getX() * radius.getZ() * Math.PI * getHeight());
+        return BigDecimal.valueOf(radius.getX())
+                .multiply(BigDecimal.valueOf(radius.getZ()))
+                .multiply(PI)
+                .multiply(BigDecimal.valueOf(getHeight()))
+                .longValue();
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CylinderRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CylinderRegion.java
@@ -32,6 +32,7 @@ import com.sk89q.worldedit.regions.iterator.FlatRegionIterator;
 import com.sk89q.worldedit.world.World;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Iterator;
 import java.util.List;
 
@@ -192,6 +193,7 @@ public class CylinderRegion extends AbstractRegion implements FlatRegion {
                 .multiply(BigDecimal.valueOf(radius.getZ()))
                 .multiply(PI)
                 .multiply(BigDecimal.valueOf(getHeight()))
+                .setScale(0, RoundingMode.FLOOR)
                 .longValue();
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/EllipsoidRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/EllipsoidRegion.java
@@ -82,7 +82,7 @@ public class EllipsoidRegion extends AbstractRegion {
         return center.toVector3().add(getRadius()).toBlockPoint();
     }
 
-    private final BigDecimal ELLIPSOID_BASE_MULTIPLIER = BigDecimal.valueOf((4.0 / 3.0) * Math.PI);
+    private static final BigDecimal ELLIPSOID_BASE_MULTIPLIER = BigDecimal.valueOf((4.0 / 3.0) * Math.PI);
 
     @Override
     public long getVolume() {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/EllipsoidRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/EllipsoidRegion.java
@@ -82,10 +82,11 @@ public class EllipsoidRegion extends AbstractRegion {
         return center.toVector3().add(getRadius()).toBlockPoint();
     }
 
+    private final BigDecimal ELLIPSOID_BASE_MULTIPLIER = BigDecimal.valueOf((4.0 / 3.0) * Math.PI);
 
     @Override
     public long getVolume() {
-        return BigDecimal.valueOf((4.0 / 3.0) * Math.PI)
+        return ELLIPSOID_BASE_MULTIPLIER
                 .multiply(BigDecimal.valueOf(radius.getX()))
                 .multiply(BigDecimal.valueOf(radius.getY()))
                 .multiply(BigDecimal.valueOf(radius.getZ()))

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/EllipsoidRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/EllipsoidRegion.java
@@ -81,8 +81,8 @@ public class EllipsoidRegion extends AbstractRegion {
     }
 
     @Override
-    public int getArea() {
-        return (int) Math.floor((4.0 / 3.0) * Math.PI * radius.getX() * radius.getY() * radius.getZ());
+    public long getVolume() {
+        return (long) Math.floor((4.0 / 3.0) * Math.PI * radius.getX() * radius.getY() * radius.getZ());
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/EllipsoidRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/EllipsoidRegion.java
@@ -26,6 +26,7 @@ import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.storage.ChunkStore;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -88,6 +89,7 @@ public class EllipsoidRegion extends AbstractRegion {
                 .multiply(BigDecimal.valueOf(radius.getX()))
                 .multiply(BigDecimal.valueOf(radius.getY()))
                 .multiply(BigDecimal.valueOf(radius.getZ()))
+                .setScale(0, RoundingMode.FLOOR)
                 .longValue();
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/EllipsoidRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/EllipsoidRegion.java
@@ -25,6 +25,7 @@ import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.storage.ChunkStore;
 
+import java.math.BigDecimal;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -80,9 +81,14 @@ public class EllipsoidRegion extends AbstractRegion {
         return center.toVector3().add(getRadius()).toBlockPoint();
     }
 
+
     @Override
     public long getVolume() {
-        return (long) Math.floor((4.0 / 3.0) * Math.PI * radius.getX() * radius.getY() * radius.getZ());
+        return BigDecimal.valueOf((4.0 / 3.0) * Math.PI)
+                .multiply(BigDecimal.valueOf(radius.getX()))
+                .multiply(BigDecimal.valueOf(radius.getY()))
+                .multiply(BigDecimal.valueOf(radius.getZ()))
+                .longValue();
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/NullRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/NullRegion.java
@@ -53,7 +53,7 @@ public class NullRegion implements Region {
     }
 
     @Override
-    public int getArea() {
+    public long getVolume() {
         return 0;
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegion.java
@@ -200,17 +200,17 @@ public class Polygonal2DRegion extends AbstractRegion implements FlatRegion {
 
     @Override
     public long getVolume() {
-        BigDecimal area = BigDecimal.ZERO;
+        long area = 0;
         int i, j = points.size() - 1;
 
         for (i = 0; i < points.size(); ++i) {
             long x = points.get(j).getBlockX() + points.get(i).getBlockX();
             long z = points.get(j).getBlockZ() - points.get(i).getBlockZ();
-            area = area.add(BigDecimal.valueOf(x).multiply(BigDecimal.valueOf(z)));
+            area += x * z;
             j = i;
         }
 
-        return area
+        return BigDecimal.valueOf(area)
                 .multiply(BigDecimal.valueOf(0.5))
                 .abs()
                 .setScale(0, RoundingMode.FLOOR)

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegion.java
@@ -204,10 +204,9 @@ public class Polygonal2DRegion extends AbstractRegion implements FlatRegion {
         int i, j = points.size() - 1;
 
         for (i = 0; i < points.size(); ++i) {
-            area = area.add(
-                    BigDecimal.valueOf(points.get(j).getBlockX() + points.get(i).getBlockX())
-                            .multiply(BigDecimal.valueOf(points.get(j).getBlockZ() - points.get(i).getBlockZ()))
-            );
+            long x = points.get(j).getBlockX() + points.get(i).getBlockX();
+            long z = points.get(j).getBlockZ() - points.get(i).getBlockZ();
+            area = area.add(BigDecimal.valueOf(x).multiply(BigDecimal.valueOf(z)));
             j = i;
         }
 
@@ -215,8 +214,7 @@ public class Polygonal2DRegion extends AbstractRegion implements FlatRegion {
                 .multiply(BigDecimal.valueOf(0.5))
                 .abs()
                 .setScale(0, RoundingMode.FLOOR)
-                .multiply(BigDecimal.valueOf(maxY - minY + 1))
-                .longValue();
+                .longValue() * (maxY - minY + 1);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegion.java
@@ -197,7 +197,7 @@ public class Polygonal2DRegion extends AbstractRegion implements FlatRegion {
     }
 
     @Override
-    public int getArea() {
+    public long getVolume() {
         double area = 0;
         int i, j = points.size() - 1;
 
@@ -207,7 +207,7 @@ public class Polygonal2DRegion extends AbstractRegion implements FlatRegion {
             j = i;
         }
 
-        return (int) Math.floor(Math.abs(area * 0.5)
+        return (long) Math.floor(Math.abs(area * 0.5)
                 * (maxY - minY + 1));
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegion.java
@@ -25,6 +25,8 @@ import com.sk89q.worldedit.regions.iterator.FlatRegion3DIterator;
 import com.sk89q.worldedit.regions.iterator.FlatRegionIterator;
 import com.sk89q.worldedit.world.World;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -198,17 +200,23 @@ public class Polygonal2DRegion extends AbstractRegion implements FlatRegion {
 
     @Override
     public long getVolume() {
-        double area = 0;
+        BigDecimal area = BigDecimal.ZERO;
         int i, j = points.size() - 1;
 
         for (i = 0; i < points.size(); ++i) {
-            area += (points.get(j).getBlockX() + points.get(i).getBlockX())
-                    * (points.get(j).getBlockZ() - points.get(i).getBlockZ());
+            area = area.add(
+                    BigDecimal.valueOf(points.get(j).getBlockX() + points.get(i).getBlockX())
+                            .multiply(BigDecimal.valueOf(points.get(j).getBlockZ() - points.get(i).getBlockZ()))
+            );
             j = i;
         }
 
-        return (long) Math.floor(Math.abs(area * 0.5)
-                * (maxY - minY + 1));
+        return area
+                .multiply(BigDecimal.valueOf(0.5))
+                .abs()
+                .setScale(0, RoundingMode.FLOOR)
+                .multiply(BigDecimal.valueOf(maxY - minY + 1))
+                .longValue();
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Region.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Region.java
@@ -71,6 +71,8 @@ public interface Region extends Iterable<BlockVector3>, Cloneable {
     /**
      * Get the number of blocks in the region.
      *
+     * <p>Note: This method <b>must</b> be overridden.</p>
+     *
      * @return number of blocks
      */
     default long getVolume() {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Region.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Region.java
@@ -61,8 +61,22 @@ public interface Region extends Iterable<BlockVector3>, Cloneable {
      * Get the number of blocks in the region.
      *
      * @return number of blocks
+     * @deprecated use {@link Region#getVolume()} to prevent overflows
      */
-    int getArea();
+    @Deprecated
+    default int getArea() {
+        return (int) getVolume();
+    }
+
+    /**
+     * Get the number of blocks in the region.
+     *
+     * @return number of blocks
+     */
+    default long getVolume() {
+        // TODO Remove default status when getArea is removed.
+        return getArea();
+    }
 
     /**
      * Get X-size.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Region.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Region.java
@@ -76,11 +76,11 @@ public interface Region extends Iterable<BlockVector3>, Cloneable {
     default long getVolume() {
         // TODO Remove default status when getArea is removed.
         try {
-            if (getClass().getMethod("getArea").getDeclaringClass().equals(this.getClass())) {
-                throw new IllegalStateException("Class " + getClass().getName() + " must override either getVolume or getArea.");
+            if (getClass().getMethod("getArea").getDeclaringClass().equals(Region.class)) {
+                throw new IllegalStateException("Class " + getClass().getName() + " must override getVolume.");
             }
         } catch (NoSuchMethodException e) {
-            e.printStackTrace();
+            throw new AssertionError(e);
         }
         return getArea();
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Region.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Region.java
@@ -75,6 +75,13 @@ public interface Region extends Iterable<BlockVector3>, Cloneable {
      */
     default long getVolume() {
         // TODO Remove default status when getArea is removed.
+        try {
+            if (getClass().getMethod("getArea").getDeclaringClass().equals(this.getClass())) {
+                throw new IllegalStateException("Class " + getClass().getName() + " must override either getVolume or getArea.");
+            }
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+        }
         return getArea();
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/RegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/RegionSelector.java
@@ -144,6 +144,8 @@ public interface RegionSelector {
     /**
      * Get the number of blocks inside the region.
      *
+     * <p>Note: This method <b>must</b> be overridden.</p>
+     *
      * @return number of blocks, or -1 if undefined
      */
     default long getVolume() {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/RegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/RegionSelector.java
@@ -148,6 +148,13 @@ public interface RegionSelector {
      */
     default long getVolume() {
         // TODO Remove default once getArea is removed
+        try {
+            if (getClass().getMethod("getArea").getDeclaringClass().equals(this.getClass())) {
+                throw new IllegalStateException("Class " + getClass().getName() + " must override either getVolume or getArea.");
+            }
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+        }
         return getArea();
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/RegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/RegionSelector.java
@@ -149,11 +149,11 @@ public interface RegionSelector {
     default long getVolume() {
         // TODO Remove default once getArea is removed
         try {
-            if (getClass().getMethod("getArea").getDeclaringClass().equals(this.getClass())) {
-                throw new IllegalStateException("Class " + getClass().getName() + " must override either getVolume or getArea.");
+            if (getClass().getMethod("getArea").getDeclaringClass().equals(RegionSelector.class)) {
+                throw new IllegalStateException("Class " + getClass().getName() + " must override getVolume.");
             }
         } catch (NoSuchMethodException e) {
-            e.printStackTrace();
+            throw new AssertionError(e);
         }
         return getArea();
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/RegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/RegionSelector.java
@@ -134,8 +134,22 @@ public interface RegionSelector {
      * Get the number of blocks inside the region.
      *
      * @return number of blocks, or -1 if undefined
+     * @deprecated use {@link RegionSelector#getVolume()}
      */
-    int getArea();
+    @Deprecated
+    default int getArea() {
+        return (int) getVolume();
+    }
+
+    /**
+     * Get the number of blocks inside the region.
+     *
+     * @return number of blocks, or -1 if undefined
+     */
+    default long getVolume() {
+        // TODO Remove default once getArea is removed
+        return getArea();
+    }
 
     /**
      * Update the selector with changes to the region.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/TransformRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/TransformRegion.java
@@ -113,8 +113,8 @@ public class TransformRegion extends AbstractRegion {
     }
 
     @Override
-    public int getArea() {
-        return region.getArea(); // Cannot transform this
+    public long getVolume() {
+        return region.getVolume(); // Cannot transform this
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/ConvexPolyhedralRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/ConvexPolyhedralRegionSelector.java
@@ -165,8 +165,8 @@ public class ConvexPolyhedralRegionSelector implements RegionSelector, CUIRegion
     }
 
     @Override
-    public int getArea() {
-        return region.getArea();
+    public long getVolume() {
+        return region.getVolume();
     }
 
     @Override
@@ -245,7 +245,7 @@ public class ConvexPolyhedralRegionSelector implements RegionSelector, CUIRegion
         int lastVertexId = -1;
         for (BlockVector3 vertex : vertices) {
             vertexIds.put(vertex, ++lastVertexId);
-            session.dispatchCUIEvent(player, new SelectionPointEvent(lastVertexId, vertex, getArea()));
+            session.dispatchCUIEvent(player, new SelectionPointEvent(lastVertexId, vertex, getVolume()));
         }
 
         for (Triangle triangle : triangles) {
@@ -268,8 +268,8 @@ public class ConvexPolyhedralRegionSelector implements RegionSelector, CUIRegion
         checkNotNull(session);
 
         if (isDefined()) {
-            session.dispatchCUIEvent(player, new SelectionPointEvent(0, region.getMinimumPoint(), getArea()));
-            session.dispatchCUIEvent(player, new SelectionPointEvent(1, region.getMaximumPoint(), getArea()));
+            session.dispatchCUIEvent(player, new SelectionPointEvent(0, region.getMinimumPoint(), getVolume()));
+            session.dispatchCUIEvent(player, new SelectionPointEvent(1, region.getMaximumPoint(), getVolume()));
         }
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/CuboidRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/CuboidRegionSelector.java
@@ -160,13 +160,13 @@ public class CuboidRegionSelector implements RegionSelector, CUIRegion {
             player.printInfo(TranslatableComponent.of(
                     "worldedit.selection.cuboid.explain.primary-area",
                     TextComponent.of(position1.toString()),
-                    TextComponent.of(region.getArea())
+                    TextComponent.of(region.getVolume())
             ));
         } else if (position1 != null) {
             player.printInfo(TranslatableComponent.of("worldedit.selection.cuboid.explain.primary", TextComponent.of(position1.toString())));
         }
 
-        session.dispatchCUIEvent(player, new SelectionPointEvent(0, pos, getArea()));
+        session.dispatchCUIEvent(player, new SelectionPointEvent(0, pos, getVolume()));
     }
 
     @Override
@@ -179,13 +179,13 @@ public class CuboidRegionSelector implements RegionSelector, CUIRegion {
             player.printInfo(TranslatableComponent.of(
                     "worldedit.selection.cuboid.explain.secondary-area",
                     TextComponent.of(position2.toString()),
-                    TextComponent.of(region.getArea())
+                    TextComponent.of(region.getVolume())
             ));
         } else if (position2 != null) {
             player.printInfo(TranslatableComponent.of("worldedit.selection.cuboid.explain.secondary", TextComponent.of(position2.toString())));
         }
 
-        session.dispatchCUIEvent(player, new SelectionPointEvent(1, pos, getArea()));
+        session.dispatchCUIEvent(player, new SelectionPointEvent(1, pos, getVolume()));
     }
 
     @Override
@@ -196,11 +196,11 @@ public class CuboidRegionSelector implements RegionSelector, CUIRegion {
         session.dispatchCUIEvent(player, new SelectionShapeEvent(getTypeID()));
 
         if (position1 != null) {
-            session.dispatchCUIEvent(player, new SelectionPointEvent(0, position1, getArea()));
+            session.dispatchCUIEvent(player, new SelectionPointEvent(0, position1, getVolume()));
         }
 
         if (position2 != null) {
-            session.dispatchCUIEvent(player, new SelectionPointEvent(1, position2, getArea()));
+            session.dispatchCUIEvent(player, new SelectionPointEvent(1, position2, getVolume()));
         }
     }
 
@@ -267,7 +267,7 @@ public class CuboidRegionSelector implements RegionSelector, CUIRegion {
     }
 
     @Override
-    public int getArea() {
+    public long getVolume() {
         if (position1 == null) {
             return -1;
         }
@@ -276,17 +276,17 @@ public class CuboidRegionSelector implements RegionSelector, CUIRegion {
             return -1;
         }
 
-        return region.getArea();
+        return region.getVolume();
     }
 
     @Override
     public void describeCUI(LocalSession session, Actor player) {
         if (position1 != null) {
-            session.dispatchCUIEvent(player, new SelectionPointEvent(0, position1, getArea()));
+            session.dispatchCUIEvent(player, new SelectionPointEvent(0, position1, getVolume()));
         }
 
         if (position2 != null) {
-            session.dispatchCUIEvent(player, new SelectionPointEvent(1, position2, getArea()));
+            session.dispatchCUIEvent(player, new SelectionPointEvent(1, position2, getVolume()));
         }
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/CylinderRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/CylinderRegionSelector.java
@@ -183,7 +183,7 @@ public class CylinderRegionSelector implements RegionSelector, CUIRegion {
                     "worldedit.selection.cylinder.explain.secondary",
                     TextComponent.of(NUMBER_FORMAT.format(region.getRadius().getX())),
                     TextComponent.of(NUMBER_FORMAT.format(region.getRadius().getZ())),
-                    TextComponent.of(region.getArea())
+                    TextComponent.of(region.getVolume())
             ));
         } else {
             player.printError(TranslatableComponent.of("worldedit.selection.cylinder.explain.secondary-missing"));
@@ -255,8 +255,8 @@ public class CylinderRegionSelector implements RegionSelector, CUIRegion {
     }
 
     @Override
-    public int getArea() {
-        return region.getArea();
+    public long getVolume() {
+        return region.getVolume();
     }
 
     @Override
@@ -268,8 +268,8 @@ public class CylinderRegionSelector implements RegionSelector, CUIRegion {
     @Override
     public void describeLegacyCUI(LocalSession session, Actor player) {
         if (isDefined()) {
-            session.dispatchCUIEvent(player, new SelectionPointEvent(0, region.getMinimumPoint(), getArea()));
-            session.dispatchCUIEvent(player, new SelectionPointEvent(1, region.getMaximumPoint(), getArea()));
+            session.dispatchCUIEvent(player, new SelectionPointEvent(0, region.getMinimumPoint(), getVolume()));
+            session.dispatchCUIEvent(player, new SelectionPointEvent(1, region.getMaximumPoint(), getVolume()));
         }
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/EllipsoidRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/EllipsoidRegionSelector.java
@@ -151,7 +151,7 @@ public class EllipsoidRegionSelector implements RegionSelector, CUIRegion {
             player.printInfo(TranslatableComponent.of(
                     "worldedit.selection.ellipsoid.explain.primary-area",
                     TextComponent.of(region.getCenter().toString()),
-                    TextComponent.of(region.getArea())
+                    TextComponent.of(region.getVolume())
             ));
         } else {
             player.printInfo(TranslatableComponent.of(
@@ -169,7 +169,7 @@ public class EllipsoidRegionSelector implements RegionSelector, CUIRegion {
             player.printInfo(TranslatableComponent.of(
                     "worldedit.selection.ellipsoid.explain.secondary-area",
                     TextComponent.of(region.getRadius().toString()),
-                    TextComponent.of(region.getArea())
+                    TextComponent.of(region.getVolume())
             ));
         } else {
             player.printInfo(TranslatableComponent.of(
@@ -238,8 +238,8 @@ public class EllipsoidRegionSelector implements RegionSelector, CUIRegion {
     }
 
     @Override
-    public int getArea() {
-        return region.getArea();
+    public long getVolume() {
+        return region.getVolume();
     }
 
     @Override
@@ -250,8 +250,8 @@ public class EllipsoidRegionSelector implements RegionSelector, CUIRegion {
 
     @Override
     public void describeLegacyCUI(LocalSession session, Actor player) {
-        session.dispatchCUIEvent(player, new SelectionPointEvent(0, region.getMinimumPoint(), getArea()));
-        session.dispatchCUIEvent(player, new SelectionPointEvent(1, region.getMaximumPoint(), getArea()));
+        session.dispatchCUIEvent(player, new SelectionPointEvent(0, region.getMinimumPoint(), getVolume()));
+        session.dispatchCUIEvent(player, new SelectionPointEvent(1, region.getMaximumPoint(), getVolume()));
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/ExtendingCuboidRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/ExtendingCuboidRegionSelector.java
@@ -134,7 +134,7 @@ public class ExtendingCuboidRegionSelector extends CuboidRegionSelector {
         player.printInfo(TranslatableComponent.of(
                 "worldedit.selection.extend.explain.primary",
                 TextComponent.of(pos.toString()),
-                TextComponent.of(region.getArea())
+                TextComponent.of(region.getVolume())
         ));
 
         explainRegionAdjust(player, session);
@@ -145,7 +145,7 @@ public class ExtendingCuboidRegionSelector extends CuboidRegionSelector {
         player.printInfo(TranslatableComponent.of(
                 "worldedit.selection.extend.explain.secondary",
                 TextComponent.of(pos.toString()),
-                TextComponent.of(region.getArea())
+                TextComponent.of(region.getVolume())
         ));
 
         explainRegionAdjust(player, session);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/Polygonal2DRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/Polygonal2DRegionSelector.java
@@ -169,7 +169,7 @@ public class Polygonal2DRegionSelector implements RegionSelector, CUIRegion {
         player.printInfo(TranslatableComponent.of("worldedit.selection.polygon2d.explain.primary", TextComponent.of(pos.toString())));
 
         session.dispatchCUIEvent(player, new SelectionShapeEvent(getTypeID()));
-        session.dispatchCUIEvent(player, new SelectionPoint2DEvent(0, pos, getArea()));
+        session.dispatchCUIEvent(player, new SelectionPoint2DEvent(0, pos, getVolume()));
         session.dispatchCUIEvent(player, new SelectionMinMaxEvent(region.getMinimumY(), region.getMaximumY()));
     }
 
@@ -181,7 +181,7 @@ public class Polygonal2DRegionSelector implements RegionSelector, CUIRegion {
                 TextComponent.of(pos.toString())
         ));
 
-        session.dispatchCUIEvent(player, new SelectionPoint2DEvent(region.size() - 1, pos, getArea()));
+        session.dispatchCUIEvent(player, new SelectionPoint2DEvent(region.size() - 1, pos, getVolume()));
         session.dispatchCUIEvent(player, new SelectionMinMaxEvent(region.getMinimumY(), region.getMaximumY()));
     }
 
@@ -242,8 +242,8 @@ public class Polygonal2DRegionSelector implements RegionSelector, CUIRegion {
     }
 
     @Override
-    public int getArea() {
-        return region.getArea();
+    public long getVolume() {
+        return region.getVolume();
     }
 
     /**
@@ -259,7 +259,7 @@ public class Polygonal2DRegionSelector implements RegionSelector, CUIRegion {
     public void describeCUI(LocalSession session, Actor player) {
         final List<BlockVector2> points = region.getPoints();
         for (int id = 0; id < points.size(); id++) {
-            session.dispatchCUIEvent(player, new SelectionPoint2DEvent(id, points.get(id), getArea()));
+            session.dispatchCUIEvent(player, new SelectionPoint2DEvent(id, points.get(id), getVolume()));
         }
 
         session.dispatchCUIEvent(player, new SelectionMinMaxEvent(region.getMinimumY(), region.getMaximumY()));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/SphereRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/SphereRegionSelector.java
@@ -93,7 +93,7 @@ public class SphereRegionSelector extends EllipsoidRegionSelector {
             player.printInfo(TranslatableComponent.of(
                     "worldedit.selection.sphere.explain.secondary-defined",
                     TextComponent.of(region.getRadius().getX()),
-                    TextComponent.of(region.getArea())
+                    TextComponent.of(region.getVolume())
             ));
         } else {
             player.printInfo(TranslatableComponent.of("worldedit.selection.sphere.explain.secondary", TextComponent.of(region.getRadius().getX())));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/request/RequestSelection.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/request/RequestSelection.java
@@ -78,8 +78,8 @@ public class RequestSelection implements Region {
     }
 
     @Override
-    public int getArea() {
-        return getRegion().getArea();
+    public long getVolume() {
+        return getRegion().getVolume();
     }
 
     @Override


### PR DESCRIPTION
I've also renamed it to getVolume, as that's more accurate.

One potential concern here is with double precision on the non-cuboid selection types when it comes to the larger sizes. Doubles are less precise above integer bounds and therefore may produce incorrect results for super large selections, not sure we should care tbh.

Fixes #1344 