### PR TITLE
Change //stack and //move to take a full offset

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/AbstractDirectionConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/AbstractDirectionConverter.java
@@ -25,9 +25,9 @@ import com.google.common.collect.ImmutableSet;
 import com.sk89q.worldedit.UnknownDirectionException;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.entity.Player;
-import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.internal.annotation.Direction;
 import com.sk89q.worldedit.internal.annotation.MultiDirection;
+import com.sk89q.worldedit.internal.annotation.OptionalArg;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import org.enginehub.piston.CommandManager;
@@ -58,12 +58,12 @@ public abstract class AbstractDirectionConverter<D> implements ArgumentConverter
     protected static <D> void register(CommandManager commandManager, AbstractDirectionConverter<D> converter,
                                        Class<D> keyClass, boolean includeDiagonals) {
         commandManager.registerConverter(
-                Key.of(keyClass, direction(includeDiagonals)),
-                converter
+            Key.of(keyClass, direction(includeDiagonals)),
+            converter
         );
         commandManager.registerConverter(
-                Key.of(keyClass, multiDirection(includeDiagonals)),
-                CommaSeparatedValuesConverter.wrap(converter)
+            Key.of(keyClass, multiDirection(includeDiagonals)),
+            CommaSeparatedValuesConverter.wrap(converter)
         );
     }
 
@@ -93,8 +93,8 @@ public abstract class AbstractDirectionConverter<D> implements ArgumentConverter
 
     @Override
     public ConversionResult<D> convert(String argument, InjectedValueAccess context) {
-        Player player = context.injectedValue(Key.of(Actor.class))
-                .filter(Player.class::isInstance).map(Player.class::cast).orElse(null);
+        Player player = context.injectedValue(Key.of(Player.class, OptionalArg.class))
+            .orElse(null);
         try {
             return SuccessfulConversion.fromSingle(convertDirection(argument, player, includeDiagonals));
         } catch (Exception e) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/DirectionVectorConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/DirectionVectorConverter.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
 
 public final class DirectionVectorConverter extends AbstractDirectionConverter<BlockVector3> {
 
-    private DirectionVectorConverter(WorldEdit worldEdit, boolean includeDiagonals) {
+    public DirectionVectorConverter(WorldEdit worldEdit, boolean includeDiagonals) {
         super(worldEdit, includeDiagonals);
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/OffsetConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/OffsetConverter.java
@@ -1,0 +1,76 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.command.argument;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.internal.annotation.Offset;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.util.formatting.text.Component;
+import com.sk89q.worldedit.util.formatting.text.TextComponent;
+import org.enginehub.piston.CommandManager;
+import org.enginehub.piston.converter.ArgumentConverter;
+import org.enginehub.piston.converter.ConversionResult;
+import org.enginehub.piston.inject.InjectedValueAccess;
+import org.enginehub.piston.inject.Key;
+
+import java.util.List;
+
+public class OffsetConverter implements ArgumentConverter<BlockVector3> {
+
+    public static void register(WorldEdit worldEdit, CommandManager commandManager) {
+        commandManager.registerConverter(
+            Key.of(BlockVector3.class, Offset.class),
+            new OffsetConverter(worldEdit)
+        );
+    }
+
+    private final DirectionVectorConverter directionVectorConverter;
+    private final VectorConverter<Integer, BlockVector3> vectorConverter =
+        VectorConverter.BLOCK_VECTOR_3_CONVERTER;
+
+    private OffsetConverter(WorldEdit worldEdit) {
+        directionVectorConverter = new DirectionVectorConverter(worldEdit, true);
+    }
+
+    @Override
+    public Component describeAcceptableArguments() {
+        return TextComponent.builder()
+            .append(directionVectorConverter.describeAcceptableArguments())
+            .append(", or ")
+            .append(vectorConverter.describeAcceptableArguments())
+            .build();
+    }
+
+    @Override
+    public List<String> getSuggestions(String input, InjectedValueAccess context) {
+        return ImmutableList.copyOf(Iterables.concat(
+            directionVectorConverter.getSuggestions(input, context),
+            vectorConverter.getSuggestions(input, context)
+        ));
+    }
+
+    @Override
+    public ConversionResult<BlockVector3> convert(String input, InjectedValueAccess context) {
+        return directionVectorConverter.convert(input, context)
+            .orElse(vectorConverter.convert(input, context));
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/VectorConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/VectorConverter.java
@@ -40,12 +40,22 @@ import java.util.List;
 import java.util.function.Function;
 
 public class VectorConverter<C, T> implements ArgumentConverter<T> {
+
+    private static final CommaSeparatedValuesConverter<Integer> INT_CONVERTER =
+        CommaSeparatedValuesConverter.wrap(ArgumentConverters.get(TypeToken.of(int.class)));
+
+    public static final VectorConverter<Integer, BlockVector3> BLOCK_VECTOR_3_CONVERTER = new VectorConverter<>(
+        INT_CONVERTER,
+        3,
+        cmps -> BlockVector3.at(cmps.get(0), cmps.get(1), cmps.get(2)),
+        "block vector with x, y, and z"
+    );
+
     public static void register(CommandManager commandManager) {
-        CommaSeparatedValuesConverter<Integer> intConverter = CommaSeparatedValuesConverter.wrap(ArgumentConverters.get(TypeToken.of(int.class)));
         CommaSeparatedValuesConverter<Double> doubleConverter = CommaSeparatedValuesConverter.wrap(ArgumentConverters.get(TypeToken.of(double.class)));
         commandManager.registerConverter(Key.of(BlockVector2.class),
             new VectorConverter<>(
-                intConverter,
+                INT_CONVERTER,
                 2,
                 cmps -> BlockVector2.at(cmps.get(0), cmps.get(1)),
                 "block vector with x and z"
@@ -57,13 +67,7 @@ public class VectorConverter<C, T> implements ArgumentConverter<T> {
                 cmps -> Vector2.at(cmps.get(0), cmps.get(1)),
                 "vector with x and z"
             ));
-        commandManager.registerConverter(Key.of(BlockVector3.class),
-            new VectorConverter<>(
-                intConverter,
-                3,
-                cmps -> BlockVector3.at(cmps.get(0), cmps.get(1), cmps.get(2)),
-                "block vector with x, y, and z"
-            ));
+        commandManager.registerConverter(Key.of(BlockVector3.class), BLOCK_VECTOR_3_CONVERTER);
         commandManager.registerConverter(Key.of(Vector3.class),
             new VectorConverter<>(
                 doubleConverter,

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
@@ -77,6 +77,7 @@ import com.sk89q.worldedit.command.argument.EntityRemoverConverter;
 import com.sk89q.worldedit.command.argument.EnumConverter;
 import com.sk89q.worldedit.command.argument.FactoryConverter;
 import com.sk89q.worldedit.command.argument.HeightConverter;
+import com.sk89q.worldedit.command.argument.OffsetConverter;
 import com.sk89q.worldedit.command.argument.RegionFactoryConverter;
 import com.sk89q.worldedit.command.argument.RegistryConverter;
 import com.sk89q.worldedit.command.argument.SideEffectConverter;
@@ -90,6 +91,7 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.event.platform.CommandEvent;
 import com.sk89q.worldedit.event.platform.CommandSuggestionEvent;
 import com.sk89q.worldedit.extent.Extent;
+import com.sk89q.worldedit.internal.annotation.OptionalArg;
 import com.sk89q.worldedit.internal.annotation.Selection;
 import com.sk89q.worldedit.internal.command.CommandArgParser;
 import com.sk89q.worldedit.internal.command.CommandLoggingHandler;
@@ -220,6 +222,7 @@ public final class PlatformCommandManager {
         WorldConverter.register(commandManager);
         SideEffectConverter.register(commandManager);
         HeightConverter.register(commandManager);
+        OffsetConverter.register(worldEdit, commandManager);
     }
 
     private void registerAlwaysInjectedValues() {
@@ -559,6 +562,7 @@ public final class PlatformCommandManager {
         store.injectValue(Key.of(Actor.class), ValueProvider.constant(actor));
         if (actor instanceof Player) {
             store.injectValue(Key.of(Player.class), ValueProvider.constant((Player) actor));
+            store.injectValue(Key.of(Player.class, OptionalArg.class), ValueProvider.constant((Player) actor));
         } else {
             store.injectValue(Key.of(Player.class), context -> {
                 throw new CommandException(TranslatableComponent.of("worldedit.command.player-only"), ImmutableList.of());

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/annotation/Offset.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/annotation/Offset.java
@@ -1,0 +1,38 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.internal.annotation;
+
+import com.sk89q.worldedit.math.BlockVector3;
+import org.enginehub.piston.inject.InjectAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates a {@link BlockVector3} parameter to inject an offset.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@InjectAnnotation
+public @interface Offset {
+    String FORWARD = "forward";
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/annotation/OptionalArg.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/annotation/OptionalArg.java
@@ -1,0 +1,38 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.internal.annotation;
+
+import com.sk89q.worldedit.entity.Player;
+import org.enginehub.piston.inject.InjectAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates a parameter to indicate it as optional. This is really a bit of a hack, used to
+ * get a {@link Player} or {@code null} instead of throwing.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@InjectAnnotation
+public @interface OptionalArg {
+}


### PR DESCRIPTION
This fixes #1363. One thing I didn't do, is that these are NOT based on your facing direction, they directly translate to x/y/z changes. If anyone has a good alternate syntax for that, I could add it, but for now I think this is good enough.

`//help stack`:
![help image](https://url.octyl.net/xgenwf89-gv8zibc0bai)
`//help move`:
![help image](https://url.octyl.net/s21kjkd67xwn0jt799ah)