### PR TITLE
Fail if any mask fails to parse

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/MaskFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/MaskFactory.java
@@ -98,13 +98,18 @@ public final class MaskFactory extends AbstractFactory<Mask> {
                 continue;
             }
 
+            Mask match = null;
             for (InputParser<Mask> parser : getParsers()) {
-                Mask match = parser.parseFromInput(component, context);
+                match = parser.parseFromInput(component, context);
 
                 if (match != null) {
-                    masks.add(match);
+                    break;
                 }
             }
+            if (match == null) {
+                throw new NoMatchException(TranslatableComponent.of("worldedit.error.no-match", TextComponent.of(component)));
+            }
+            masks.add(match);
         }
 
         switch (masks.size()) {


### PR DESCRIPTION
This prevents things like `"20% grass_block"` from accidentally meaning `grass_block`, since the parser just ignores the failed mask.