### PR TITLE
Properly repeat extents for negative coordinates

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/RepeatingExtentPattern.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/RepeatingExtentPattern.java
@@ -88,9 +88,9 @@ public class RepeatingExtentPattern extends AbstractExtentPattern {
     @Override
     public BaseBlock applyBlock(BlockVector3 position) {
         BlockVector3 base = position.add(offset);
-        int x = Math.abs(base.getBlockX()) % size.getBlockX();
-        int y = Math.abs(base.getBlockY()) % size.getBlockY();
-        int z = Math.abs(base.getBlockZ()) % size.getBlockZ();
+        int x = Math.floorMod(base.getBlockX(), size.getBlockX());
+        int y = Math.floorMod(base.getBlockY(), size.getBlockY());
+        int z = Math.floorMod(base.getBlockZ(), size.getBlockZ());
         return getExtent().getFullBlock(BlockVector3.at(x, y, z).add(origin));
     }
 


### PR DESCRIPTION
An extent's content was returned mirrored/flipped when applied for negative positions, as e.g. `Math.abs(-2) % 3` returns 2 instead of 1 (as 1 + -1 * 3 = -2).

This PR fixes it by using [Math.floorMod()](https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#floorMod-int-int-) which provides the properties of the mathematical congruence relation for positive divisors.