### PR TITLE
Persist default state of selwand and navwand in session

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -681,17 +681,17 @@ public class LocalSession {
         }
         if (tool instanceof SelectionWand) {
             setSingleItemTool(id -> {
-                if (!Objects.equals(this.wandItem, id)) {
+                this.wandItem = id;
+                if (!Objects.equals(this.wandItem, config.wandItem)) {
                     wandItemDefault = false;
                 }
-                this.wandItem = id;
             }, this.wandItem, item);
         } else if (tool instanceof NavigationWand) {
             setSingleItemTool(id -> {
-                if (!Objects.equals(this.navWandItem, id)) {
+                this.navWandItem = id;
+                if (!Objects.equals(this.navWandItem, config.navigationWand)) {
                     navWandItemDefault = false;
                 }
-                this.navWandItem = id;
             }, this.navWandItem, item);
         } else if (tool == null) {
             // Check if un-setting sel/nav
@@ -1127,6 +1127,7 @@ public class LocalSession {
     public boolean isWandItemDefault() {
         if (wandItemDefault == null) {
             wandItemDefault = Objects.equals(wandItem, config.wandItem);
+            setDirty();
         }
         return wandItemDefault;
     }
@@ -1147,6 +1148,7 @@ public class LocalSession {
     public boolean isNavWandItemDefault() {
         if (navWandItemDefault == null) {
             navWandItemDefault = Objects.equals(navWandItem, config.navigationWand);
+            setDirty();
         }
         return navWandItemDefault;
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -65,6 +65,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -116,7 +117,9 @@ public class LocalSession {
     private RegionSelectorType defaultSelector;
     private boolean useServerCUI = false; // Save this to not annoy players.
     private String wandItem;
+    private Boolean wandItemDefault;
     private String navWandItem;
+    private Boolean navWandItemDefault;
 
     /**
      * Construct the object.
@@ -677,9 +680,19 @@ public class LocalSession {
             throw new InvalidToolBindException(item, TranslatableComponent.of("worldedit.tool.error.item-only"));
         }
         if (tool instanceof SelectionWand) {
-            setSingleItemTool(id -> this.wandItem = id, this.wandItem, item);
+            setSingleItemTool(id -> {
+                if (!Objects.equals(this.wandItem, id)) {
+                    wandItemDefault = false;
+                }
+                this.wandItem = id;
+            }, this.wandItem, item);
         } else if (tool instanceof NavigationWand) {
-            setSingleItemTool(id -> this.navWandItem = id, this.navWandItem, item);
+            setSingleItemTool(id -> {
+                if (!Objects.equals(this.navWandItem, id)) {
+                    navWandItemDefault = false;
+                }
+                this.navWandItem = id;
+            }, this.navWandItem, item);
         } else if (tool == null) {
             // Check if un-setting sel/nav
             String id = item.getId();
@@ -1107,11 +1120,35 @@ public class LocalSession {
     }
 
     /**
+     * Get if the selection wand item should use the default, or null if unknown.
+     *
+     * @return if it should use the default
+     */
+    public boolean isWandItemDefault() {
+        if (wandItemDefault == null) {
+            wandItemDefault = Objects.equals(wandItem, config.wandItem);
+        }
+        return wandItemDefault;
+    }
+
+    /**
      * Get the preferred navigation wand item for this user, or {@code null} to use the default.
      * @return item id of nav wand item, or {@code null}
      */
     public String getNavWandItem() {
         return navWandItem;
+    }
+
+    /**
+     * Get if the navigation wand item should use the default, or null if unknown.
+     *
+     * @return if it should use the default
+     */
+    public boolean isNavWandItemDefault() {
+        if (navWandItemDefault == null) {
+            navWandItemDefault = Objects.equals(navWandItem, config.navigationWand);
+        }
+        return navWandItemDefault;
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -682,16 +682,12 @@ public class LocalSession {
         if (tool instanceof SelectionWand) {
             setSingleItemTool(id -> {
                 this.wandItem = id;
-                if (!Objects.equals(this.wandItem, config.wandItem)) {
-                    wandItemDefault = false;
-                }
+                this.wandItemDefault = id.equals(config.wandItem);
             }, this.wandItem, item);
         } else if (tool instanceof NavigationWand) {
             setSingleItemTool(id -> {
                 this.navWandItem = id;
-                if (!Objects.equals(this.navWandItem, config.navigationWand)) {
-                    navWandItemDefault = false;
-                }
+                this.navWandItemDefault = id.equals(config.navigationWand);
             }, this.navWandItem, item);
         } else if (tool == null) {
             // Check if un-setting sel/nav

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
@@ -208,7 +208,6 @@ public class SessionManager {
                     }
                 }
             }
-            session.compareAndResetDirty();
         }
 
         if (shouldBoundLimit(owner, "worldedit.limit.unrestricted", session.getBlockChangeLimit(), config.maxChangeLimit)) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
@@ -189,6 +189,26 @@ public class SessionManager {
             // Remember the session regardless of if it's currently active or not.
             // And have the SessionTracker FLUSH inactive sessions.
             sessions.put(getKey(owner), new SessionHolder(sessionKey, session));
+        } else {
+            if (session.isWandItemDefault()) {
+                try {
+                    setDefaultWand(session.getWandItem(), config.wandItem, session, new SelectionWand());
+                } catch (InvalidToolBindException e) {
+                    if (warnedInvalidTool.add("selwand")) {
+                        log.warn("Invalid selection wand tool set in config. Tool will not be assigned: " + e.getItemType());
+                    }
+                }
+            }
+            if (session.isNavWandItemDefault()) {
+                try {
+                    setDefaultWand(session.getNavWandItem(), config.navigationWand, session, new NavigationWand());
+                } catch (InvalidToolBindException e) {
+                    if (warnedInvalidTool.add("navwand")) {
+                        log.warn("Invalid navigation wand tool set in config. Tool will not be assigned: " + e.getItemType());
+                    }
+                }
+            }
+            session.compareAndResetDirty();
         }
 
         if (shouldBoundLimit(owner, "worldedit.limit.unrestricted", session.getBlockChangeLimit(), config.maxChangeLimit)) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
@@ -171,14 +171,22 @@ public class SessionManager {
             session.setBlockChangeLimit(config.defaultChangeLimit);
             session.setTimeout(config.calculationTimeout);
             try {
-                setDefaultWand(session.getWandItem(), config.wandItem, session, new SelectionWand());
+                if (session.isWandItemDefault()) {
+                    setDefaultWand(config.wandItem, config.wandItem, session, new SelectionWand());
+                } else {
+                    setDefaultWand(session.getWandItem(), config.wandItem, session, new SelectionWand());
+                }
             } catch (InvalidToolBindException e) {
                 if (warnedInvalidTool.add("selwand")) {
                     log.warn("Invalid selection wand tool set in config. Tool will not be assigned: " + e.getItemType());
                 }
             }
             try {
-                setDefaultWand(session.getNavWandItem(), config.navigationWand, session, new NavigationWand());
+                if (session.isNavWandItemDefault()) {
+                    setDefaultWand(config.navigationWand, config.navigationWand, session, new NavigationWand());
+                } else {
+                    setDefaultWand(session.getNavWandItem(), config.navigationWand, session, new NavigationWand());
+                }
             } catch (InvalidToolBindException e) {
                 if (warnedInvalidTool.add("navwand")) {
                     log.warn("Invalid navigation wand tool set in config. Tool will not be assigned: " + e.getItemType());
@@ -189,31 +197,6 @@ public class SessionManager {
             // Remember the session regardless of if it's currently active or not.
             // And have the SessionTracker FLUSH inactive sessions.
             sessions.put(getKey(owner), new SessionHolder(sessionKey, session));
-        } else {
-            if (session.isWandItemDefault()) {
-                try {
-                    ItemType item = ItemTypes.get(config.wandItem);
-                    if (item != null) {
-                        session.setTool(item, new SelectionWand());
-                    }
-                } catch (InvalidToolBindException e) {
-                    if (warnedInvalidTool.add("selwand")) {
-                        log.warn("Invalid selection wand tool set in config. Tool will not be assigned: " + e.getItemType());
-                    }
-                }
-            }
-            if (session.isNavWandItemDefault()) {
-                try {
-                    ItemType item = ItemTypes.get(config.navigationWand);
-                    if (item != null) {
-                        session.setTool(item, new NavigationWand());
-                    }
-                } catch (InvalidToolBindException e) {
-                    if (warnedInvalidTool.add("navwand")) {
-                        log.warn("Invalid navigation wand tool set in config. Tool will not be assigned: " + e.getItemType());
-                    }
-                }
-            }
         }
 
         if (shouldBoundLimit(owner, "worldedit.limit.unrestricted", session.getBlockChangeLimit(), config.maxChangeLimit)) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
@@ -192,7 +192,10 @@ public class SessionManager {
         } else {
             if (session.isWandItemDefault()) {
                 try {
-                    setDefaultWand(config.wandItem, config.wandItem, session, new SelectionWand());
+                    ItemType item = ItemTypes.get(config.wandItem);
+                    if (item != null) {
+                        session.setTool(item, new SelectionWand());
+                    }
                 } catch (InvalidToolBindException e) {
                     if (warnedInvalidTool.add("selwand")) {
                         log.warn("Invalid selection wand tool set in config. Tool will not be assigned: " + e.getItemType());
@@ -201,7 +204,10 @@ public class SessionManager {
             }
             if (session.isNavWandItemDefault()) {
                 try {
-                    setDefaultWand(config.navigationWand, config.navigationWand, session, new NavigationWand());
+                    ItemType item = ItemTypes.get(config.navigationWand);
+                    if (item != null) {
+                        session.setTool(item, new NavigationWand());
+                    }
                 } catch (InvalidToolBindException e) {
                     if (warnedInvalidTool.add("navwand")) {
                         log.warn("Invalid navigation wand tool set in config. Tool will not be assigned: " + e.getItemType());

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
@@ -171,22 +171,16 @@ public class SessionManager {
             session.setBlockChangeLimit(config.defaultChangeLimit);
             session.setTimeout(config.calculationTimeout);
             try {
-                if (session.isWandItemDefault()) {
-                    setDefaultWand(config.wandItem, config.wandItem, session, new SelectionWand());
-                } else {
-                    setDefaultWand(session.getWandItem(), config.wandItem, session, new SelectionWand());
-                }
+                String sessionItem = session.isWandItemDefault() ? null : session.getWandItem();
+                setDefaultWand(sessionItem, config.wandItem, session, new SelectionWand());
             } catch (InvalidToolBindException e) {
                 if (warnedInvalidTool.add("selwand")) {
                     log.warn("Invalid selection wand tool set in config. Tool will not be assigned: " + e.getItemType());
                 }
             }
             try {
-                if (session.isNavWandItemDefault()) {
-                    setDefaultWand(config.navigationWand, config.navigationWand, session, new NavigationWand());
-                } else {
-                    setDefaultWand(session.getNavWandItem(), config.navigationWand, session, new NavigationWand());
-                }
+                String sessionItem = session.isNavWandItemDefault() ? null : session.getNavWandItem();
+                setDefaultWand(sessionItem, config.navigationWand, session, new NavigationWand());
             } catch (InvalidToolBindException e) {
                 if (warnedInvalidTool.add("navwand")) {
                     log.warn("Invalid navigation wand tool set in config. Tool will not be assigned: " + e.getItemType());

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
@@ -192,7 +192,7 @@ public class SessionManager {
         } else {
             if (session.isWandItemDefault()) {
                 try {
-                    setDefaultWand(session.getWandItem(), config.wandItem, session, new SelectionWand());
+                    setDefaultWand(config.wandItem, config.wandItem, session, new SelectionWand());
                 } catch (InvalidToolBindException e) {
                     if (warnedInvalidTool.add("selwand")) {
                         log.warn("Invalid selection wand tool set in config. Tool will not be assigned: " + e.getItemType());
@@ -201,7 +201,7 @@ public class SessionManager {
             }
             if (session.isNavWandItemDefault()) {
                 try {
-                    setDefaultWand(session.getNavWandItem(), config.navigationWand, session, new NavigationWand());
+                    setDefaultWand(config.navigationWand, config.navigationWand, session, new NavigationWand());
                 } catch (InvalidToolBindException e) {
                     if (warnedInvalidTool.add("navwand")) {
                         log.warn("Invalid navigation wand tool set in config. Tool will not be assigned: " + e.getItemType());


### PR DESCRIPTION
Stores a nullable boolean for both selwand and navwand, and magically migrates this over.

Fixes #1587