### PR TITLE
fix: require extent for mask parsing

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BiomeMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BiomeMaskParser.java
@@ -76,6 +76,6 @@ public class BiomeMaskParser extends InputParser<Mask> {
             biomes.add(biome);
         }
 
-        return new BiomeMask(context.getExtent(), biomes);
+        return new BiomeMask(context.requireExtent(), biomes);
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlockCategoryMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlockCategoryMaskParser.java
@@ -53,7 +53,7 @@ public class BlockCategoryMaskParser extends InputParser<Mask> {
         if (category == null) {
             throw new InputParseException("Unrecognised tag '" + input.substring(2) + '\'');
         } else {
-            return new BlockCategoryMask(context.getExtent(), category);
+            return new BlockCategoryMask(context.requireExtent(), category);
         }
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlockStateMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlockStateMaskParser.java
@@ -52,7 +52,7 @@ public class BlockStateMaskParser extends InputParser<Mask> {
         boolean strict = input.charAt(1) == '=';
         String states = input.substring(2 + (strict ? 1 : 0), input.length() - 1);
         try {
-            return new BlockStateMask(context.getExtent(),
+            return new BlockStateMask(context.requireExtent(),
                     Splitter.on(',').omitEmptyStrings().trimResults().withKeyValueSeparator('=').split(states),
                     strict);
         } catch (Exception e) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlocksMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlocksMaskParser.java
@@ -55,7 +55,7 @@ public class BlocksMaskParser extends InputParser<Mask> {
             if (holders.isEmpty()) {
                 return null;
             }
-            return new BlockMask(context.getExtent(), holders);
+            return new BlockMask(context.requireExtent(), holders);
         } catch (NoMatchException e) {
             return null;
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/ExistingMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/ExistingMaskParser.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.extension.factory.parser.mask;
 
 import com.google.common.collect.ImmutableList;
 import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.ParserContext;
 import com.sk89q.worldedit.function.mask.ExistingBlockMask;
 import com.sk89q.worldedit.function.mask.Mask;
@@ -42,7 +43,7 @@ public class ExistingMaskParser extends SimpleInputParser<Mask> {
     }
 
     @Override
-    public Mask parseFromSimpleInput(String input, ParserContext context) {
-        return new ExistingBlockMask(context.getExtent());
+    public Mask parseFromSimpleInput(String input, ParserContext context) throws InputParseException {
+        return new ExistingBlockMask(context.requireExtent());
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/ExpressionMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/ExpressionMaskParser.java
@@ -57,7 +57,7 @@ public class ExpressionMaskParser extends InputParser<Mask> {
         try {
             Expression exp = Expression.compile(input.substring(1), "x", "y", "z");
             WorldEditExpressionEnvironment env = new WorldEditExpressionEnvironment(
-                    context.getExtent(), Vector3.ONE, Vector3.ZERO);
+                    context.requireExtent(), Vector3.ONE, Vector3.ZERO);
             exp.setEnvironment(env);
             if (context.getActor() != null) {
                 SessionOwner owner = context.getActor();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/OffsetMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/OffsetMaskParser.java
@@ -61,7 +61,7 @@ public class OffsetMaskParser extends InputParser<Mask> {
         if (input.length() > 1) {
             submask = worldEdit.getMaskFactory().parseFromInput(input.substring(1), context);
         } else {
-            submask = new ExistingBlockMask(context.getExtent());
+            submask = new ExistingBlockMask(context.requireExtent());
         }
         OffsetMask offsetMask = new OffsetMask(submask, BlockVector3.at(0, firstChar == '>' ? -1 : 1, 0));
         return new MaskIntersection(offsetMask, Masks.negate(submask));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/SolidMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/SolidMaskParser.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.extension.factory.parser.mask;
 
 import com.google.common.collect.ImmutableList;
 import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.ParserContext;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.mask.SolidBlockMask;
@@ -42,7 +43,7 @@ public class SolidMaskParser extends SimpleInputParser<Mask> {
     }
 
     @Override
-    public Mask parseFromSimpleInput(String input, ParserContext context) {
-        return new SolidBlockMask(context.getExtent());
+    public Mask parseFromSimpleInput(String input, ParserContext context) throws InputParseException {
+        return new SolidBlockMask(context.requireExtent());
     }
 }


### PR DESCRIPTION
This uses requireExtent rather than getExtent, to prevent an error from being thrown.

This message is still somewhat non-helpful, but I'll fix it when making exceptions localisable.

Fixes https://github.com/EngineHub/WorldEdit/issues/1364