### PR TITLE
Allow stacking by block units with //stack

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -99,6 +99,7 @@ import com.sk89q.worldedit.regions.CylinderRegion;
 import com.sk89q.worldedit.regions.EllipsoidRegion;
 import com.sk89q.worldedit.regions.FlatRegion;
 import com.sk89q.worldedit.regions.Region;
+import com.sk89q.worldedit.regions.RegionOperationException;
 import com.sk89q.worldedit.regions.Regions;
 import com.sk89q.worldedit.regions.shape.ArbitraryBiomeShape;
 import com.sk89q.worldedit.regions.shape.ArbitraryShape;
@@ -1408,6 +1409,43 @@ public class EditSession implements Extent, AutoCloseable {
         ForwardExtentCopy copy = new ForwardExtentCopy(this, region, this, to);
         copy.setRepetitions(count);
         copy.setTransform(new AffineTransform().translate(offset.multiply(size)));
+        copy.setCopyingEntities(copyEntities);
+        copy.setCopyingBiomes(copyBiomes);
+        if (mask != null) {
+            copy.setSourceMask(mask);
+        }
+        Operations.completeLegacy(copy);
+        return copy.getAffected();
+    }
+
+    /**
+     * Stack a cuboid region.
+     *
+     * @param region the region to stack
+     * @param offset how far to move the contents each stack
+     * @param count the number of times to stack
+     * @param copyEntities true to copy entities
+     * @param copyBiomes true to copy biomes
+     * @param mask source mask for the operation (only matching blocks are copied)
+     * @param blockUnits true to stack by block units rather than clipboard size
+     * @return number of blocks affected
+     * @throws MaxChangedBlocksException thrown if too many blocks are changed
+     * @throws RegionOperationException thrown if the region operation is invalid
+     */
+    public int stackCuboidRegion(Region region, BlockVector3 offset, int count,
+                                 boolean copyEntities, boolean copyBiomes, Mask mask, boolean blockUnits) throws MaxChangedBlocksException, RegionOperationException {
+        checkNotNull(region);
+        checkNotNull(offset);
+        checkArgument(count >= 1, "count >= 1 required");
+
+        BlockVector3 size = region.getMaximumPoint().subtract(region.getMinimumPoint()).add(1, 1, 1);
+        if (blockUnits && offset.getX() < size.getX() && offset.getY() < size.getY() && offset.getZ() < size.getZ()) {
+            throw new RegionOperationException(TranslatableComponent.of("worldedit.stack.intersecting-region"));
+        }
+        BlockVector3 to = region.getMinimumPoint();
+        ForwardExtentCopy copy = new ForwardExtentCopy(this, region, this, to);
+        copy.setRepetitions(count);
+        copy.setTransform(new AffineTransform().translate(blockUnits ? offset : offset.multiply(size)));
         copy.setCopyingEntities(copyEntities);
         copy.setCopyingBiomes(copyBiomes);
         if (mask != null) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1400,22 +1400,12 @@ public class EditSession implements Extent, AutoCloseable {
      */
     public int stackCuboidRegion(Region region, BlockVector3 offset, int count,
                                  boolean copyEntities, boolean copyBiomes, Mask mask) throws MaxChangedBlocksException {
-        checkNotNull(region);
-        checkNotNull(offset);
-        checkArgument(count >= 1, "count >= 1 required");
-
-        BlockVector3 size = region.getMaximumPoint().subtract(region.getMinimumPoint()).add(1, 1, 1);
-        BlockVector3 to = region.getMinimumPoint();
-        ForwardExtentCopy copy = new ForwardExtentCopy(this, region, this, to);
-        copy.setRepetitions(count);
-        copy.setTransform(new AffineTransform().translate(offset.multiply(size)));
-        copy.setCopyingEntities(copyEntities);
-        copy.setCopyingBiomes(copyBiomes);
-        if (mask != null) {
-            copy.setSourceMask(mask);
+        try {
+            return stackCuboidRegion(region, offset, count, copyEntities, copyBiomes, mask, false);
+        } catch (RegionOperationException e) {
+            // This should never happen
+            return 0;
         }
-        Operations.completeLegacy(copy);
-        return copy.getAffected();
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1421,6 +1421,10 @@ public class EditSession implements Extent, AutoCloseable {
     /**
      * Stack a cuboid region using block units.
      *
+     * <p>
+     *     Use {@link Region#getBoundingBox()} to stack a non-cuboid region.
+     * </p>
+     *
      * @param region the region to stack
      * @param offset how far to move the contents each stack in block units
      * @param count the number of times to stack

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1406,9 +1406,9 @@ public class EditSession implements Extent, AutoCloseable {
         BlockVector3 size = region.getMaximumPoint().subtract(region.getMinimumPoint()).add(1, 1, 1);
         try {
             return stackRegionBlockUnits(region, offset.multiply(size), count, copyEntities, copyBiomes, mask);
-        } catch (RegionOperationException ignored) {
+        } catch (RegionOperationException e) {
             // Should never be able to happen
-            return 0;
+            throw new AssertionError(e);
         }
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1432,13 +1432,15 @@ public class EditSession implements Extent, AutoCloseable {
      * @throws RegionOperationException thrown if the region operation is invalid
      */
     public int stackCuboidRegionBlockUnits(CuboidRegion region, BlockVector3 offset, int count,
-                                 boolean copyEntities, boolean copyBiomes, Mask mask) throws MaxChangedBlocksException, RegionOperationException {
+                                           boolean copyEntities, boolean copyBiomes, Mask mask
+    ) throws MaxChangedBlocksException, RegionOperationException {
         checkNotNull(region);
         checkNotNull(offset);
         checkArgument(count >= 1, "count >= 1 required");
 
         BlockVector3 size = region.getMaximumPoint().subtract(region.getMinimumPoint()).add(1, 1, 1);
-        if (offset.getX() < size.getX() && offset.getY() < size.getY() && offset.getZ() < size.getZ()) {
+        BlockVector3 offsetAbs = offset.abs();
+        if (offsetAbs.getX() < size.getX() && offsetAbs.getY() < size.getY() && offsetAbs.getZ() < size.getZ()) {
             throw new RegionOperationException(TranslatableComponent.of("worldedit.stack.intersecting-region"));
         }
         BlockVector3 to = region.getMinimumPoint();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1402,20 +1402,14 @@ public class EditSession implements Extent, AutoCloseable {
                                  boolean copyEntities, boolean copyBiomes, Mask mask) throws MaxChangedBlocksException {
         checkNotNull(region);
         checkNotNull(offset);
-        checkArgument(count >= 1, "count >= 1 required");
 
         BlockVector3 size = region.getMaximumPoint().subtract(region.getMinimumPoint()).add(1, 1, 1);
-        BlockVector3 to = region.getMinimumPoint();
-        ForwardExtentCopy copy = new ForwardExtentCopy(this, region, this, to);
-        copy.setRepetitions(count);
-        copy.setTransform(new AffineTransform().translate(offset.multiply(size)));
-        copy.setCopyingEntities(copyEntities);
-        copy.setCopyingBiomes(copyBiomes);
-        if (mask != null) {
-            copy.setSourceMask(mask);
+        try {
+            return stackRegionBlockUnits(region, offset.multiply(size), count, copyEntities, copyBiomes, mask);
+        } catch (RegionOperationException ignored) {
+            // Should never be able to happen
+            return 0;
         }
-        Operations.completeLegacy(copy);
-        return copy.getAffected();
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1400,42 +1400,51 @@ public class EditSession implements Extent, AutoCloseable {
      */
     public int stackCuboidRegion(Region region, BlockVector3 offset, int count,
                                  boolean copyEntities, boolean copyBiomes, Mask mask) throws MaxChangedBlocksException {
-        try {
-            return stackCuboidRegion(region, offset, count, copyEntities, copyBiomes, mask, false);
-        } catch (RegionOperationException e) {
-            // This should never happen
-            return 0;
-        }
-    }
-
-    /**
-     * Stack a cuboid region.
-     *
-     * @param region the region to stack
-     * @param offset how far to move the contents each stack
-     * @param count the number of times to stack
-     * @param copyEntities true to copy entities
-     * @param copyBiomes true to copy biomes
-     * @param mask source mask for the operation (only matching blocks are copied)
-     * @param blockUnits true to stack by block units rather than clipboard size
-     * @return number of blocks affected
-     * @throws MaxChangedBlocksException thrown if too many blocks are changed
-     * @throws RegionOperationException thrown if the region operation is invalid
-     */
-    public int stackCuboidRegion(Region region, BlockVector3 offset, int count,
-                                 boolean copyEntities, boolean copyBiomes, Mask mask, boolean blockUnits) throws MaxChangedBlocksException, RegionOperationException {
         checkNotNull(region);
         checkNotNull(offset);
         checkArgument(count >= 1, "count >= 1 required");
 
         BlockVector3 size = region.getMaximumPoint().subtract(region.getMinimumPoint()).add(1, 1, 1);
-        if (blockUnits && offset.getX() < size.getX() && offset.getY() < size.getY() && offset.getZ() < size.getZ()) {
+        BlockVector3 to = region.getMinimumPoint();
+        ForwardExtentCopy copy = new ForwardExtentCopy(this, region, this, to);
+        copy.setRepetitions(count);
+        copy.setTransform(new AffineTransform().translate(offset.multiply(size)));
+        copy.setCopyingEntities(copyEntities);
+        copy.setCopyingBiomes(copyBiomes);
+        if (mask != null) {
+            copy.setSourceMask(mask);
+        }
+        Operations.completeLegacy(copy);
+        return copy.getAffected();
+    }
+
+    /**
+     * Stack a cuboid region using block units.
+     *
+     * @param region the region to stack
+     * @param offset how far to move the contents each stack in block units
+     * @param count the number of times to stack
+     * @param copyEntities true to copy entities
+     * @param copyBiomes true to copy biomes
+     * @param mask source mask for the operation (only matching blocks are copied)
+     * @return number of blocks affected
+     * @throws MaxChangedBlocksException thrown if too many blocks are changed
+     * @throws RegionOperationException thrown if the region operation is invalid
+     */
+    public int stackCuboidRegionBlockUnits(CuboidRegion region, BlockVector3 offset, int count,
+                                 boolean copyEntities, boolean copyBiomes, Mask mask) throws MaxChangedBlocksException, RegionOperationException {
+        checkNotNull(region);
+        checkNotNull(offset);
+        checkArgument(count >= 1, "count >= 1 required");
+
+        BlockVector3 size = region.getMaximumPoint().subtract(region.getMinimumPoint()).add(1, 1, 1);
+        if (offset.getX() < size.getX() && offset.getY() < size.getY() && offset.getZ() < size.getZ()) {
             throw new RegionOperationException(TranslatableComponent.of("worldedit.stack.intersecting-region"));
         }
         BlockVector3 to = region.getMinimumPoint();
         ForwardExtentCopy copy = new ForwardExtentCopy(this, region, this, to);
         copy.setRepetitions(count);
-        copy.setTransform(new AffineTransform().translate(blockUnits ? offset : offset.multiply(size)));
+        copy.setTransform(new AffineTransform().translate(offset));
         copy.setCopyingEntities(copyEntities);
         copy.setCopyingBiomes(copyBiomes);
         if (mask != null) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1421,7 +1421,9 @@ public class EditSession implements Extent, AutoCloseable {
     /**
      * Stack a cuboid region using block units.
      *
-     * <p>Use {@link Region#getBoundingBox()} to stack a non-cuboid region.</p>
+     * <p>
+     * Use {@link Region#getBoundingBox()} to stack a non-cuboid region.
+     * </p>
      *
      * @param region the region to stack
      * @param offset how far to move the contents each stack in block units

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1419,11 +1419,7 @@ public class EditSession implements Extent, AutoCloseable {
     }
 
     /**
-     * Stack a cuboid region using block units.
-     *
-     * <p>
-     * Use {@link Region#getBoundingBox()} to stack a non-cuboid region.
-     * </p>
+     * Stack a region using block units.
      *
      * @param region the region to stack
      * @param offset how far to move the contents each stack in block units
@@ -1435,8 +1431,8 @@ public class EditSession implements Extent, AutoCloseable {
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      * @throws RegionOperationException thrown if the region operation is invalid
      */
-    public int stackCuboidRegionBlockUnits(CuboidRegion region, BlockVector3 offset, int count,
-                                           boolean copyEntities, boolean copyBiomes, Mask mask) throws MaxChangedBlocksException, RegionOperationException {
+    public int stackRegionBlockUnits(Region region, BlockVector3 offset, int count,
+                                     boolean copyEntities, boolean copyBiomes, Mask mask) throws MaxChangedBlocksException, RegionOperationException {
         checkNotNull(region);
         checkNotNull(offset);
         checkArgument(count >= 1, "count >= 1 required");

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1434,8 +1434,7 @@ public class EditSession implements Extent, AutoCloseable {
      * @throws RegionOperationException thrown if the region operation is invalid
      */
     public int stackCuboidRegionBlockUnits(CuboidRegion region, BlockVector3 offset, int count,
-                                           boolean copyEntities, boolean copyBiomes, Mask mask
-    ) throws MaxChangedBlocksException, RegionOperationException {
+                                           boolean copyEntities, boolean copyBiomes, Mask mask) throws MaxChangedBlocksException, RegionOperationException {
         checkNotNull(region);
         checkNotNull(offset);
         checkArgument(count >= 1, "count >= 1 required");

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1421,9 +1421,7 @@ public class EditSession implements Extent, AutoCloseable {
     /**
      * Stack a cuboid region using block units.
      *
-     * <p>
-     *     Use {@link Region#getBoundingBox()} to stack a non-cuboid region.
-     * </p>
+     * <p>Use {@link Region#getBoundingBox()} to stack a non-cuboid region.</p>
      *
      * @param region the region to stack
      * @param offset how far to move the contents each stack in block units

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -338,7 +338,7 @@ public class RegionCommands {
                 session.getRegionSelector(world).learnChanges();
                 session.getRegionSelector(world).explainRegionAdjust(actor, session);
             } catch (RegionOperationException e) {
-                actor.printError(TextComponent.of(e.getMessage()));
+                actor.printError(e.getRichMessage());
             }
         }
 
@@ -367,6 +367,8 @@ public class RegionCommands {
                          boolean copyEntities,
                      @Switch(name = 'b', desc = "Also copy biomes")
                          boolean copyBiomes,
+                     @Switch(name = 'r', desc = "Use block units")
+                        boolean blockUnits,
                      @ArgFlag(name = 'm', desc = "Set the include mask, non-matching blocks become air")
                          Mask mask) throws WorldEditException {
 
@@ -381,7 +383,7 @@ public class RegionCommands {
             combinedMask = mask;
         }
 
-        int affected = editSession.stackCuboidRegion(region, offset, count, copyEntities, copyBiomes, combinedMask);
+        int affected = editSession.stackCuboidRegion(region, offset, count, copyEntities, copyBiomes, combinedMask, blockUnits);
 
         if (moveSelection) {
             try {
@@ -393,7 +395,7 @@ public class RegionCommands {
                 session.getRegionSelector(world).learnChanges();
                 session.getRegionSelector(world).explainRegionAdjust(actor, session);
             } catch (RegionOperationException e) {
-                actor.printError(TextComponent.of(e.getMessage()));
+                actor.printError(e.getRichMessage());
             }
         }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -393,7 +393,8 @@ public class RegionCommands {
             try {
                 final BlockVector3 size = region.getMaximumPoint().subtract(region.getMinimumPoint()).add(1, 1, 1);
 
-                final BlockVector3 shiftVector = offset.multiply(size).multiply(count);
+                final BlockVector3 shiftSize = blockUnits ? offset : offset.multiply(size);
+                final BlockVector3 shiftVector = shiftSize.multiply(count);
                 region.shift(shiftVector);
 
                 session.getRegionSelector(world).learnChanges();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -382,11 +382,11 @@ public class RegionCommands {
             combinedMask = mask;
         }
 
-        int affected = 0;
+        int affected;
         if (blockUnits) {
-            editSession.stackRegionBlockUnits(region, offset, count, copyEntities, copyBiomes, combinedMask);
+            affected = editSession.stackRegionBlockUnits(region, offset, count, copyEntities, copyBiomes, combinedMask);
         } else {
-            editSession.stackCuboidRegion(region, offset, count, copyEntities, copyBiomes, combinedMask);
+            affected = editSession.stackCuboidRegion(region, offset, count, copyEntities, copyBiomes, combinedMask);
         }
 
         if (moveSelection) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -371,8 +371,6 @@ public class RegionCommands {
                         boolean blockUnits,
                      @ArgFlag(name = 'm', desc = "Set the include mask, non-matching blocks become air")
                          Mask mask) throws WorldEditException {
-        checkCommandArgument(region instanceof CuboidRegion, TranslatableComponent.of("worldedit.stack.invalid-type"));
-
         Mask combinedMask;
         if (ignoreAirBlocks) {
             if (mask == null) {
@@ -386,7 +384,7 @@ public class RegionCommands {
 
         int affected = 0;
         if (blockUnits) {
-            editSession.stackCuboidRegionBlockUnits((CuboidRegion) region, offset, count, copyEntities, copyBiomes, combinedMask);
+            editSession.stackCuboidRegionBlockUnits(region.getBoundingBox(), offset, count, copyEntities, copyBiomes, combinedMask);
         } else {
             editSession.stackCuboidRegion(region, offset, count, copyEntities, copyBiomes, combinedMask);
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -371,6 +371,7 @@ public class RegionCommands {
                         boolean blockUnits,
                      @ArgFlag(name = 'm', desc = "Set the include mask, non-matching blocks become air")
                          Mask mask) throws WorldEditException {
+        checkCommandArgument(region instanceof CuboidRegion, TranslatableComponent.of("worldedit.stack.invalid-type"));
 
         Mask combinedMask;
         if (ignoreAirBlocks) {
@@ -383,7 +384,12 @@ public class RegionCommands {
             combinedMask = mask;
         }
 
-        int affected = editSession.stackCuboidRegion(region, offset, count, copyEntities, copyBiomes, combinedMask, blockUnits);
+        int affected = 0;
+        if (blockUnits) {
+            editSession.stackCuboidRegionBlockUnits((CuboidRegion) region, offset, count, copyEntities, copyBiomes, combinedMask);
+        } else {
+            editSession.stackCuboidRegion(region, offset, count, copyEntities, copyBiomes, combinedMask);
+        }
 
         if (moveSelection) {
             try {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -384,7 +384,7 @@ public class RegionCommands {
 
         int affected = 0;
         if (blockUnits) {
-            editSession.stackCuboidRegionBlockUnits(region.getBoundingBox(), offset, count, copyEntities, copyBiomes, combinedMask);
+            editSession.stackRegionBlockUnits(region, offset, count, copyEntities, copyBiomes, combinedMask);
         } else {
             editSession.stackCuboidRegion(region, offset, count, copyEntities, copyBiomes, combinedMask);
         }

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -191,6 +191,7 @@
     "worldedit.curve.invalid-type": "//curve only works with convex polyhedral selections",
     "worldedit.replace.replaced": "{0} blocks have been replaced.",
     "worldedit.stack.changed": "{0} blocks changed. Undo with //undo",
+    "worldedit.stack.intersecting-region": "Stack offset must not collide with the region when using block units",
     "worldedit.regen.regenerated": "Region regenerated.",
     "worldedit.regen.failed": "Unable to regenerate chunks. Check console for details.",
     "worldedit.walls.changed": "{0} blocks have been changed.",

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -192,6 +192,7 @@
     "worldedit.replace.replaced": "{0} blocks have been replaced.",
     "worldedit.stack.changed": "{0} blocks changed. Undo with //undo",
     "worldedit.stack.intersecting-region": "Stack offset must not collide with the region when using block units",
+    "worldedit.stack.invalid-type": "//stack only works with cuboid selections",
     "worldedit.regen.regenerated": "Region regenerated.",
     "worldedit.regen.failed": "Unable to regenerate chunks. Check console for details.",
     "worldedit.walls.changed": "{0} blocks have been changed.",

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -192,7 +192,6 @@
     "worldedit.replace.replaced": "{0} blocks have been replaced.",
     "worldedit.stack.changed": "{0} blocks changed. Undo with //undo",
     "worldedit.stack.intersecting-region": "Stack offset must not collide with the region when using block units",
-    "worldedit.stack.invalid-type": "//stack only works with cuboid selections",
     "worldedit.regen.regenerated": "Region regenerated.",
     "worldedit.regen.failed": "Unable to regenerate chunks. Check console for details.",
     "worldedit.walls.changed": "{0} blocks have been changed.",


### PR DESCRIPTION
Adds a method of using //stack with block units rather than selection units (`-r` flag). 

Closes #1443