### PR TITLE
Move archive unpack into WE working dir

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlatform.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlatform.java
@@ -23,6 +23,7 @@ import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.util.concurrency.LazyReference;
 import com.sk89q.worldedit.util.io.ResourceLoader;
 import com.sk89q.worldedit.util.io.WorldEditResourceLoader;
+import com.sk89q.worldedit.util.io.file.ArchiveUnpacker;
 import com.sk89q.worldedit.util.translation.TranslationManager;
 import com.sk89q.worldedit.world.DataFixer;
 import com.sk89q.worldedit.world.World;
@@ -38,9 +39,16 @@ import java.util.List;
 public abstract class AbstractPlatform implements Platform {
 
     private final ResourceLoader resourceLoader = new WorldEditResourceLoader(WorldEdit.getInstance());
+    private final LazyReference<ArchiveUnpacker> archiveUnpacker = LazyReference.from(() -> {
+        try {
+            return new ArchiveUnpacker(getConfiguration().getWorkingDirectoryPath().resolve(".archive-unpack"));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    });
     private final LazyReference<TranslationManager> translationManager = LazyReference.from(() -> {
         try {
-            return new TranslationManager(getResourceLoader());
+            return new TranslationManager(archiveUnpacker.getValue(), getResourceLoader());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/translation/TranslationManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/translation/TranslationManager.java
@@ -96,17 +96,19 @@ public class TranslationManager {
     private final Lock loadLock = new ReentrantLock();
     private Locale defaultLocale = Locale.ENGLISH;
 
+    private final ArchiveUnpacker archiveUnpacker;
     private final ResourceLoader resourceLoader;
     private final Path userProvidedFlatRoot;
     private final Path internalZipRoot;
     @Nullable
     private Path userProvidedZipRoot;
 
-    public TranslationManager(ResourceLoader resourceLoader) throws IOException {
+    public TranslationManager(ArchiveUnpacker archiveUnpacker, ResourceLoader resourceLoader) throws IOException {
+        this.archiveUnpacker = archiveUnpacker;
         this.resourceLoader = resourceLoader;
         checkNotNull(resourceLoader);
         this.userProvidedFlatRoot = resourceLoader.getLocalResource("lang");
-        this.internalZipRoot = ArchiveUnpacker.unpackArchive(checkNotNull(
+        this.internalZipRoot = archiveUnpacker.unpackArchive(checkNotNull(
             resourceLoader.getRootResource("lang/i18n.zip"),
             "Missing internal i18n.zip!"
         ));
@@ -116,7 +118,7 @@ public class TranslationManager {
         Path userZip = resourceLoader.getLocalResource("lang/i18n.zip");
         Path result = null;
         if (Files.exists(userZip)) {
-            result = ArchiveUnpacker.unpackArchive(userZip.toUri().toURL());
+            result = archiveUnpacker.unpackArchive(userZip.toUri().toURL());
         }
         this.userProvidedZipRoot = result;
     }


### PR DESCRIPTION
Likely fixes an issue with temporary dir permissions if two users have the same `user.name` for some reason. I can't think of a normal setup where this occurs, but it _does_ happen, apparently:
```java
Caused by: java.nio.file.AccessDeniedException: /tmp/worldedit-unpack-dir-for-mcx_277353/1bd9bc7f
	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:84) ~[?:1.8.0_171]
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102) ~[?:1.8.0_171]
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107) ~[?:1.8.0_171]
	at sun.nio.fs.UnixFileSystemProvider.checkAccess(UnixFileSystemProvider.java:308) ~[?:1.8.0_171]
	at java.nio.file.Files.createDirectories(Files.java:746) ~[?:1.8.0_171]
	at com.sk89q.worldedit.util.io.file.ArchiveUnpacker.unpackArchive(ArchiveUnpacker.java:104) ~[?:?]
	at com.sk89q.worldedit.util.translation.TranslationManager.<init>(TranslationManager.java:109) ~[?:?]
```