### PR TITLE
Replace BlockStates reading with new 1.16 logic

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SpongeSchematicReader.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SpongeSchematicReader.java
@@ -39,6 +39,7 @@ import com.sk89q.worldedit.extension.platform.Capability;
 import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.extent.clipboard.BlockArrayClipboard;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
+import com.sk89q.worldedit.internal.Constants;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.regions.Region;
@@ -95,7 +96,7 @@ public class SpongeSchematicReader extends NBTSchematicReader {
         int liveDataVersion = platform.getDataVersion();
 
         if (schematicVersion == 1) {
-            dataVersion = 1631; // this is a relatively safe assumption unless someone imports a schematic from 1.12, e.g. sponge 7.1-
+            dataVersion = Constants.DATA_VERSION_MC_1_13_2; // this is a relatively safe assumption unless someone imports a schematic from 1.12, e.g. sponge 7.1-
             fixer = platform.getDataFixer();
             return readVersion1(schematicTag);
         } else if (schematicVersion == 2) {
@@ -126,7 +127,7 @@ public class SpongeSchematicReader extends NBTSchematicReader {
             CompoundTag schematicTag = getBaseTag();
             Map<String, Tag> schematic = schematicTag.getValue();
             if (schematicVersion == 1) {
-                return OptionalInt.of(1631);
+                return OptionalInt.of(Constants.DATA_VERSION_MC_1_13_2);
             } else if (schematicVersion == 2) {
                 return OptionalInt.of(requireTag(schematic, "DataVersion", IntTag.class).getValue());
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/Constants.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/Constants.java
@@ -43,11 +43,6 @@ public final class Constants {
     }
 
     /**
-     * The DataVersion for Minecraft 1.12.2
-     */
-    public static final int DATA_VERSION_MC_1_12_2 = 1343;
-
-    /**
      * The DataVersion for Minecraft 1.13
      */
     public static final int DATA_VERSION_MC_1_13 = 1519;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/Constants.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/Constants.java
@@ -42,4 +42,34 @@ public final class Constants {
         ));
     }
 
+    /**
+     * The DataVersion for Minecraft 1.12.2
+     */
+    public static final int DATA_VERSION_MC_1_12_2 = 1343;
+
+    /**
+     * The DataVersion for Minecraft 1.13
+     */
+    public static final int DATA_VERSION_MC_1_13 = 1519;
+
+    /**
+     * The DataVersion for Minecraft 1.13.2
+     */
+    public static final int DATA_VERSION_MC_1_13_2 = 1631;
+
+    /**
+     * The DataVersion for Minecraft 1.16
+     */
+    public static final int DATA_VERSION_MC_1_14 = 1952;
+
+    /**
+     * The DataVersion for Minecraft 1.16
+     */
+    public static final int DATA_VERSION_MC_1_15 = 2225;
+
+    /**
+     * The DataVersion for Minecraft 1.16
+     */
+    public static final int DATA_VERSION_MC_1_16 = 2566;
+
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/AnvilChunk13.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/AnvilChunk13.java
@@ -54,7 +54,7 @@ public class AnvilChunk13 implements Chunk {
 
     /**
      * Construct the chunk with a compound tag.
-     * 
+     *
      * @param tag the tag to read
      * @throws DataException on a data error
      */
@@ -112,44 +112,23 @@ public class AnvilChunk13 implements Chunk {
                 }
                 palette[paletteEntryId] = blockState;
             }
-            int paletteBits = 4;
-            while ((1 << paletteBits) < paletteSize) {
-                ++paletteBits;
-            }
-            int paletteMask = (1 << paletteBits) - 1;
 
             // parse block states
             long[] blockStatesSerialized = NBTUtils.getChildTag(sectionTag.getValue(), "BlockStates", LongArrayTag.class).getValue();
 
             int blocksPerChunkSection = 16 * 16 * 16;
             BlockState[] chunkSectionBlocks = new BlockState[blocksPerChunkSection];
-            blocks[y] = chunkSectionBlocks;
 
-            long currentSerializedValue = 0;
-            int nextSerializedItem = 0;
-            int remainingBits = 0;
+            PackedIntArrayReader reader = new PackedIntArrayReader(blockStatesSerialized);
             for (int blockPos = 0; blockPos < blocksPerChunkSection; blockPos++) {
-                int localBlockId;
-                if (remainingBits < paletteBits) {
-                    int bitsNextLong = paletteBits - remainingBits;
-                    localBlockId = (int) currentSerializedValue;
-                    if (nextSerializedItem >= blockStatesSerialized.length) {
-                        throw new InvalidFormatException("Too short block state table");
-                    }
-                    currentSerializedValue = blockStatesSerialized[nextSerializedItem++];
-                    localBlockId |= (currentSerializedValue & ((1 << bitsNextLong) - 1)) << remainingBits;
-                    currentSerializedValue >>>= bitsNextLong;
-                    remainingBits = 64 - bitsNextLong;
-                } else {
-                    localBlockId = (int) (currentSerializedValue & paletteMask);
-                    currentSerializedValue >>>= paletteBits;
-                    remainingBits -= paletteBits;
+                int index = reader.get(blockPos);
+                if (index >= palette.length) {
+                    throw new InvalidFormatException("Invalid block state table entry: " + index);
                 }
-                if (localBlockId >= palette.length) {
-                    throw new InvalidFormatException("Invalid block state table entry: " + localBlockId);
-                }
-                chunkSectionBlocks[blockPos] = palette[localBlockId];
+                chunkSectionBlocks[blockPos] = palette[index];
             }
+
+            blocks[y] = chunkSectionBlocks;
         }
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/AnvilChunk16.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/AnvilChunk16.java
@@ -1,0 +1,53 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.world.chunk;
+
+import com.sk89q.jnbt.CompoundTag;
+import com.sk89q.worldedit.world.DataException;
+import com.sk89q.worldedit.world.block.BlockState;
+import com.sk89q.worldedit.world.storage.InvalidFormatException;
+
+/**
+ * The chunk format for Minecraft 1.16 and newer
+ */
+public class AnvilChunk16 extends AnvilChunk13 {
+
+    /**
+     * Construct the chunk with a compound tag.
+     *
+     * @param tag the tag to read
+     * @throws DataException on a data error
+     */
+    public AnvilChunk16(CompoundTag tag) throws DataException {
+        super(tag);
+    }
+
+    @Override
+    protected void readBlockStates(BlockState[] palette, long[] blockStatesSerialized, BlockState[] chunkSectionBlocks) throws InvalidFormatException {
+        PackedIntArrayReader reader = new PackedIntArrayReader(blockStatesSerialized);
+        for (int blockPos = 0; blockPos < chunkSectionBlocks.length; blockPos++) {
+            int index = reader.get(blockPos);
+            if (index >= palette.length) {
+                throw new InvalidFormatException("Invalid block state table entry: " + index);
+            }
+            chunkSectionBlocks[blockPos] = palette[index];
+        }
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/PackedIntArrayReader.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/PackedIntArrayReader.java
@@ -43,8 +43,8 @@ public class PackedIntArrayReader {
         this.data = data;
         this.elementBits = data.length * 64 / 4096;
         this.maxValue = (1L << elementBits) - 1L;
-        this.elementsPerLong = (char) (64 / elementBits);
-        this.factor = FACTORS[elementBits];
+        this.elementsPerLong = 64 / elementBits;
+        this.factor = FACTORS[elementsPerLong - 1];
         int j = (SIZE + this.elementsPerLong - 1) / this.elementsPerLong;
         if (j != data.length) {
             throw new IllegalStateException("Invalid packed-int array provided, should be of length " + j);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/PackedIntArrayReader.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/PackedIntArrayReader.java
@@ -1,0 +1,66 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.world.chunk;
+
+import static com.google.common.base.Preconditions.checkElementIndex;
+
+public class PackedIntArrayReader {
+    private static final int[] FACTORS = new int[64];
+
+    static {
+        FACTORS[0] = -1;
+        for (int i = 2; i <= 64; i++) {
+            FACTORS[i - 1] = (int) (Integer.toUnsignedLong(-1) / i);
+        }
+    }
+
+    private static final int SIZE = 4096;
+
+    private final long[] data;
+    private final int elementBits;
+    private final long maxValue;
+    private final int elementsPerLong;
+    private final int factor;
+
+    public PackedIntArrayReader(long[] data) {
+        this.data = data;
+        this.elementBits = data.length * 64 / 4096;
+        this.maxValue = (1L << elementBits) - 1L;
+        this.elementsPerLong = (char) (64 / elementBits);
+        this.factor = FACTORS[elementBits];
+        int j = (SIZE + this.elementsPerLong - 1) / this.elementsPerLong;
+        if (j != data.length) {
+            throw new IllegalStateException("Invalid packed-int array provided, should be of length " + j);
+        }
+    }
+
+    public int get(int index) {
+        checkElementIndex(index, SIZE);
+        int i = this.adjustIndex(index);
+        long l = this.data[i];
+        int j = (index - i * this.elementsPerLong) * this.elementBits;
+        return (int) (l >> j & this.maxValue);
+    }
+
+    private int adjustIndex(int i) {
+        return (int) ((long) i * factor + factor >> 32);
+    }
+
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledBlockData.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledBlockData.java
@@ -25,19 +25,21 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.platform.Capability;
+import com.sk89q.worldedit.internal.Constants;
 import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.util.gson.VectorAdapter;
 import com.sk89q.worldedit.util.io.ResourceLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.annotation.Nullable;
 
 /**
  * Provides block data based on the built-in block database that is bundled
@@ -82,11 +84,11 @@ public final class BundledBlockData {
         Gson gson = gsonBuilder.create();
         URL url = null;
         final int dataVersion = WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.WORLD_EDITING).getDataVersion();
-        if (dataVersion > 2566) { // > MC 1.15
+        if (dataVersion >= Constants.DATA_VERSION_MC_1_16) {
             url = resourceLoader.getResource(BundledBlockData.class, "blocks.116.json");
-        } else if (dataVersion > 2224) { // > MC 1.14
+        } else if (dataVersion >= Constants.DATA_VERSION_MC_1_15) {
             url = resourceLoader.getResource(BundledBlockData.class, "blocks.115.json");
-        } else if (dataVersion > 1900) { // > MC 1.13
+        } else if (dataVersion >= Constants.DATA_VERSION_MC_1_14) {
             url = resourceLoader.getResource(BundledBlockData.class, "blocks.114.json");
         }
         if (url == null) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledItemData.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledItemData.java
@@ -25,6 +25,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.platform.Capability;
+import com.sk89q.worldedit.internal.Constants;
 import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.util.gson.VectorAdapter;
 import com.sk89q.worldedit.util.io.ResourceLoader;
@@ -82,11 +83,11 @@ public final class BundledItemData {
         Gson gson = gsonBuilder.create();
         URL url = null;
         final int dataVersion = WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.WORLD_EDITING).getDataVersion();
-        if (dataVersion > 2566) { // > MC 1.15
+        if (dataVersion >= Constants.DATA_VERSION_MC_1_16) {
             url = resourceLoader.getResource(BundledBlockData.class, "items.116.json");
-        } else if (dataVersion > 2224) { // > MC 1.14
+        } else if (dataVersion >= Constants.DATA_VERSION_MC_1_15) {
             url = resourceLoader.getResource(BundledBlockData.class, "items.115.json");
-        } else if (dataVersion > 1900) { // > MC 1.13
+        } else if (dataVersion >= Constants.DATA_VERSION_MC_1_14) {
             url = resourceLoader.getResource(BundledBlockData.class, "items.114.json");
         }
         if (url == null) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/LegacyMapper.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/LegacyMapper.java
@@ -30,6 +30,7 @@ import com.sk89q.worldedit.extension.factory.BlockFactory;
 import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.ParserContext;
 import com.sk89q.worldedit.extension.platform.Capability;
+import com.sk89q.worldedit.internal.Constants;
 import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.util.gson.VectorAdapter;
 import com.sk89q.worldedit.util.io.ResourceLoader;
@@ -104,7 +105,7 @@ public final class LegacyMapper {
             // if fixer is available, try using that first, as some old blocks that were renamed share names with new blocks
             if (fixer != null) {
                 try {
-                    String newEntry = fixer.fixUp(DataFixer.FixTypes.BLOCK_STATE, value, 1631);
+                    String newEntry = fixer.fixUp(DataFixer.FixTypes.BLOCK_STATE, value, Constants.DATA_VERSION_MC_1_12_2);
                     state = blockFactory.parseFromInput(newEntry, parserContext).toImmutableState();
                 } catch (InputParseException e) {
                 }
@@ -133,7 +134,7 @@ public final class LegacyMapper {
             String value = itemEntry.getValue();
             ItemType type = ItemTypes.get(value);
             if (type == null && fixer != null) {
-                value = fixer.fixUp(DataFixer.FixTypes.ITEM_TYPE, value, 1631);
+                value = fixer.fixUp(DataFixer.FixTypes.ITEM_TYPE, value, Constants.DATA_VERSION_MC_1_12_2);
                 type = ItemTypes.get(value);
             }
             if (type == null) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/LegacyMapper.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/LegacyMapper.java
@@ -105,7 +105,7 @@ public final class LegacyMapper {
             // if fixer is available, try using that first, as some old blocks that were renamed share names with new blocks
             if (fixer != null) {
                 try {
-                    String newEntry = fixer.fixUp(DataFixer.FixTypes.BLOCK_STATE, value, Constants.DATA_VERSION_MC_1_12_2);
+                    String newEntry = fixer.fixUp(DataFixer.FixTypes.BLOCK_STATE, value, Constants.DATA_VERSION_MC_1_13_2);
                     state = blockFactory.parseFromInput(newEntry, parserContext).toImmutableState();
                 } catch (InputParseException e) {
                 }
@@ -134,7 +134,7 @@ public final class LegacyMapper {
             String value = itemEntry.getValue();
             ItemType type = ItemTypes.get(value);
             if (type == null && fixer != null) {
-                value = fixer.fixUp(DataFixer.FixTypes.ITEM_TYPE, value, Constants.DATA_VERSION_MC_1_12_2);
+                value = fixer.fixUp(DataFixer.FixTypes.ITEM_TYPE, value, Constants.DATA_VERSION_MC_1_13_2);
                 type = ItemTypes.get(value);
             }
             if (type == null) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/ChunkStoreHelper.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/ChunkStoreHelper.java
@@ -29,6 +29,7 @@ import com.sk89q.worldedit.world.DataException;
 import com.sk89q.worldedit.world.DataFixer;
 import com.sk89q.worldedit.world.chunk.AnvilChunk;
 import com.sk89q.worldedit.world.chunk.AnvilChunk13;
+import com.sk89q.worldedit.world.chunk.AnvilChunk16;
 import com.sk89q.worldedit.world.chunk.Chunk;
 import com.sk89q.worldedit.world.chunk.OldChunk;
 
@@ -64,6 +65,11 @@ public class ChunkStoreHelper {
     private static final int DATA_VERSION_MC_1_13 = 1519;
 
     /**
+     * The DataVersion for Minecraft 1.16
+     */
+    private static final int DATA_VERSION_MC_1_16 = 2566;
+
+    /**
      * Convert a chunk NBT tag into a {@link Chunk} implementation.
      *
      * @param rootTag the root tag of the chunk
@@ -94,11 +100,15 @@ public class ChunkStoreHelper {
         if (dataVersion == 0) dataVersion = -1;
         final Platform platform = WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.WORLD_EDITING);
         final int currentDataVersion = platform.getDataVersion();
-        if (tag.getValue().containsKey("Sections") &&  dataVersion < currentDataVersion) { // only fix up MCA format, DFU doesn't support MCR chunks
+        if (tag.getValue().containsKey("Sections") && dataVersion < currentDataVersion) { // only fix up MCA format, DFU doesn't support MCR chunks
             final DataFixer dataFixer = platform.getDataFixer();
             if (dataFixer != null) {
-                return new AnvilChunk13((CompoundTag) dataFixer.fixUp(DataFixer.FixTypes.CHUNK, rootTag, dataVersion).getValue().get("Level"));
+                tag = (CompoundTag) dataFixer.fixUp(DataFixer.FixTypes.CHUNK, rootTag, dataVersion).getValue().get("Level");
+                dataVersion = currentDataVersion;
             }
+        }
+        if (dataVersion >= DATA_VERSION_MC_1_16) {
+            return new AnvilChunk16(tag);
         }
         if (dataVersion >= DATA_VERSION_MC_1_13) {
             return new AnvilChunk13(tag);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/ChunkStoreHelper.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/ChunkStoreHelper.java
@@ -25,6 +25,7 @@ import com.sk89q.jnbt.Tag;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.platform.Capability;
 import com.sk89q.worldedit.extension.platform.Platform;
+import com.sk89q.worldedit.internal.Constants;
 import com.sk89q.worldedit.world.DataException;
 import com.sk89q.worldedit.world.DataFixer;
 import com.sk89q.worldedit.world.chunk.AnvilChunk;
@@ -58,16 +59,6 @@ public class ChunkStoreHelper {
             return (CompoundTag) tag;
         }
     }
-
-    /**
-     * The DataVersion for Minecraft 1.13
-     */
-    private static final int DATA_VERSION_MC_1_13 = 1519;
-
-    /**
-     * The DataVersion for Minecraft 1.16
-     */
-    private static final int DATA_VERSION_MC_1_16 = 2566;
 
     /**
      * Convert a chunk NBT tag into a {@link Chunk} implementation.
@@ -107,10 +98,10 @@ public class ChunkStoreHelper {
                 dataVersion = currentDataVersion;
             }
         }
-        if (dataVersion >= DATA_VERSION_MC_1_16) {
+        if (dataVersion >= Constants.DATA_VERSION_MC_1_16) {
             return new AnvilChunk16(tag);
         }
-        if (dataVersion >= DATA_VERSION_MC_1_13) {
+        if (dataVersion >= Constants.DATA_VERSION_MC_1_13) {
             return new AnvilChunk13(tag);
         }
 


### PR DESCRIPTION
Turns out Mojang changes the chunk format all the time now I guess.

Logic is JMH Certified:tm: to be one of the fastest options, with high readability.

Edit: oh, yeah. fixes #1409 btw