### PR TITLE
Fixed snapshot database under symlinks on windows

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/snapshot/experimental/fs/FileSystemSnapshotDatabase.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/snapshot/experimental/fs/FileSystemSnapshotDatabase.java
@@ -93,7 +93,11 @@ public class FileSystemSnapshotDatabase implements SnapshotDatabase {
 
     public FileSystemSnapshotDatabase(Path root, ArchiveNioSupport archiveNioSupport) {
         checkArgument(Files.isDirectory(root), "Database root is not a directory");
-        this.root = root.toAbsolutePath();
+        try {
+            this.root = root.toRealPath();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to resolve snapshot database path", e);
+        }
         this.archiveNioSupport = archiveNioSupport;
     }
 


### PR DESCRIPTION
Uses a real path rather than absolute path, resolving any symlinks.

Fixes #1444 