### PR TITLE
Use fabric-lifecycle-events-v1 over deprecated v0.

### DIFF
--- a/worldedit-fabric/build.gradle.kts
+++ b/worldedit-fabric/build.gradle.kts
@@ -52,15 +52,15 @@ dependencies {
     "modCompile"("net.fabricmc:fabric-loader:$loaderVersion")
 
     // [1] declare fabric-api dependency...
-    "fabricApi"("net.fabricmc.fabric-api:fabric-api:0.13.1+build.370-1.16")
+    "fabricApi"("net.fabricmc.fabric-api:fabric-api:0.14.0+build.371-1.16")
 
     // [2] and now we resolve it to pick out what we want :D
     val wantedDependencies = setOf(
         "net.fabricmc.fabric-api:fabric-api-base",
         "net.fabricmc.fabric-api:fabric-events-interaction-v0",
-        "net.fabricmc.fabric-api:fabric-events-lifecycle-v0",
         "net.fabricmc.fabric-api:fabric-command-api-v1",
-        "net.fabricmc.fabric-api:fabric-networking-v0"
+        "net.fabricmc.fabric-api:fabric-networking-v0",
+        "net.fabricmc.fabric-api:fabric-lifecycle-events-v1"
     )
     val fabricApiDependencies = fabricApiConfiguration.incoming.resolutionResult.allDependencies
         .onEach {

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorldEdit.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorldEdit.java
@@ -39,12 +39,11 @@ import com.sk89q.worldedit.world.item.ItemCategory;
 import com.sk89q.worldedit.world.item.ItemType;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
 import net.fabricmc.fabric.api.event.player.UseBlockCallback;
 import net.fabricmc.fabric.api.event.player.UseItemCallback;
-import net.fabricmc.fabric.api.event.server.ServerStartCallback;
-import net.fabricmc.fabric.api.event.server.ServerStopCallback;
-import net.fabricmc.fabric.api.event.server.ServerTickCallback;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.minecraft.entity.player.PlayerEntity;
@@ -113,10 +112,10 @@ public class FabricWorldEdit implements ModInitializer {
 
         WECUIPacketHandler.init();
 
-        ServerTickCallback.EVENT.register(ThreadSafeCache.getInstance());
+        ServerTickEvents.END_SERVER_TICK.register(ThreadSafeCache.getInstance());
         CommandRegistrationCallback.EVENT.register(this::registerCommands);
-        ServerStartCallback.EVENT.register(this::onStartServer);
-        ServerStopCallback.EVENT.register(this::onStopServer);
+        ServerLifecycleEvents.SERVER_STARTED.register(this::onStartServer);
+        ServerLifecycleEvents.SERVER_STOPPING.register(this::onStopServer);
         AttackBlockCallback.EVENT.register(this::onLeftClickBlock);
         UseBlockCallback.EVENT.register(this::onRightClickBlock);
         UseItemCallback.EVENT.register(this::onRightClickAir);

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/ThreadSafeCache.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/ThreadSafeCache.java
@@ -19,7 +19,7 @@
 
 package com.sk89q.worldedit.fabric;
 
-import net.fabricmc.fabric.api.event.server.ServerTickCallback;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 
@@ -32,7 +32,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
 /**
  * Caches data that cannot be accessed from another thread safely.
  */
-public class ThreadSafeCache implements ServerTickCallback {
+public class ThreadSafeCache implements ServerTickEvents.EndTick {
 
     private static final long REFRESH_DELAY = 1000 * 30;
     private static final ThreadSafeCache INSTANCE = new ThreadSafeCache();
@@ -49,7 +49,7 @@ public class ThreadSafeCache implements ServerTickCallback {
     }
 
     @Override
-    public void tick(MinecraftServer server) {
+    public void onEndTick(MinecraftServer server) {
         long now = System.currentTimeMillis();
 
         if (now - lastRefresh > REFRESH_DELAY) {

--- a/worldedit-fabric/src/main/resources/fabric.mod.json
+++ b/worldedit-fabric/src/main/resources/fabric.mod.json
@@ -30,7 +30,7 @@
     "depends": {
         "fabricloader": ">=0.4.0",
         "fabric-api-base": "*",
-        "fabric-events-lifecycle-v0": "*",
+        "fabric-lifecycle-events-v1": "*",
         "fabric-events-interaction-v0": "*",
         "fabric-networking-v0": "*"
     },


### PR DESCRIPTION
fabric-events-lifecycle-v0 is now deprecated, so upgrading to use new events.