### PR TITLE
Saner Translation Loading

### DIFF
--- a/buildSrc/src/main/kotlin/PlatformConfig.kt
+++ b/buildSrc/src/main/kotlin/PlatformConfig.kt
@@ -125,8 +125,6 @@ fun Project.applyShadowConfiguration() {
         exclude(".cache")
         exclude("LICENSE*")
         exclude("META-INF/maven/**")
-        // it's in the i18n zip, we only use it in dev
-        exclude("**/lang/strings.json")
         minimize()
     }
 }


### PR DESCRIPTION
This loads our internal strings.json, bundled from the repository, not from crowdin; for the default locale in all cases. This allows us to iterate locally and test new translations without needing to run an i18n.zip build.