### PR TITLE
Add a way to get a safe teleport location in the world object

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
@@ -108,39 +108,14 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
     public void findFreePosition(Location searchPos) {
         Extent world = searchPos.getExtent();
 
+        if (!(world instanceof World)) {
+            throw new IllegalArgumentException("Unable to teleport a player to a non world type.");
+        }
+
         int worldMinY = world.getMinimumPoint().getY();
         int worldMaxY = world.getMaximumPoint().getY();
-
-        int x = searchPos.getBlockX();
-        int y = Math.max(worldMinY, searchPos.getBlockY());
-        int origY = y;
-        int z = searchPos.getBlockZ();
-        int yPlusSearchHeight = y + WorldEdit.getInstance().getConfiguration().defaultVerticalHeight;
-        int maxY = Math.min(worldMaxY, yPlusSearchHeight) + 2;
-
-        byte free = 0;
-
-        while (y <= maxY) {
-            if (!world.getBlock(BlockVector3.at(x, y, z)).getBlockType().getMaterial().isMovementBlocker()) {
-                ++free;
-            } else {
-                free = 0;
-            }
-
-            if (free == 2) {
-                boolean worked = true;
-
-                if (y - 1 != origY) {
-                    worked = trySetPosition(Vector3.at(x + 0.5, y - 2 + 1, z + 0.5));
-                }
-
-                if (worked) {
-                    return;
-                }
-            }
-
-            ++y;
-        }
+        Vector3 tp =  ((World) world).getSafeTeleportLocation(searchPos.toVector().toBlockPoint(), worldMinY, worldMaxY);
+        trySetPosition(tp);
     }
 
     @Override


### PR DESCRIPTION
I want to use a method to get safe teleport locations with WorldEdit methods. Currently the only method to teleport a player to a safe place teleports the player directly to that place.

I need some better way for my WorldGuard PR: https://github.com/EngineHub/WorldGuard/pull/1621

Basically I moved the code from AbstractPlayerActor to World. I don't think that code is perfect now and I want to have some hints to find a safe teleport location. E.g. the current method teleports you into liquids like water and lava. That's not a safe teleport location. If that's intended I should rename the getSafeTeleportLocation to getFreeTeleportLocation.

Maybe we could add some boolean value to force safe teleport locations for that method.