### PR TITLE
Add a #air mask, the opposite of #existing

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/MaskFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/MaskFactory.java
@@ -20,6 +20,7 @@
 package com.sk89q.worldedit.extension.factory;
 
 import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.extension.factory.parser.mask.AirMaskParser;
 import com.sk89q.worldedit.extension.factory.parser.mask.BiomeMaskParser;
 import com.sk89q.worldedit.extension.factory.parser.mask.BlockCategoryMaskParser;
 import com.sk89q.worldedit.extension.factory.parser.mask.BlockStateMaskParser;
@@ -64,6 +65,7 @@ public final class MaskFactory extends AbstractFactory<Mask> {
         super(worldEdit, new BlocksMaskParser(worldEdit));
 
         register(new ExistingMaskParser(worldEdit));
+        register(new AirMaskParser(worldEdit));
         register(new SolidMaskParser(worldEdit));
         register(new LazyRegionMaskParser(worldEdit));
         register(new RegionMaskParser(worldEdit));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/AirMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/AirMaskParser.java
@@ -1,0 +1,50 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.extension.factory.parser.mask;
+
+import com.google.common.collect.ImmutableList;
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.extension.input.InputParseException;
+import com.sk89q.worldedit.extension.input.ParserContext;
+import com.sk89q.worldedit.function.mask.ExistingBlockMask;
+import com.sk89q.worldedit.function.mask.Mask;
+import com.sk89q.worldedit.function.mask.Masks;
+import com.sk89q.worldedit.internal.registry.SimpleInputParser;
+
+import java.util.List;
+
+public class AirMaskParser extends SimpleInputParser<Mask> {
+
+    private final List<String> aliases = ImmutableList.of("#air");
+
+    public AirMaskParser(WorldEdit worldEdit) {
+        super(worldEdit);
+    }
+
+    @Override
+    public List<String> getMatchedAliases() {
+        return aliases;
+    }
+
+    @Override
+    public Mask parseFromSimpleInput(String input, ParserContext context) throws InputParseException {
+        return Masks.negate(new ExistingBlockMask(context.requireExtent()));
+    }
+}


### PR DESCRIPTION
Rather simple, just adds a `#air` mask that masks all air types, it's just an alias for `!#existing`.