### PR TITLE
Workaround for snapshot files with not-to-spec slashes.

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/TrueZipMcRegionChunkStore.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/TrueZipMcRegionChunkStore.java
@@ -97,10 +97,15 @@ public class TrueZipMcRegionChunkStore extends McRegionChunkStore {
             for (Enumeration<? extends ZipEntry> e = zip.entries(); e.hasMoreElements(); ) {
                 ZipEntry testEntry = e.nextElement();
                 // Check for world
-                if (worldPattern.matcher(testEntry.getName()).matches()) {
+                String entryName = testEntry.getName();
+                if (worldPattern.matcher(entryName).matches()) {
                     // Check for file
-                    if (pattern.matcher(testEntry.getName()).matches()) {
-                        folder = testEntry.getName().substring(0, testEntry.getName().lastIndexOf('/'));
+                    if (pattern.matcher(entryName).matches()) {
+                        int endIndex = entryName.lastIndexOf('/');
+                        if (endIndex < 0) {
+                            endIndex = entryName.lastIndexOf('\\');
+                        }
+                        folder = entryName.substring(0, endIndex);
                         if (folder.endsWith("poi")) {
                             continue;
                         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/ZippedMcRegionChunkStore.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/ZippedMcRegionChunkStore.java
@@ -81,12 +81,18 @@ public class ZippedMcRegionChunkStore extends McRegionChunkStore {
             }
         } else {
             Pattern pattern = Pattern.compile(".*\\.mc[ra]$");
+            Pattern worldPattern = Pattern.compile(worldName + "[\\\\/].*");
             for (Enumeration<? extends ZipEntry> e = zip.entries(); e.hasMoreElements(); ) {
                 ZipEntry testEntry = e.nextElement();
                 // Check for world
-                if (testEntry.getName().startsWith(worldName + "/")) {
-                    if (pattern.matcher(testEntry.getName()).matches()) { // does entry end in .mca
-                        folder = testEntry.getName().substring(0, testEntry.getName().lastIndexOf('/'));
+                String entryName = testEntry.getName();
+                if (worldPattern.matcher(entryName).matches()) {
+                    if (pattern.matcher(entryName).matches()) { // does entry end in .mca
+                        int endIndex = entryName.lastIndexOf('/');
+                        if (endIndex < 0) {
+                            endIndex = entryName.lastIndexOf('\\');
+                        }
+                        folder = entryName.substring(0, endIndex);
                         if (folder.endsWith("poi")) {
                             continue;
                         }


### PR DESCRIPTION
Some utilities will create zip entries using windows path separators, which despite being against the zip file specification, we should probably read in anyway.