### PR TITLE
Replace setPosition with trySetPosition

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
@@ -139,9 +139,9 @@ public class BukkitPlayer extends AbstractPlayerActor {
     }
 
     @Override
-    public void setPosition(Vector3 pos, float pitch, float yaw) {
-        player.teleport(new Location(player.getWorld(), pos.getX(), pos.getY(),
-                pos.getZ(), yaw, pitch));
+    public boolean trySetPosition(Vector3 pos, float pitch, float yaw) {
+        return player.teleport(new Location(player.getWorld(), pos.getX(), pos.getY(),
+            pos.getZ(), yaw, pitch));
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/entity/Player.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/entity/Player.java
@@ -24,6 +24,8 @@ import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extent.inventory.BlockBag;
 import com.sk89q.worldedit.function.mask.Mask;
+import com.sk89q.worldedit.internal.util.DeprecationUtil;
+import com.sk89q.worldedit.internal.util.NonAbstractForCompatibility;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.util.Direction;
@@ -282,8 +284,40 @@ public interface Player extends Entity, Actor {
      * @param pos where to move them
      * @param pitch the pitch (up/down) of the player's view in degrees
      * @param yaw the yaw (left/right) of the player's view in degrees
+     * @deprecated This method may fail without indication. Use
+     * {@link #trySetPosition(Vector3, float, float)} instead
      */
-    void setPosition(Vector3 pos, float pitch, float yaw);
+    @Deprecated
+    default void setPosition(Vector3 pos, float pitch, float yaw) {
+        trySetPosition(pos, pitch, yaw);
+    }
+
+    /**
+     * Attempt to move the player.
+     *
+     * <p>
+     * This action may fail, due to other mods cancelling the move.
+     * If so, this method will return {@code false}.
+     * </p>
+     *
+     * @param pos where to move them
+     * @param pitch the pitch (up/down) of the player's view in degrees
+     * @param yaw the yaw (left/right) of the player's view in degrees
+     * @return if the move was able to occur
+     * @apiNote This must be overridden by new subclasses. See {@link NonAbstractForCompatibility}
+     *          for details
+     */
+    @NonAbstractForCompatibility(
+        delegateName = "setPosition",
+        delegateParams = { Vector3.class, float.class, float.class }
+    )
+    default boolean trySetPosition(Vector3 pos, float pitch, float yaw) {
+        DeprecationUtil.checkDelegatingOverride(getClass());
+
+        setPosition(pos, pitch, yaw);
+
+        return true;
+    }
 
     /**
      * Sends a fake block to the client.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
@@ -47,8 +47,9 @@ import com.sk89q.worldedit.world.gamemode.GameModes;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.item.ItemTypes;
 
-import javax.annotation.Nullable;
 import java.io.File;
+
+import javax.annotation.Nullable;
 
 /**
  * An abstract implementation of both a {@link Actor} and a {@link Player}
@@ -126,11 +127,15 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
             }
 
             if (free == 2) {
+                boolean worked = true;
+
                 if (y - 1 != origY) {
-                    setPosition(Vector3.at(x + 0.5, y - 2 + 1, z + 0.5));
+                    worked = trySetPosition(Vector3.at(x + 0.5, y - 2 + 1, z + 0.5));
                 }
 
-                return;
+                if (worked) {
+                    return;
+                }
             }
 
             ++y;
@@ -152,8 +157,8 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
         while (y >= minY) {
             final BlockVector3 pos = BlockVector3.at(x, y, z);
             final BlockState id = world.getBlock(pos);
-            if (id.getBlockType().getMaterial().isMovementBlocker()) {
-                setPosition(Vector3.at(x + 0.5, y + 1, z + 0.5));
+            if (id.getBlockType().getMaterial().isMovementBlocker()
+                && trySetPosition(Vector3.at(x + 0.5, y + 1, z + 0.5))) {
                 return;
             }
 
@@ -166,6 +171,26 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
         findFreePosition(getBlockLocation());
     }
 
+    private boolean isBadSpaceForStanding(BlockVector3 location) {
+        BlockType type = getWorld().getBlock(location).getBlockType();
+        return type.getMaterial().isMovementBlocker() || type == BlockTypes.LAVA;
+    }
+
+    /**
+     * @param location where the player would be placed (not Y offset)
+     * @return if the player can stand at the location
+     */
+    private boolean isLocationGoodForStanding(BlockVector3 location) {
+        if (isBadSpaceForStanding(location.add(0, 1, 0))) {
+            return false;
+        }
+        if (isBadSpaceForStanding(location)) {
+            return false;
+        }
+        return getWorld().getBlock(location.add(0, -1, 0)).getBlockType().getMaterial()
+            .isMovementBlocker();
+    }
+
     @Override
     public boolean ascendLevel() {
         final World world = getWorld();
@@ -176,31 +201,10 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
         int yPlusSearchHeight = y + WorldEdit.getInstance().getConfiguration().defaultVerticalHeight;
         int maxY = Math.min(world.getMaxY(), yPlusSearchHeight) + 2;
 
-        int free = 0;
-        int spots = 0;
-
         while (y <= maxY) {
-            if (!world.getBlock(BlockVector3.at(x, y, z)).getBlockType().getMaterial().isMovementBlocker()) {
-                ++free;
-            } else {
-                free = 0;
-            }
-
-            if (free == 2) {
-                ++spots;
-                if (spots == 2) {
-                    final BlockVector3 platform = BlockVector3.at(x, y - 2, z);
-                    final BlockState block = world.getBlock(platform);
-                    final BlockType type = block.getBlockType();
-
-                    // Don't get put in lava!
-                    if (type == BlockTypes.LAVA) {
-                        return false;
-                    }
-
-                    setPosition(platform.toVector3().add(0.5, 1, 0.5));
-                    return true;
-                }
+            if (isLocationGoodForStanding(BlockVector3.at(x, y, z))
+                && trySetPosition(Vector3.at(x + 0.5, y, z + 0.5))) {
+                return true;
             }
 
             ++y;
@@ -219,35 +223,10 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
         int yLessSearchHeight = y - WorldEdit.getInstance().getConfiguration().defaultVerticalHeight;
         int minY = Math.min(world.getMinY() + 1, yLessSearchHeight);
 
-        byte free = 0;
-
         while (y >= minY) {
-            if (!world.getBlock(BlockVector3.at(x, y, z)).getBlockType().getMaterial().isMovementBlocker()) {
-                ++free;
-            } else {
-                free = 0;
-            }
-
-            if (free == 2) {
-                // So we've found a spot, but we have to drop the player
-                // lightly and also check to see if there's something to
-                // stand upon
-                while (y >= minY) {
-                    final BlockVector3 platform = BlockVector3.at(x, y, z);
-                    final BlockState block = world.getBlock(platform);
-                    final BlockType type = block.getBlockType();
-
-                    // Don't want to end up in lava
-                    if (!type.getMaterial().isAir() && type != BlockTypes.LAVA) {
-                        // Found a block!
-                        setPosition(platform.toVector3().add(0.5, 1, 0.5));
-                        return true;
-                    }
-
-                    --y;
-                }
-
-                return false;
+            if (isLocationGoodForStanding(BlockVector3.at(x, y, z))
+                && trySetPosition(Vector3.at(x + 0.5, y, z + 0.5))) {
+                return true;
             }
 
             --y;
@@ -502,9 +481,9 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
     }
 
     @Override
-    public void setPosition(Vector3 pos) {
+    public boolean trySetPosition(Vector3 pos) {
         final Location location = getLocation();
-        setPosition(pos, location.getPitch(), location.getYaw());
+        return trySetPosition(pos, location.getPitch(), location.getYaw());
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/Locatable.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/Locatable.java
@@ -54,9 +54,27 @@ public interface Locatable {
      * Sets the position of this actor.
      *
      * @param pos where to move them
+     * @deprecated This method may fail without indication. Use {@link #trySetPosition(Vector3)}
+     * instead
      */
+    @Deprecated
     default void setPosition(Vector3 pos) {
-        setLocation(new Location(getExtent(), pos));
+        trySetPosition(pos);
+    }
+
+    /**
+     * Attempts to set the position of this actor.
+     *
+     * <p>
+     * This action may fail, due to other mods cancelling the move.
+     * If so, this method will return {@code false}.
+     * </p>
+     *
+     * @param pos the position to set
+     * @return if the position was able to be set
+     */
+    default boolean trySetPosition(Vector3 pos) {
+        return setLocation(new Location(getExtent(), pos));
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlayerProxy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlayerProxy.java
@@ -106,8 +106,8 @@ class PlayerProxy extends AbstractPlayerActor {
     }
 
     @Override
-    public void setPosition(Vector3 pos, float pitch, float yaw) {
-        basePlayer.setPosition(pos, pitch, yaw);
+    public boolean trySetPosition(Vector3 pos, float pitch, float yaw) {
+        return basePlayer.trySetPosition(pos, pitch, yaw);
     }
 
     @Override

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricPlayer.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricPlayer.java
@@ -174,8 +174,9 @@ public class FabricPlayer extends AbstractPlayerActor {
     }
 
     @Override
-    public void setPosition(Vector3 pos, float pitch, float yaw) {
+    public boolean trySetPosition(Vector3 pos, float pitch, float yaw) {
         this.player.networkHandler.requestTeleport(pos.getX(), pos.getY(), pos.getZ(), yaw, pitch);
+        return true;
     }
 
     @Override

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePlayer.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePlayer.java
@@ -173,8 +173,9 @@ public class ForgePlayer extends AbstractPlayerActor {
     }
 
     @Override
-    public void setPosition(Vector3 pos, float pitch, float yaw) {
+    public boolean trySetPosition(Vector3 pos, float pitch, float yaw) {
         this.player.connection.setPlayerLocation(pos.getX(), pos.getY(), pos.getZ(), yaw, pitch);
+        return true;
     }
 
     @Override

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongePlayer.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongePlayer.java
@@ -165,12 +165,12 @@ public class SpongePlayer extends AbstractPlayerActor {
     }
 
     @Override
-    public void setPosition(Vector3 pos, float pitch, float yaw) {
+    public boolean trySetPosition(Vector3 pos, float pitch, float yaw) {
         org.spongepowered.api.world.Location<World> loc = new org.spongepowered.api.world.Location<>(
-                this.player.getWorld(), pos.getX(), pos.getY(), pos.getZ()
+            this.player.getWorld(), pos.getX(), pos.getY(), pos.getZ()
         );
 
-        this.player.setLocationAndRotation(loc, new Vector3d(pitch, yaw, 0));
+        return this.player.setLocationAndRotation(loc, new Vector3d(pitch, yaw, 0));
     }
 
     @Override


### PR DESCRIPTION
Allows cancellation information to be fed back into the ascend/descend algorithms.

This PR also rewrites ascend/descend to use a simpler algorithm that is clear about what it does.

Fixes #1368.