### PR TITLE
Added an OffsetsMask, with a parser for an Exposed/Surface mask

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/MaskFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/MaskFactory.java
@@ -26,6 +26,7 @@ import com.sk89q.worldedit.extension.factory.parser.mask.BlockCategoryMaskParser
 import com.sk89q.worldedit.extension.factory.parser.mask.BlockStateMaskParser;
 import com.sk89q.worldedit.extension.factory.parser.mask.BlocksMaskParser;
 import com.sk89q.worldedit.extension.factory.parser.mask.ExistingMaskParser;
+import com.sk89q.worldedit.extension.factory.parser.mask.ExposedMaskParser;
 import com.sk89q.worldedit.extension.factory.parser.mask.ExpressionMaskParser;
 import com.sk89q.worldedit.extension.factory.parser.mask.LazyRegionMaskParser;
 import com.sk89q.worldedit.extension.factory.parser.mask.NegateMaskParser;
@@ -66,6 +67,7 @@ public final class MaskFactory extends AbstractFactory<Mask> {
 
         register(new ExistingMaskParser(worldEdit));
         register(new AirMaskParser(worldEdit));
+        register(new ExposedMaskParser(worldEdit));
         register(new SolidMaskParser(worldEdit));
         register(new LazyRegionMaskParser(worldEdit));
         register(new RegionMaskParser(worldEdit));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/ExposedMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/ExposedMaskParser.java
@@ -1,0 +1,51 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.extension.factory.parser.mask;
+
+import com.google.common.collect.ImmutableList;
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.extension.input.InputParseException;
+import com.sk89q.worldedit.extension.input.ParserContext;
+import com.sk89q.worldedit.function.mask.ExistingBlockMask;
+import com.sk89q.worldedit.function.mask.Mask;
+import com.sk89q.worldedit.function.mask.Masks;
+import com.sk89q.worldedit.function.mask.OffsetsMask;
+import com.sk89q.worldedit.internal.registry.SimpleInputParser;
+
+import java.util.List;
+
+public class ExposedMaskParser extends SimpleInputParser<Mask> {
+
+    private final List<String> aliases = ImmutableList.of("#exposed", "#surface");
+
+    public ExposedMaskParser(WorldEdit worldEdit) {
+        super(worldEdit);
+    }
+
+    @Override
+    public List<String> getMatchedAliases() {
+        return this.aliases;
+    }
+
+    @Override
+    public Mask parseFromSimpleInput(String input, ParserContext context) throws InputParseException {
+        return new OffsetsMask(Masks.negate(new ExistingBlockMask(context.requireExtent())), true);
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/ExposedMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/ExposedMaskParser.java
@@ -46,6 +46,8 @@ public class ExposedMaskParser extends SimpleInputParser<Mask> {
 
     @Override
     public Mask parseFromSimpleInput(String input, ParserContext context) throws InputParseException {
-        return new OffsetsMask(Masks.negate(new ExistingBlockMask(context.requireExtent())), true);
+        return OffsetsMask.builder(Masks.negate(new ExistingBlockMask(context.requireExtent())))
+            .excludeSelf(true)
+            .build();
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/OffsetMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/OffsetMaskParser.java
@@ -26,7 +26,7 @@ import com.sk89q.worldedit.function.mask.ExistingBlockMask;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.mask.MaskIntersection;
 import com.sk89q.worldedit.function.mask.Masks;
-import com.sk89q.worldedit.function.mask.OffsetMask;
+import com.sk89q.worldedit.function.mask.OffsetsMask;
 import com.sk89q.worldedit.internal.registry.InputParser;
 import com.sk89q.worldedit.math.BlockVector3;
 
@@ -63,7 +63,7 @@ public class OffsetMaskParser extends InputParser<Mask> {
         } else {
             submask = new ExistingBlockMask(context.requireExtent());
         }
-        OffsetMask offsetMask = new OffsetMask(submask, BlockVector3.at(0, firstChar == '>' ? -1 : 1, 0));
+        Mask offsetMask = OffsetsMask.single(submask, BlockVector3.at(0, firstChar == '>' ? -1 : 1, 0));
         return new MaskIntersection(offsetMask, Masks.negate(submask));
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/OffsetMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/OffsetMask.java
@@ -28,7 +28,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Checks whether another mask tests true for a position that is offset
  * a given vector.
+ *
+ * @deprecated Use {@link OffsetsMask#single}
  */
+@Deprecated
 public class OffsetMask extends AbstractMask {
 
     private Mask mask;
@@ -95,7 +98,7 @@ public class OffsetMask extends AbstractMask {
     public Mask2D toMask2D() {
         Mask2D childMask = getMask().toMask2D();
         if (childMask != null) {
-            return new OffsetMask2D(childMask, getOffset().toBlockVector2());
+            return OffsetsMask2D.single(childMask, getOffset().toBlockVector2());
         } else {
             return null;
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/OffsetMask2D.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/OffsetMask2D.java
@@ -26,7 +26,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Checks whether another mask tests true for a position that is offset
  * a given vector.
+ *
+ * @deprecated Use {@link OffsetsMask2D#single}
  */
+@Deprecated
 public class OffsetMask2D extends AbstractMask2D {
 
     private Mask2D mask;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/OffsetsMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/OffsetsMask.java
@@ -20,11 +20,11 @@
 package com.sk89q.worldedit.function.mask;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Direction;
 
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -35,12 +35,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class OffsetsMask extends AbstractMask {
 
-    private static final ImmutableList<BlockVector3> OFFSET_LIST = ImmutableList.copyOf(
+    private static final ImmutableSet<BlockVector3> OFFSET_LIST =
         Direction.valuesOf(Direction.Flag.CARDINAL | Direction.Flag.UPRIGHT)
             .stream()
             .map(Direction::toBlockVector)
-            .collect(Collectors.toList())
-    );
+            .collect(ImmutableSet.toImmutableSet());
 
     /**
      * Create an offsets mask for a single offset.
@@ -70,7 +69,7 @@ public class OffsetsMask extends AbstractMask {
         private boolean excludeSelf;
         private int minMatches = 1;
         private int maxMatches = Integer.MAX_VALUE;
-        private ImmutableList<BlockVector3> offsets = OFFSET_LIST;
+        private ImmutableSet<BlockVector3> offsets = OFFSET_LIST;
 
         private Builder() {
         }
@@ -130,7 +129,7 @@ public class OffsetsMask extends AbstractMask {
          * @return this builder, for chaining
          */
         public Builder offsets(Iterable<BlockVector3> offsets) {
-            this.offsets = ImmutableList.copyOf(offsets);
+            this.offsets = ImmutableSet.copyOf(offsets);
             return this;
         }
 
@@ -148,9 +147,9 @@ public class OffsetsMask extends AbstractMask {
     private final boolean excludeSelf;
     private final int minMatches;
     private final int maxMatches;
-    private final ImmutableList<BlockVector3> offsets;
+    private final ImmutableSet<BlockVector3> offsets;
 
-    private OffsetsMask(Mask mask, boolean excludeSelf, int minMatches, int maxMatches, ImmutableList<BlockVector3> offsets) {
+    private OffsetsMask(Mask mask, boolean excludeSelf, int minMatches, int maxMatches, ImmutableSet<BlockVector3> offsets) {
         checkNotNull(mask);
         checkNotNull(offsets);
         // Validate match args. No need to test maxMatches as it must be >=0 based on the conditions here.
@@ -207,7 +206,7 @@ public class OffsetsMask extends AbstractMask {
      *
      * @return the offsets
      */
-    public ImmutableList<BlockVector3> getOffsets() {
+    public ImmutableSet<BlockVector3> getOffsets() {
         return this.offsets;
     }
 
@@ -240,7 +239,7 @@ public class OffsetsMask extends AbstractMask {
                 .excludeSelf(excludeSelf)
                 .minMatches(minMatches)
                 .maxMatches(maxMatches)
-                .offsets(Lists.transform(offsets, BlockVector3::toBlockVector2))
+                .offsets(Iterables.transform(offsets, BlockVector3::toBlockVector2))
                 .build();
         } else {
             return null;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/OffsetsMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/OffsetsMask.java
@@ -1,0 +1,213 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.function.mask;
+
+import com.google.common.collect.ImmutableList;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.util.Direction;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Checks whether any face of the given offsets to a block match a given mask.
+ */
+public class OffsetsMask extends AbstractMask {
+
+    private static final ImmutableList<BlockVector3> OFFSET_LIST = ImmutableList.copyOf(
+        Direction.valuesOf(Direction.Flag.CARDINAL | Direction.Flag.UPRIGHT)
+            .stream()
+            .map(Direction::toBlockVector)
+            .collect(Collectors.toList())
+    );
+
+    private final Mask mask;
+    private final boolean excludeSelf;
+    private final int minMatches;
+    private final int maxMatches;
+    private final ImmutableList<BlockVector3> offsets;
+
+    /**
+     * Create an OffsetsMask for a single offset.
+     *
+     * @param mask The mask to use
+     * @param offset The offset
+     * @return The offsets mask
+     */
+    public static OffsetsMask single(Mask mask, BlockVector3 offset) {
+        return new OffsetsMask(mask, false, 1, 1, ImmutableList.of(offset));
+    }
+
+    /**
+     * Create a new instance using all adjacent faces excluding diagonals.
+     *
+     * <p>
+     *     Note: This passes as long as there is at least one match, and does not
+     *     exclude cases where the block being checked matches the mask.
+     * </p>
+     *
+     * @param mask the mask to test against
+     */
+    public OffsetsMask(Mask mask) {
+        this(mask, false);
+    }
+
+    /**
+     * Create a new instance using all adjacent faces excluding diagonals.
+     *
+     * <p>
+     *     Note: This passes as long as there is at least one match.
+     * </p>
+     *
+     * @param mask the mask to test against
+     * @param excludeSelf excludes blocks where the mask matches itself
+     */
+    public OffsetsMask(Mask mask, boolean excludeSelf) {
+        this(mask, excludeSelf, 1, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Create a new instance using all adjacent faces excluding diagonals.
+     *
+     * @param mask the mask to test against
+     * @param excludeSelf excludes blocks where the mask matches itself
+     * @param minMatches the minimum number of matches (inclusive)
+     * @param maxMatches the maximum number of matches (inclusive)
+     */
+    public OffsetsMask(Mask mask, boolean excludeSelf, int minMatches, int maxMatches) {
+        this(mask, excludeSelf, minMatches, maxMatches, OFFSET_LIST);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * <p>
+     *     Note: the minimum number of matches must be 0 or greater, and
+     *     the maximum number of matches cannot be below the minimum.
+     * </p>
+     *
+     * @param mask the mask to test against
+     * @param excludeSelf excludes blocks where the mask matches itself
+     * @param minMatches the minimum number of matches (inclusive)
+     * @param maxMatches the maximum number of matches (inclusive)
+     * @param offsets the block offsets to test with
+     */
+    public OffsetsMask(Mask mask, boolean excludeSelf, int minMatches, int maxMatches, List<BlockVector3> offsets) {
+        checkNotNull(mask);
+        checkNotNull(offsets);
+        // Validate match args. No need to test maxMatches as it must be >=0 based on the conditions here.
+        checkArgument(minMatches <= maxMatches, "minMatches must be less than or equal to maxMatches");
+        checkArgument(minMatches >= 0, "minMatches must be greater than or equal to 0");
+        checkArgument(minMatches <= offsets.size(), "minMatches must be less than or equal to the number of offsets");
+        checkArgument(offsets.size() > 0, "offsets must have at least one element");
+
+        this.mask = mask;
+        this.excludeSelf = excludeSelf;
+        this.minMatches = minMatches;
+        this.maxMatches = maxMatches;
+        this.offsets = ImmutableList.copyOf(offsets);
+    }
+
+    /**
+     * Get the mask.
+     *
+     * @return the mask
+     */
+    public Mask getMask() {
+        return mask;
+    }
+
+    /**
+     * Get the offsets.
+     *
+     * @return the offsets
+     */
+    public ImmutableList<BlockVector3> getOffsets() {
+        return this.offsets;
+    }
+
+    /**
+     * Get the flag determining if matching the current block should fail the mask.
+     *
+     * @return if it should exclude self-matches
+     */
+    public boolean getExcludeSelf() {
+        return this.excludeSelf;
+    }
+
+    /**
+     * Gets the minimum number of matches to pass.
+     *
+     * @return the minimum number of matches
+     */
+    public int getMinMatches() {
+        return this.minMatches;
+    }
+
+    /**
+     * Gets the maximum number of matches to pass.
+     *
+     * @return the maximum number of matches
+     */
+    public int getMaxMatches() {
+        return this.maxMatches;
+    }
+
+    @Override
+    public boolean test(BlockVector3 vector) {
+        if (excludeSelf && mask.test(vector)) {
+            return false;
+        }
+
+        int matches = 0;
+
+        for (BlockVector3 offset : offsets) {
+            if (mask.test(vector.add(offset))) {
+                matches++;
+                if (matches > maxMatches) {
+                    return false;
+                }
+            }
+        }
+
+        return minMatches <= matches && matches <= maxMatches;
+    }
+
+    @Nullable
+    @Override
+    public Mask2D toMask2D() {
+        Mask2D childMask = getMask().toMask2D();
+        if (childMask != null) {
+            return new OffsetsMask2D(
+                childMask,
+                excludeSelf,
+                minMatches,
+                maxMatches,
+                getOffsets().stream().map(BlockVector3::toBlockVector2).collect(Collectors.toList())
+            );
+        } else {
+            return null;
+        }
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/OffsetsMask2D.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/OffsetsMask2D.java
@@ -1,0 +1,183 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.function.mask;
+
+import com.google.common.collect.ImmutableList;
+import com.sk89q.worldedit.math.BlockVector2;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.util.Direction;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Checks whether any face of the given offsets to a block match a given mask.
+ */
+public class OffsetsMask2D extends AbstractMask2D {
+
+    private static final ImmutableList<BlockVector2> OFFSET_LIST = ImmutableList.copyOf(
+        Direction.valuesOf(Direction.Flag.CARDINAL)
+            .stream()
+            .map(Direction::toBlockVector)
+            .map(BlockVector3::toBlockVector2)
+            .collect(Collectors.toList())
+    );
+
+    private final Mask2D mask;
+    private final boolean excludeSelf;
+    private final int minMatches;
+    private final int maxMatches;
+    private final ImmutableList<BlockVector2> offsets;
+
+    /**
+     * Create an OffsetsMask2D for a single offset.
+     *
+     * @param mask The mask to use
+     * @param offset The offset
+     * @return The offsets mask
+     */
+    public static OffsetsMask2D single(Mask2D mask, BlockVector2 offset) {
+        return new OffsetsMask2D(mask, false, 1, 1, ImmutableList.of(offset));
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param mask the mask to test against
+     */
+    public OffsetsMask2D(Mask2D mask) {
+        this(mask, false);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param mask the mask to test against
+     * @param excludeSelf excludes blocks where the mask matches itself
+     */
+    public OffsetsMask2D(Mask2D mask, boolean excludeSelf) {
+        this(mask, excludeSelf, 1, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param mask the mask to test against
+     * @param excludeSelf excludes blocks where the mask matches itself
+     * @param minMatches the minimum number of matches (inclusive)
+     * @param maxMatches the maximum number of matches (inclusive)
+     */
+    public OffsetsMask2D(Mask2D mask, boolean excludeSelf, int minMatches, int maxMatches) {
+        this(mask, excludeSelf, minMatches, maxMatches, OFFSET_LIST);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param mask the mask to test against
+     * @param excludeSelf excludes blocks where the mask matches itself
+     * @param minMatches the minimum number of matches (inclusive)
+     * @param maxMatches the maximum number of matches (inclusive)
+     * @param offsets the block offsets to test with
+     */
+    public OffsetsMask2D(Mask2D mask, boolean excludeSelf, int minMatches, int maxMatches, List<BlockVector2> offsets) {
+        checkNotNull(mask);
+        checkNotNull(offsets);
+        // Validate match args. No need to test maxMatches as it must be >=0 based on the conditions here.
+        checkArgument(minMatches <= maxMatches, "minMatches must be less than or equal to maxMatches");
+        checkArgument(minMatches >= 0, "minMatches must be greater than or equal to 0");
+        checkArgument(minMatches <= offsets.size(), "minMatches must be less than or equal to the number of offsets");
+        checkArgument(offsets.size() > 0, "offsets must have at least one element");
+
+        this.mask = mask;
+        this.excludeSelf = excludeSelf;
+        this.minMatches = minMatches;
+        this.maxMatches = maxMatches;
+        this.offsets = ImmutableList.copyOf(offsets);
+    }
+
+    /**
+     * Get the mask.
+     *
+     * @return the mask
+     */
+    public Mask2D getMask() {
+        return mask;
+    }
+
+    /**
+     * Get the offsets.
+     *
+     * @return the offsets
+     */
+    public List<BlockVector2> getOffsets() {
+        return this.offsets;
+    }
+
+    /**
+     * Get the flag determining if matching the current block should fail the mask.
+     *
+     * @return if it should exclude self-matches
+     */
+    public boolean getExcludeSelf() {
+        return this.excludeSelf;
+    }
+
+    /**
+     * Gets the minimum number of matches to pass.
+     *
+     * @return the minimum number of matches
+     */
+    public int getMinMatches() {
+        return this.minMatches;
+    }
+
+    /**
+     * Gets the maximum number of matches to pass.
+     *
+     * @return the maximum number of matches
+     */
+    public int getMaxMatches() {
+        return this.maxMatches;
+    }
+
+    @Override
+    public boolean test(BlockVector2 vector) {
+        if (excludeSelf && mask.test(vector)) {
+            return false;
+        }
+
+        int matches = 0;
+
+        for (BlockVector2 offset : offsets) {
+            if (mask.test(vector.add(offset))) {
+                matches++;
+                if (matches > maxMatches) {
+                    return false;
+                }
+            }
+        }
+
+        return minMatches <= matches && matches <= maxMatches;
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/OffsetsMask2D.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/OffsetsMask2D.java
@@ -43,64 +43,115 @@ public class OffsetsMask2D extends AbstractMask2D {
             .collect(Collectors.toList())
     );
 
+    /**
+     * Create an offsets mask for a single offset.
+     *
+     * @param mask the mask to use
+     * @param offset the offset
+     * @return the new offsets mask
+     */
+    public static OffsetsMask2D single(Mask2D mask, BlockVector2 offset) {
+        return builder(mask).maxMatches(1).offsets(ImmutableList.of(offset)).build();
+    }
+
+    /**
+     * Create a new builder, using the given mask.
+     * @param mask the mask to use
+     * @return the builder
+     */
+    public static Builder builder(Mask2D mask) {
+        return new Builder().mask(mask);
+    }
+
+    /**
+     * A builder for an {@link OffsetsMask}.
+     */
+    public static final class Builder {
+        private Mask2D mask;
+        private boolean excludeSelf;
+        private int minMatches = 1;
+        private int maxMatches = Integer.MAX_VALUE;
+        private ImmutableList<BlockVector2> offsets = OFFSET_LIST;
+
+        private Builder() {
+        }
+
+        /**
+         * Set the mask to test.
+         * @param mask the mask to test
+         * @return this builder, for chaining
+         */
+        public Builder mask(Mask2D mask) {
+            this.mask = mask;
+            return this;
+        }
+
+        /**
+         * Set whether the mask should fail if the original position matches. Defaults to
+         * {@code false}.
+         *
+         * @param excludeSelf {@code true} to exclude the original position if it matches
+         * @return this builder, for chaining
+         */
+        public Builder excludeSelf(boolean excludeSelf) {
+            this.excludeSelf = excludeSelf;
+            return this;
+        }
+
+        /**
+         * Set the minimum amount of matches required. Defaults to {@code 1}. Must be smaller than
+         * or equal to the {@linkplain #maxMatches(int) max matches} and the {@link #offsets} size,
+         * and greater than or equal to {@code 0}.
+         *
+         * @param minMatches the minimum amount of matches required
+         * @return this builder, for chaining
+         */
+        public Builder minMatches(int minMatches) {
+            this.minMatches = minMatches;
+            return this;
+        }
+
+        /**
+         * Set the maximum amount of matches allowed. Defaults to {@link Integer#MAX_VALUE}. Must
+         * be greater than or equal to {@linkplain #minMatches(int)}.
+         *
+         * @param maxMatches the maximum amount of matches allowed
+         * @return this builder, for chaining
+         */
+        public Builder maxMatches(int maxMatches) {
+            this.maxMatches = maxMatches;
+            return this;
+        }
+
+        /**
+         * Set the offsets to test. Defaults to all {@linkplain Direction.Flag#CARDINAL cardinal}
+         * directions.
+         *
+         * @param offsets the offsets to test
+         * @return this builder, for chaining
+         */
+        public Builder offsets(Iterable<BlockVector2> offsets) {
+            this.offsets = ImmutableList.copyOf(offsets);
+            return this;
+        }
+
+        /**
+         * Build an offsets mask.
+         *
+         * @return the new mask
+         */
+        public OffsetsMask2D build() {
+            return new OffsetsMask2D(mask, excludeSelf, minMatches, maxMatches, offsets);
+        }
+    }
+
     private final Mask2D mask;
     private final boolean excludeSelf;
     private final int minMatches;
     private final int maxMatches;
     private final ImmutableList<BlockVector2> offsets;
 
-    /**
-     * Create an OffsetsMask2D for a single offset.
-     *
-     * @param mask The mask to use
-     * @param offset The offset
-     * @return The offsets mask
-     */
-    public static OffsetsMask2D single(Mask2D mask, BlockVector2 offset) {
-        return new OffsetsMask2D(mask, false, 1, 1, ImmutableList.of(offset));
-    }
-
-    /**
-     * Create a new instance.
-     *
-     * @param mask the mask to test against
-     */
-    public OffsetsMask2D(Mask2D mask) {
-        this(mask, false);
-    }
-
-    /**
-     * Create a new instance.
-     *
-     * @param mask the mask to test against
-     * @param excludeSelf excludes blocks where the mask matches itself
-     */
-    public OffsetsMask2D(Mask2D mask, boolean excludeSelf) {
-        this(mask, excludeSelf, 1, Integer.MAX_VALUE);
-    }
-
-    /**
-     * Create a new instance.
-     *
-     * @param mask the mask to test against
-     * @param excludeSelf excludes blocks where the mask matches itself
-     * @param minMatches the minimum number of matches (inclusive)
-     * @param maxMatches the maximum number of matches (inclusive)
-     */
-    public OffsetsMask2D(Mask2D mask, boolean excludeSelf, int minMatches, int maxMatches) {
-        this(mask, excludeSelf, minMatches, maxMatches, OFFSET_LIST);
-    }
-
-    /**
-     * Create a new instance.
-     *
-     * @param mask the mask to test against
-     * @param excludeSelf excludes blocks where the mask matches itself
-     * @param minMatches the minimum number of matches (inclusive)
-     * @param maxMatches the maximum number of matches (inclusive)
-     * @param offsets the block offsets to test with
-     */
-    public OffsetsMask2D(Mask2D mask, boolean excludeSelf, int minMatches, int maxMatches, List<BlockVector2> offsets) {
+    private OffsetsMask2D(Mask2D mask, boolean excludeSelf, int minMatches, int maxMatches, ImmutableList<BlockVector2> offsets) {
         checkNotNull(mask);
         checkNotNull(offsets);
         // Validate match args. No need to test maxMatches as it must be >=0 based on the conditions here.
@@ -113,7 +164,7 @@ public class OffsetsMask2D extends AbstractMask2D {
         this.excludeSelf = excludeSelf;
         this.minMatches = minMatches;
         this.maxMatches = maxMatches;
-        this.offsets = ImmutableList.copyOf(offsets);
+        this.offsets = offsets;
     }
 
     /**
@@ -123,15 +174,6 @@ public class OffsetsMask2D extends AbstractMask2D {
      */
     public Mask2D getMask() {
         return mask;
-    }
-
-    /**
-     * Get the offsets.
-     *
-     * @return the offsets
-     */
-    public List<BlockVector2> getOffsets() {
-        return this.offsets;
     }
 
     /**
@@ -159,6 +201,15 @@ public class OffsetsMask2D extends AbstractMask2D {
      */
     public int getMaxMatches() {
         return this.maxMatches;
+    }
+
+    /**
+     * Get the offsets.
+     *
+     * @return the offsets
+     */
+    public ImmutableList<BlockVector2> getOffsets() {
+        return this.offsets;
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/OffsetsMask2D.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/OffsetsMask2D.java
@@ -20,12 +20,10 @@
 package com.sk89q.worldedit.function.mask;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Direction;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -35,13 +33,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class OffsetsMask2D extends AbstractMask2D {
 
-    private static final ImmutableList<BlockVector2> OFFSET_LIST = ImmutableList.copyOf(
+    private static final ImmutableSet<BlockVector2> OFFSET_LIST =
         Direction.valuesOf(Direction.Flag.CARDINAL)
             .stream()
             .map(Direction::toBlockVector)
             .map(BlockVector3::toBlockVector2)
-            .collect(Collectors.toList())
-    );
+            .collect(ImmutableSet.toImmutableSet());
 
     /**
      * Create an offsets mask for a single offset.
@@ -71,7 +68,7 @@ public class OffsetsMask2D extends AbstractMask2D {
         private boolean excludeSelf;
         private int minMatches = 1;
         private int maxMatches = Integer.MAX_VALUE;
-        private ImmutableList<BlockVector2> offsets = OFFSET_LIST;
+        private ImmutableSet<BlockVector2> offsets = OFFSET_LIST;
 
         private Builder() {
         }
@@ -131,7 +128,7 @@ public class OffsetsMask2D extends AbstractMask2D {
          * @return this builder, for chaining
          */
         public Builder offsets(Iterable<BlockVector2> offsets) {
-            this.offsets = ImmutableList.copyOf(offsets);
+            this.offsets = ImmutableSet.copyOf(offsets);
             return this;
         }
 
@@ -149,9 +146,9 @@ public class OffsetsMask2D extends AbstractMask2D {
     private final boolean excludeSelf;
     private final int minMatches;
     private final int maxMatches;
-    private final ImmutableList<BlockVector2> offsets;
+    private final ImmutableSet<BlockVector2> offsets;
 
-    private OffsetsMask2D(Mask2D mask, boolean excludeSelf, int minMatches, int maxMatches, ImmutableList<BlockVector2> offsets) {
+    private OffsetsMask2D(Mask2D mask, boolean excludeSelf, int minMatches, int maxMatches, ImmutableSet<BlockVector2> offsets) {
         checkNotNull(mask);
         checkNotNull(offsets);
         // Validate match args. No need to test maxMatches as it must be >=0 based on the conditions here.
@@ -208,7 +205,7 @@ public class OffsetsMask2D extends AbstractMask2D {
      *
      * @return the offsets
      */
-    public ImmutableList<BlockVector2> getOffsets() {
+    public ImmutableSet<BlockVector2> getOffsets() {
         return this.offsets;
     }
 


### PR DESCRIPTION
Adds an AdjacentMask, a mask that checks whether any touching blocks match a given mask. Also includes an option to not allow itself to match the mask as well.

Due to the limitations of our mask parser, the full power of this mask isn't exposed yet. I have however, created a `#exposed` or `#surface` mask that matches all blocks that are exposed to air (excluding air itself). This is a somewhat common feature request/question we get in the Discord.