### PR TITLE
Allow regeneration to accept Extents instead of EditSessions.

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
@@ -27,6 +27,7 @@ import com.sk89q.worldedit.blocks.BaseItem;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.entity.BaseEntity;
+import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.internal.wna.WorldNativeAccess;
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -198,11 +199,11 @@ public class BukkitWorld extends AbstractWorld {
     }
 
     @Override
-    public boolean regenerate(Region region, EditSession editSession, RegenOptions options) {
+    public boolean regenerate(Region region, Extent extent, RegenOptions options) {
         BukkitImplAdapter adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
         try {
             if (adapter != null) {
-                return adapter.regenerate(getWorld(), region, editSession, options);
+                return adapter.regenerate(getWorld(), region, extent, options);
             } else {
                 throw new UnsupportedOperationException("Missing BukkitImplAdapater for this version.");
             }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
@@ -24,6 +24,7 @@ import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.blocks.BaseItem;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.entity.BaseEntity;
+import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.internal.wna.WorldNativeAccess;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.Region;
@@ -227,6 +228,18 @@ public interface BukkitImplAdapter {
      * @return true on success, false on failure
      */
     default boolean regenerate(World world, Region region, EditSession session, RegenOptions options) {
+        return regenerate(world, region, (Extent) session, options);
+    }
+
+    /**
+     * Regenerate a region in the given world, so it appears "as new".
+     * @param world the world to regen in
+     * @param region the region to regen
+     * @param extent the extent to use for setting blocks
+     * @param options the regeneration options
+     * @return true on success, false on failure
+     */
+    default boolean regenerate(World world, Region region, Extent extent, RegenOptions options) {
         throw new UnsupportedOperationException("This adapter does not support regeneration.");
     }
 }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
@@ -223,18 +223,6 @@ public interface BukkitImplAdapter {
      * Regenerate a region in the given world, so it appears "as new".
      * @param world the world to regen in
      * @param region the region to regen
-     * @param session the session to use for setting blocks
-     * @param options the regeneration options
-     * @return true on success, false on failure
-     */
-    default boolean regenerate(World world, Region region, EditSession session, RegenOptions options) {
-        return regenerate(world, region, (Extent) session, options);
-    }
-
-    /**
-     * Regenerate a region in the given world, so it appears "as new".
-     * @param world the world to regen in
-     * @param region the region to regen
      * @param extent the extent to use for setting blocks
      * @param options the regeneration options
      * @return true on success, false on failure

--- a/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/schematic/ClipboardWorld.java
+++ b/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/schematic/ClipboardWorld.java
@@ -27,6 +27,7 @@ import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.cli.CLIWorld;
 import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.entity.Entity;
+import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
 import com.sk89q.worldedit.extent.clipboard.io.ClipboardFormats;
 import com.sk89q.worldedit.extent.clipboard.io.ClipboardWriter;
@@ -106,7 +107,7 @@ public class ClipboardWorld extends AbstractWorld implements Clipboard, CLIWorld
     }
 
     @Override
-    public boolean regenerate(Region region, EditSession editSession, RegenOptions options) {
+    public boolean regenerate(Region region, Extent extent, RegenOptions options) {
         return false;
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/NullWorld.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/NullWorld.java
@@ -26,6 +26,7 @@ import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.entity.Entity;
+import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.regions.Region;
@@ -113,7 +114,7 @@ public class NullWorld extends AbstractWorld {
     }
 
     @Override
-    public boolean regenerate(Region region, EditSession editSession, RegenOptions options) {
+    public boolean regenerate(Region region, Extent extent, RegenOptions options) {
         return false;
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
@@ -27,6 +27,7 @@ import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.function.mask.Mask;
+import com.sk89q.worldedit.internal.util.DeprecationUtil;
 import com.sk89q.worldedit.internal.util.NonAbstractForCompatibility;
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -208,6 +209,17 @@ public interface World extends Extent, Keyed {
      * Regenerate an area.
      *
      * @param region the region
+     * @param editSession the {@link EditSession}
+     * @return true if re-generation was successful
+     */
+    default boolean regenerate(Region region, EditSession editSession) {
+        return regenerate(region, editSession, RegenOptions.builder().build());
+    }
+
+    /**
+     * Regenerate an area.
+     *
+     * @param region the region
      * @param extent the {@link Extent}
      * @return true if re-generation was successful
      */
@@ -219,43 +231,24 @@ public interface World extends Extent, Keyed {
      * Regenerate an area.
      *
      * @param region the region
-     * @param editSession the {@link EditSession}
-     * @return true if re-generation was successful
-     */
-    default boolean regenerate(Region region, EditSession editSession) {
-        return regenerate(region, (Extent) editSession, RegenOptions.builder().build());
-    }
-
-    /**
-     * Regenerate an area.
-     *
-     * @param region the region
      * @param extent the {@link Extent}
      * @param options the regeneration options
      * @return true if regeneration was successful
-     */
-    @NonAbstractForCompatibility(
-        delegateName = "regenerate",
-        delegateParams = { Region.class, Extent.class }
-    )
-    default boolean regenerate(Region region, Extent extent, RegenOptions options) {
-        return regenerate(region, extent);
-    }
-
-    /**
-     * Regenerate an area.
-     *
-     * @param region the region
-     * @param editSession the {@link EditSession}
-     * @param options the regeneration options
-     * @return true if regeneration was successful
+     * @apiNote This must be overridden by new subclasses. See {@link NonAbstractForCompatibility}
+     *          for details
      */
     @NonAbstractForCompatibility(
         delegateName = "regenerate",
         delegateParams = { Region.class, EditSession.class }
     )
-    default boolean regenerate(Region region, EditSession editSession, RegenOptions options) {
-        return regenerate(region, (Extent) editSession);
+    default boolean regenerate(Region region, Extent extent, RegenOptions options) {
+        DeprecationUtil.checkDelegatingOverride(getClass());
+        if (extent instanceof EditSession) {
+            return regenerate(region, (EditSession) extent);
+        }
+        throw new UnsupportedOperationException("This World class ("
+            + getClass().getName()
+            + ") does not implement the general Extent variant of this method");
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
@@ -208,11 +208,38 @@ public interface World extends Extent, Keyed {
      * Regenerate an area.
      *
      * @param region the region
+     * @param extent the {@link Extent}
+     * @return true if re-generation was successful
+     */
+    default boolean regenerate(Region region, Extent extent) {
+        return regenerate(region, extent, RegenOptions.builder().build());
+    }
+
+    /**
+     * Regenerate an area.
+     *
+     * @param region the region
      * @param editSession the {@link EditSession}
      * @return true if re-generation was successful
      */
     default boolean regenerate(Region region, EditSession editSession) {
-        return regenerate(region, editSession, RegenOptions.builder().build());
+        return regenerate(region, (Extent) editSession, RegenOptions.builder().build());
+    }
+
+    /**
+     * Regenerate an area.
+     *
+     * @param region the region
+     * @param extent the {@link Extent}
+     * @param options the regeneration options
+     * @return true if regeneration was successful
+     */
+    @NonAbstractForCompatibility(
+        delegateName = "regenerate",
+        delegateParams = { Region.class, Extent.class }
+    )
+    default boolean regenerate(Region region, Extent extent, RegenOptions options) {
+        return regenerate(region, extent);
     }
 
     /**
@@ -228,7 +255,7 @@ public interface World extends Extent, Keyed {
         delegateParams = { Region.class, EditSession.class }
     )
     default boolean regenerate(Region region, EditSession editSession, RegenOptions options) {
-        return regenerate(region, editSession);
+        return regenerate(region, (Extent) editSession);
     }
 
     /**

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorld.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorld.java
@@ -26,6 +26,7 @@ import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.entity.Entity;
+import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.regions.Region;
@@ -182,7 +183,7 @@ public abstract class SpongeWorld extends AbstractWorld {
     }
 
     @Override
-    public boolean regenerate(Region region, EditSession editSession, RegenOptions options) {
+    public boolean regenerate(Region region, Extent extent, RegenOptions options) {
         return false;
     }
 


### PR DESCRIPTION
Allows for custom Extents to be parsed to regen, and for clipboard regeneration, etc whilst still allowing EditSessions