### PR TITLE
Add splatter brush

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1740,15 +1740,15 @@ public class EditSession implements Extent, AutoCloseable {
      *
      * @param pos Center of the splatter
      * @param block The block pattern to use
-     * @param radius The cylinder's radius
+     * @param radius The sphere's radius
      * @param decay The higher the number the more decay, between 0 and 10
      * @return number of blocks changed
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */
     public int makeSplatter(BlockVector3 pos, Pattern block, double radius, int decay) throws MaxChangedBlocksException {
         //  decay is 0 - 10, 0 should be a circle.
-        checkArgument(decay >= 0, "decay >= 0");
-        checkArgument(decay <= 10, "decay <= 10");
+        checkArgument(decay >= 0, "decay must be >= 0");
+        checkArgument(decay <= 10, "decay must be <= 10");
         radius += 0.5;
 
         int affected = 0;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/BrushCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/BrushCommands.java
@@ -182,7 +182,10 @@ public class BrushCommands {
                                   int decay) throws WorldEditException {
         worldEdit.checkMaxBrushRadius(radius);
 
-        decay = Math.max(Math.min(decay, 10), 0);
+        if (decay < 0 || decay > 10) {
+            player.printError(TranslatableComponent.of("worldedit.brush.splatter.decay-out-of-range", TextComponent.of(decay)));
+            return;
+        }
 
         BrushTool tool = session.getBrushTool(player.getItemInHand(HandSide.MAIN_HAND).getType());
         tool.setFill(pattern);

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -22,6 +22,7 @@
     "worldedit.brush.sphere.equip": "Sphere brush shape equipped ({0}).",
     "worldedit.brush.cylinder.equip": "Cylinder brush shape equipped ({0} by {1}).",
     "worldedit.brush.splatter.equip": "Splatter brush shape equipped ({0} with {1} decay).",
+    "worldedit.brush.splatter.decay-out-of-range": "Splatter brush decay value: {0} is out of range 0 - 10.",
     "worldedit.brush.clipboard.equip": "Clipboard brush shape equipped.",
     "worldedit.brush.smooth.equip": "Smooth brush equipped ({0} x {1}x using {2}).",
     "worldedit.brush.extinguish.equip": "Extinguisher equipped ({0}).",


### PR DESCRIPTION
Fixes #1524

![image](https://user-images.githubusercontent.com/17665267/94988710-99590e00-05b2-11eb-9316-fbc3fb24ea17.png)
(going left-to-right, it's the different decay values of 0-10 for radius 5)

Tried a bunch of different approaches to achieve this and I felt this was pretty close to the original ticket - happy if others have a better approach