### PR TITLE
Remove Y limits if a region has no world

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/AbstractRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/AbstractRegion.java
@@ -207,11 +207,11 @@ public abstract class AbstractRegion implements Region {
     // Sub-class utilities
 
     protected final int getWorldMinY() {
-        return world == null ? 0 : world.getMinY();
+        return world == null ? Integer.MIN_VALUE : world.getMinY();
     }
 
     protected final int getWorldMaxY() {
-        return world == null ? 255 : world.getMaxY();
+        return world == null ? Integer.MAX_VALUE : world.getMaxY();
     }
 
 }


### PR DESCRIPTION
This allows schematics to load in without clipping, so that they may be properly rotated later.

Edit: fixes #1495.