### PR TITLE
Fix SideEffectSet.none() being the default set

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/SideEffectSet.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/SideEffectSet.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit.util;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
 import java.util.Arrays;
@@ -29,7 +30,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class SideEffectSet {
-    private static final SideEffectSet DEFAULT = new SideEffectSet(Maps.newEnumMap(SideEffect.class));
+    private static final SideEffectSet DEFAULT = new SideEffectSet(ImmutableMap.of());
     private static final SideEffectSet NONE = new SideEffectSet(
         Arrays.stream(SideEffect.values()).collect(Collectors.toMap(Function.identity(), state -> SideEffect.State.OFF))
     );

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/SideEffectSet.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/SideEffectSet.java
@@ -30,10 +30,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class SideEffectSet {
-    private static final SideEffectSet DEFAULT = new SideEffectSet(
-            Arrays.stream(SideEffect.values()).collect(Collectors.toMap(Function.identity(), SideEffect::getDefaultValue))
+    private static final SideEffectSet DEFAULT = new SideEffectSet();
+    private static final SideEffectSet NONE = new SideEffectSet(
+        Arrays.stream(SideEffect.values()).collect(Collectors.toMap(Function.identity(), state -> SideEffect.State.OFF))
     );
-    private static final SideEffectSet NONE = new SideEffectSet();
 
     private final Map<SideEffect, SideEffect.State> sideEffects;
     private final Set<SideEffect> appliedSideEffects;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/SideEffectSet.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/SideEffectSet.java
@@ -19,7 +19,6 @@
 
 package com.sk89q.worldedit.util;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
 import java.util.Arrays;
@@ -30,7 +29,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class SideEffectSet {
-    private static final SideEffectSet DEFAULT = new SideEffectSet();
+    private static final SideEffectSet DEFAULT = new SideEffectSet(Maps.newEnumMap(SideEffect.class));
     private static final SideEffectSet NONE = new SideEffectSet(
         Arrays.stream(SideEffect.values()).collect(Collectors.toMap(Function.identity(), state -> SideEffect.State.OFF))
     );
@@ -38,10 +37,6 @@ public class SideEffectSet {
     private final Map<SideEffect, SideEffect.State> sideEffects;
     private final Set<SideEffect> appliedSideEffects;
     private final boolean appliesAny;
-
-    private SideEffectSet() {
-        this(ImmutableMap.of());
-    }
 
     public SideEffectSet(Map<SideEffect, SideEffect.State> sideEffects) {
         this.sideEffects = Maps.immutableEnumMap(sideEffects);


### PR DESCRIPTION
The NONE SideEffectSet was just passing in the empty constructor, which assumes default state.

I've fixed this, and made the DEFAULT SideEffectSet do what NONE was doing.