### PR TITLE
Deprecate BlockQuirkExtent, handle lower down

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
@@ -442,6 +442,7 @@ public class BukkitWorld extends AbstractWorld {
 
     @Override
     public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 position, B block, SideEffectSet sideEffects) {
+        clearContainerBlockContents(position);
         if (worldNativeAccess != null) {
             try {
                 return worldNativeAccess.setBlock(position, block, sideEffects);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -40,7 +40,6 @@ import com.sk89q.worldedit.extent.reorder.MultiStageReorder;
 import com.sk89q.worldedit.extent.validation.BlockChangeLimiter;
 import com.sk89q.worldedit.extent.validation.DataValidatorExtent;
 import com.sk89q.worldedit.extent.world.BiomeQuirkExtent;
-import com.sk89q.worldedit.extent.world.BlockQuirkExtent;
 import com.sk89q.worldedit.extent.world.ChunkLoadingExtent;
 import com.sk89q.worldedit.extent.world.SideEffectExtent;
 import com.sk89q.worldedit.extent.world.SurvivalModeExtent;
@@ -257,7 +256,6 @@ public class EditSession implements Extent, AutoCloseable {
                 watchdogExtents.add(watchdogExtent);
             }
             extent = traceIfNeeded(survivalExtent = new SurvivalModeExtent(extent, world));
-            extent = traceIfNeeded(new BlockQuirkExtent(extent, world));
             extent = traceIfNeeded(new BiomeQuirkExtent(extent));
             extent = traceIfNeeded(new ChunkLoadingExtent(extent, world));
             extent = traceIfNeeded(new LastAccessExtentCache(extent));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/BlockQuirkExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/BlockQuirkExtent.java
@@ -33,7 +33,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Handles various quirks when setting blocks, such as ice turning
  * into water or containers dropping their contents.
+ *
+ * @deprecated Handled by the world entirely now
  */
+@Deprecated
 public class BlockQuirkExtent extends AbstractDelegateExtent {
 
     private final World world;

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorld.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorld.java
@@ -186,6 +186,7 @@ public class FabricWorld extends AbstractWorld {
 
     @Override
     public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 position, B block, SideEffectSet sideEffects) throws WorldEditException {
+        clearContainerBlockContents(position);
         return worldNativeAccess.setBlock(position, block, sideEffects);
     }
 

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java
@@ -189,6 +189,7 @@ public class ForgeWorld extends AbstractWorld {
 
     @Override
     public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 position, B block, SideEffectSet sideEffects) throws WorldEditException {
+        clearContainerBlockContents(position);
         return nativeAccess.setBlock(position, block, sideEffects);
     }
 


### PR DESCRIPTION
Ice is no longer turning into water since before 1.7.10, so that part has been removed entirely.