### PR TITLE
Mojang AB and the Column Biome Fuzzer

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
@@ -489,6 +489,12 @@ public class BukkitWorld extends AbstractWorld {
         return false;
     }
 
+    @Override
+    public boolean fullySupports3DBiomes() {
+        // Supports if API does and we're not in the overworld
+        return HAS_3D_BIOMES && getWorld().getEnvironment() != World.Environment.NORMAL;
+    }
+
     @SuppressWarnings("deprecated")
     @Override
     public BiomeType getBiome(BlockVector3 position) {

--- a/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/schematic/ClipboardWorld.java
+++ b/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/schematic/ClipboardWorld.java
@@ -149,6 +149,11 @@ public class ClipboardWorld extends AbstractWorld implements Clipboard, CLIWorld
     }
 
     @Override
+    public boolean fullySupports3DBiomes() {
+        return true;
+    }
+
+    @Override
     public BiomeType getBiome(BlockVector3 position) {
         return clipboard.getBiome(position);
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/biome/BiomeReplace.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/biome/BiomeReplace.java
@@ -28,6 +28,7 @@ import com.sk89q.worldedit.function.RegionFunction;
 import com.sk89q.worldedit.function.pattern.BiomePattern;
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.biome.BiomeType;
 
 /**
@@ -63,12 +64,18 @@ public class BiomeReplace implements FlatRegionFunction, RegionFunction {
 
     @Override
     public boolean apply(BlockVector3 position) throws WorldEditException {
+        if (extent instanceof World && !((World) extent).fullySupports3DBiomes()) {
+            position = position.withY(0);
+        }
         return extent.setBiome(position, biome.applyBiome(position));
     }
 
     @Override
     @Deprecated
     public boolean apply(BlockVector2 position) throws WorldEditException {
+        if (extent instanceof World && !((World) extent).fullySupports3DBiomes()) {
+            return apply(position.toBlockVector3());
+        }
         boolean success = false;
         for (int y = extent.getMinimumPoint().getY(); y <= extent.getMaximumPoint().getY(); y++) {
             success |= apply(position.toBlockVector3(y));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/biome/ExtentBiomeCopy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/biome/ExtentBiomeCopy.java
@@ -26,6 +26,7 @@ import com.sk89q.worldedit.function.RegionFunction;
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.transform.Transform;
+import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.biome.BiomeType;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -91,9 +92,15 @@ public class ExtentBiomeCopy implements FlatRegionFunction, RegionFunction {
     public boolean apply(BlockVector3 position) throws WorldEditException {
         BiomeType biome = source.getBiome(position);
         BlockVector3 orig = position.subtract(from);
-        BlockVector3 transformed = transform.apply(orig.toVector3()).toBlockPoint();
+        BlockVector3 transformed = transform.apply(orig.toVector3())
+            .toBlockPoint()
+            .add(to);
 
-        return destination.setBiome(transformed.add(to), biome);
+        if (destination instanceof World && !((World) destination).fullySupports3DBiomes()) {
+            transformed = transformed.withY(0);
+        }
+
+        return destination.setBiome(transformed, biome);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/ArbitraryBiomeShape.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/ArbitraryBiomeShape.java
@@ -122,6 +122,8 @@ public abstract class ArbitraryBiomeShape {
     public int generate(EditSession editSession, BiomeType baseBiome, boolean hollow) {
         int affected = 0;
 
+        boolean fullySupports3DBiomes = editSession.getWorld().fullySupports3DBiomes();
+
         for (BlockVector3 position : getExtent()) {
             int x = position.getBlockX();
             int y = position.getBlockY();
@@ -130,6 +132,9 @@ public abstract class ArbitraryBiomeShape {
             if (!hollow) {
                 final BiomeType material = getBiome(x, y, z, baseBiome);
                 if (material != null && material != BiomeTypes.THE_VOID) {
+                    if (!fullySupports3DBiomes) {
+                        position = position.withY(0);
+                    }
                     editSession.getWorld().setBiome(position, material);
                     ++affected;
                 }
@@ -172,6 +177,10 @@ public abstract class ArbitraryBiomeShape {
 
             if (!draw) {
                 continue;
+            }
+
+            if (!fullySupports3DBiomes) {
+                position = position.withY(0);
             }
 
             editSession.getWorld().setBiome(position, material);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/ArbitraryBiomeShape.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/ArbitraryBiomeShape.java
@@ -23,7 +23,8 @@ import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.world.biome.BiomeType;
-import com.sk89q.worldedit.world.biome.BiomeTypes;
+
+import java.util.BitSet;
 
 /**
  * Generates solid and hollow shapes according to materials returned by the
@@ -39,6 +40,8 @@ public abstract class ArbitraryBiomeShape {
     private final int cacheSizeX;
     private final int cacheSizeY;
     private final int cacheSizeZ;
+    private final BiomeType[] cache;
+    private final BitSet isCached;
 
     public ArbitraryBiomeShape(Region extent) {
         this.extent = extent;
@@ -55,20 +58,12 @@ public abstract class ArbitraryBiomeShape {
         cacheSizeZ = max.getZ() - cacheOffsetZ + 2;
 
         cache = new BiomeType[cacheSizeX * cacheSizeY * cacheSizeZ];
+        isCached = new BitSet(cache.length);
     }
 
     protected Iterable<BlockVector3> getExtent() {
         return extent;
     }
-
-
-    /**
-     * Cache entries:
-     * null = unknown
-     * OUTSIDE = outside
-     * else = inside
-     */
-    private final BiomeType[] cache;
 
     /**
      * Override this function to specify the shape to generate.
@@ -83,32 +78,18 @@ public abstract class ArbitraryBiomeShape {
     private BiomeType getBiomeCached(int x, int y, int z, BiomeType baseBiome) {
         final int index = (y - cacheOffsetY) + (z - cacheOffsetZ) * cacheSizeY + (x - cacheOffsetX) * cacheSizeY * cacheSizeZ;
 
-        final BiomeType cacheEntry = cache[index];
-        if (cacheEntry == null) {// unknown, fetch material
+        if (!isCached.get(index)) {
             final BiomeType material = getBiome(x, y, z, baseBiome);
-            if (material == null) {
-                // outside
-                cache[index] = null;
-                return null;
-            }
-
+            isCached.set(index);
             cache[index] = material;
             return material;
         }
 
-        return cacheEntry;
+        return cache[index];
     }
 
-    private boolean isInsideCached(int x, int y, int z, BiomeType baseBiome) {
-        final int index = (y - cacheOffsetY) + (z - cacheOffsetZ) * cacheSizeY + (x - cacheOffsetX) * cacheSizeY * cacheSizeZ;
-
-        final BiomeType cacheEntry = cache[index];
-        if (cacheEntry == null) {
-            // unknown block, meaning they must be outside the extent at this stage, but might still be inside the shape
-            return getBiomeCached(x, y, z, baseBiome) != null;
-        }
-
-        return cacheEntry != BiomeTypes.THE_VOID;
+    private boolean isOutside(int x, int y, int z, BiomeType baseBiome) {
+        return getBiomeCached(x, y, z, baseBiome) == null;
     }
 
     /**
@@ -131,7 +112,7 @@ public abstract class ArbitraryBiomeShape {
 
             if (!hollow) {
                 final BiomeType material = getBiome(x, y, z, baseBiome);
-                if (material != null && material != BiomeTypes.THE_VOID) {
+                if (material != null) {
                     if (!fullySupports3DBiomes) {
                         position = position.withY(0);
                     }
@@ -147,35 +128,7 @@ public abstract class ArbitraryBiomeShape {
                 continue;
             }
 
-            boolean draw = false;
-            do {
-                if (!isInsideCached(x + 1, y, z, material)) {
-                    draw = true;
-                    break;
-                }
-                if (!isInsideCached(x - 1, y, z, material)) {
-                    draw = true;
-                    break;
-                }
-                if (!isInsideCached(x, y, z + 1, material)) {
-                    draw = true;
-                    break;
-                }
-                if (!isInsideCached(x, y, z - 1, material)) {
-                    draw = true;
-                    break;
-                }
-                if (!isInsideCached(x, y + 1, z, material)) {
-                    draw = true;
-                    break;
-                }
-                if (!isInsideCached(x, y - 1, z, material)) {
-                    draw = true;
-                    break;
-                }
-            } while (false);
-
-            if (!draw) {
+            if (!shouldDraw(x, y, z, material)) {
                 continue;
             }
 
@@ -188,6 +141,27 @@ public abstract class ArbitraryBiomeShape {
         }
 
         return affected;
+    }
+
+    private boolean shouldDraw(int x, int y, int z, BiomeType material) {
+        // we should draw this if the surrounding blocks fall outside the shape,
+        // this position will form an edge of the hull
+        if (isOutside(x + 1, y, z, material)) {
+            return true;
+        }
+        if (isOutside(x - 1, y, z, material)) {
+            return true;
+        }
+        if (isOutside(x, y, z + 1, material)) {
+            return true;
+        }
+        if (isOutside(x, y, z - 1, material)) {
+            return true;
+        }
+        if (isOutside(x, y + 1, z, material)) {
+            return true;
+        }
+        return isOutside(x, y - 1, z, material);
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/NullWorld.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/NullWorld.java
@@ -92,6 +92,11 @@ public class NullWorld extends AbstractWorld {
     }
 
     @Override
+    public boolean fullySupports3DBiomes() {
+        return false;
+    }
+
+    @Override
     public BiomeType getBiome(BlockVector3 position) {
         return BiomeTypes.THE_VOID;
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
@@ -101,6 +101,20 @@ public interface World extends Extent, Keyed {
     boolean useItem(BlockVector3 position, BaseItem item, Direction face);
 
     /**
+     * Does this world fully support 3D biomes?
+     *
+     * <p>
+     * If {@code false}, the world only visually reads biomes from {@code y = 0}.
+     * The biomes will still be set in 3D, but the client will only see the one at
+     * {@code y = 0}. It is up to the caller to determine if they want to set that
+     * biome instead, or simply warn the actor.
+     * </p>
+     *
+     * @return if the world fully supports 3D biomes
+     */
+    boolean fullySupports3DBiomes();
+
+    /**
      * Similar to {@link Extent#setBlock(BlockVector3, BlockStateHolder)} but a
      * {@code notifyAndLight} parameter indicates whether adjacent blocks
      * should be notified that changes have been made and lighting operations

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorld.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorld.java
@@ -74,7 +74,9 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldProperties;
+import net.minecraft.world.biome.source.BiomeAccessType;
 import net.minecraft.world.biome.source.BiomeArray;
+import net.minecraft.world.biome.source.HorizontalVoronoiBiomeAccessType;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkManager;
 import net.minecraft.world.chunk.ChunkStatus;
@@ -189,6 +191,12 @@ public class FabricWorld extends AbstractWorld {
             return true;
         }
         return false;
+    }
+
+    @Override
+    public boolean fullySupports3DBiomes() {
+        BiomeAccessType biomeAccessType = getWorld().getDimension().getBiomeAccessType();
+        return !(biomeAccessType instanceof HorizontalVoronoiBiomeAccessType);
     }
 
     @Override

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java
@@ -72,7 +72,9 @@ import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeContainer;
+import net.minecraft.world.biome.ColumnFuzzedBiomeMagnifier;
 import net.minecraft.world.biome.DefaultBiomeFeatures;
+import net.minecraft.world.biome.IBiomeMagnifier;
 import net.minecraft.world.chunk.AbstractChunkProvider;
 import net.minecraft.world.chunk.ChunkStatus;
 import net.minecraft.world.chunk.IChunk;
@@ -198,6 +200,12 @@ public class ForgeWorld extends AbstractWorld {
             return true;
         }
         return false;
+    }
+
+    @Override
+    public boolean fullySupports3DBiomes() {
+        IBiomeMagnifier magnifier = getWorld().getDimension().getType().getMagnifier();
+        return !(magnifier instanceof ColumnFuzzedBiomeMagnifier);
     }
 
     @Override


### PR DESCRIPTION
Adds the ability to detect the column biome fuzzer, and uses that API to drop edits to `Y = 0` when it is present.

Also includes bonus fix for `ArbitraryBiomeShape`, since I was touching the code already.