### PR TITLE
Add a command to apply side effects

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
@@ -286,9 +286,7 @@ public class GeneralCommands {
 
     @Command(
         name = "/update",
-        desc = "Apply a side effect",
-        descFooter = "Note that this command is GOING to change in the future."
-            + " Do not depend on the exact format of this command yet."
+        desc = "Apply a side effect"
     )
     @CommandPermissions("worldedit.update")
     void update(Actor actor, LocalSession session, World injectedWorld,

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
@@ -32,13 +32,11 @@ import com.sk89q.worldedit.command.util.WorldEditAsyncCommandBuilder;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extension.platform.Capability;
-import com.sk89q.worldedit.function.RegionFunction;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.operation.Operations;
 import com.sk89q.worldedit.function.visitor.RegionVisitor;
 import com.sk89q.worldedit.internal.command.CommandRegistrationHandler;
 import com.sk89q.worldedit.internal.command.CommandUtil;
-import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.SideEffect;
 import com.sk89q.worldedit.util.SideEffectSet;
 import com.sk89q.worldedit.util.auth.AuthorizationException;
@@ -293,11 +291,9 @@ public class GeneralCommands {
             + " Do not depend on the exact format of this command yet."
     )
     @CommandPermissions("worldedit.perf")
-    void perfApply(Actor actor, LocalSession session,
-                   World injectedWorld,
-              @Arg(desc = "The side effect", def = "")
-                  SideEffect sideEffect
-              ) throws WorldEditException {
+    void perfApply(Actor actor, LocalSession session, World injectedWorld,
+                   @Arg(desc = "The side effect", def = "")
+                       SideEffect sideEffect) throws WorldEditException {
         SideEffectSet sideEffectSet = sideEffect == null ? SideEffectSet.defaults() : SideEffectSet.none().with(sideEffect, SideEffect.State.ON);
 
         RegionVisitor visitor = new RegionVisitor(session.getSelection(injectedWorld), position -> {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
@@ -295,7 +295,9 @@ public class GeneralCommands {
     void update(Actor actor, LocalSession session, World injectedWorld,
                    @Arg(desc = "The side effect", def = "")
                        SideEffect sideEffect) throws WorldEditException {
-        SideEffectSet sideEffectSet = sideEffect == null ? SideEffectSet.defaults() : SideEffectSet.none().with(sideEffect, SideEffect.State.ON);
+        SideEffectSet sideEffectSet = sideEffect == null
+            ? session.getSideEffectSet()
+            : SideEffectSet.none().with(sideEffect, SideEffect.State.ON);
 
         RegionFunction apply = new ApplySideEffect(injectedWorld, sideEffectSet);
         if (session.getMask() != null) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
@@ -295,6 +295,10 @@ public class GeneralCommands {
     void update(Actor actor, LocalSession session, World injectedWorld,
                @Arg(desc = "The side effects", def = "")
                    SideEffectSet sideEffectSet) throws WorldEditException {
+        if (!sideEffectSet.doesApplyAny()) {
+            // Use defaults if none supplied.
+            sideEffectSet = SideEffectSet.defaults();
+        }
         RegionFunction apply = new ApplySideEffect(injectedWorld, sideEffectSet);
         if (session.getMask() != null) {
             apply = new RegionMaskingFilter(session.getMask(), apply);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
@@ -289,7 +289,7 @@ public class GeneralCommands {
 
     @Command(
         name = "/update",
-        desc = "Apply a side effect"
+        desc = "Apply side effects to your selection"
     )
     @CommandPermissions("worldedit.update")
     void update(Actor actor, LocalSession session, World injectedWorld,

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
@@ -32,6 +32,9 @@ import com.sk89q.worldedit.command.util.WorldEditAsyncCommandBuilder;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extension.platform.Capability;
+import com.sk89q.worldedit.function.RegionFunction;
+import com.sk89q.worldedit.function.RegionMaskingFilter;
+import com.sk89q.worldedit.function.block.ApplySideEffect;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.operation.Operations;
 import com.sk89q.worldedit.function.visitor.RegionVisitor;
@@ -294,10 +297,12 @@ public class GeneralCommands {
                        SideEffect sideEffect) throws WorldEditException {
         SideEffectSet sideEffectSet = sideEffect == null ? SideEffectSet.defaults() : SideEffectSet.none().with(sideEffect, SideEffect.State.ON);
 
-        RegionVisitor visitor = new RegionVisitor(session.getSelection(injectedWorld), position -> {
-            injectedWorld.applySideEffects(position, injectedWorld.getBlock(position), sideEffectSet);
-            return true;
-        });
+        RegionFunction apply = new ApplySideEffect(injectedWorld, sideEffectSet);
+        if (session.getMask() != null) {
+            apply = new RegionMaskingFilter(session.getMask(), apply);
+        }
+
+        RegionVisitor visitor = new RegionVisitor(session.getSelection(injectedWorld), apply);
         Operations.complete(visitor);
 
         if (sideEffect != null) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
@@ -32,9 +32,13 @@ import com.sk89q.worldedit.command.util.WorldEditAsyncCommandBuilder;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extension.platform.Capability;
+import com.sk89q.worldedit.function.RegionFunction;
 import com.sk89q.worldedit.function.mask.Mask;
+import com.sk89q.worldedit.function.operation.Operations;
+import com.sk89q.worldedit.function.visitor.RegionVisitor;
 import com.sk89q.worldedit.internal.command.CommandRegistrationHandler;
 import com.sk89q.worldedit.internal.command.CommandUtil;
+import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.SideEffect;
 import com.sk89q.worldedit.util.SideEffectSet;
 import com.sk89q.worldedit.util.auth.AuthorizationException;
@@ -76,7 +80,7 @@ public class GeneralCommands {
                                 CommandManager commandManager,
                                 CommandManagerService commandManagerService,
                                 WorldEdit worldEdit) {
-        // Collect the tool commands
+        // Collect the commands
         CommandManager collect = commandManagerService.newCommandManager();
 
         registration.register(
@@ -280,6 +284,27 @@ public class GeneralCommands {
             SideEffectBox sideEffectBox = new SideEffectBox(session.getSideEffectSet());
             actor.print(sideEffectBox.create(1));
         }
+    }
+
+    @Command(
+        name = "/perf-apply",
+        desc = "Apply a side effect",
+        descFooter = "Note that this command is GOING to change in the future."
+            + " Do not depend on the exact format of this command yet."
+    )
+    @CommandPermissions("worldedit.perf")
+    void perfApply(Actor actor, LocalSession session,
+                   World injectedWorld,
+              @Arg(desc = "The side effect", def = "")
+                  SideEffect sideEffect
+              ) throws WorldEditException {
+        SideEffectSet sideEffectSet = sideEffect == null ? SideEffectSet.defaults() : SideEffectSet.none().with(sideEffect, SideEffect.State.ON);
+
+        RegionVisitor visitor = new RegionVisitor(session.getSelection(injectedWorld), position -> {
+            injectedWorld.applySideEffects(position, injectedWorld.getBlock(position), sideEffectSet);
+            return true;
+        });
+        Operations.complete(visitor);
     }
 
     @Command(

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
@@ -285,13 +285,13 @@ public class GeneralCommands {
     }
 
     @Command(
-        name = "/perf-apply",
+        name = "/update",
         desc = "Apply a side effect",
         descFooter = "Note that this command is GOING to change in the future."
             + " Do not depend on the exact format of this command yet."
     )
-    @CommandPermissions("worldedit.perf")
-    void perfApply(Actor actor, LocalSession session, World injectedWorld,
+    @CommandPermissions("worldedit.update")
+    void update(Actor actor, LocalSession session, World injectedWorld,
                    @Arg(desc = "The side effect", def = "")
                        SideEffect sideEffect) throws WorldEditException {
         SideEffectSet sideEffectSet = sideEffect == null ? SideEffectSet.defaults() : SideEffectSet.none().with(sideEffect, SideEffect.State.ON);
@@ -301,6 +301,12 @@ public class GeneralCommands {
             return true;
         });
         Operations.complete(visitor);
+
+        if (sideEffect != null) {
+            actor.printInfo(TranslatableComponent.of("worldedit.update.single", TranslatableComponent.of(sideEffect.getDisplayName())));
+        } else {
+            actor.printInfo(TranslatableComponent.of("worldedit.update"));
+        }
     }
 
     @Command(

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
@@ -293,12 +293,8 @@ public class GeneralCommands {
     )
     @CommandPermissions("worldedit.update")
     void update(Actor actor, LocalSession session, World injectedWorld,
-                   @Arg(desc = "The side effect", def = "")
-                       SideEffect sideEffect) throws WorldEditException {
-        SideEffectSet sideEffectSet = sideEffect == null
-            ? session.getSideEffectSet()
-            : SideEffectSet.none().with(sideEffect, SideEffect.State.ON);
-
+               @Arg(desc = "The side effects", def = "")
+                   SideEffectSet sideEffectSet) throws WorldEditException {
         RegionFunction apply = new ApplySideEffect(injectedWorld, sideEffectSet);
         if (session.getMask() != null) {
             apply = new RegionMaskingFilter(session.getMask(), apply);
@@ -307,11 +303,7 @@ public class GeneralCommands {
         RegionVisitor visitor = new RegionVisitor(session.getSelection(injectedWorld), apply);
         Operations.complete(visitor);
 
-        if (sideEffect != null) {
-            actor.printInfo(TranslatableComponent.of("worldedit.update.single", TranslatableComponent.of(sideEffect.getDisplayName())));
-        } else {
-            actor.printInfo(TranslatableComponent.of("worldedit.update"));
-        }
+        actor.printInfo(TranslatableComponent.of("worldedit.update"));
     }
 
     @Command(

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
@@ -295,7 +295,7 @@ public class GeneralCommands {
     void update(Actor actor, LocalSession session, World injectedWorld,
                @Arg(desc = "The side effects", def = "")
                    SideEffectSet sideEffectSet) throws WorldEditException {
-        if (!sideEffectSet.doesApplyAny()) {
+        if (sideEffectSet == null) {
             // Use defaults if none supplied.
             sideEffectSet = SideEffectSet.defaults();
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
@@ -293,8 +293,8 @@ public class GeneralCommands {
     )
     @CommandPermissions("worldedit.update")
     void update(Actor actor, LocalSession session, World injectedWorld,
-               @Arg(desc = "The side effects", def = "")
-                   SideEffectSet sideEffectSet) throws WorldEditException {
+                @Arg(desc = "The side effects", def = "")
+                    SideEffectSet sideEffectSet) throws WorldEditException {
         if (sideEffectSet == null) {
             // Use defaults if none supplied.
             sideEffectSet = SideEffectSet.defaults();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/CommaSeparatedValuesConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/CommaSeparatedValuesConverter.java
@@ -87,7 +87,7 @@ public class CommaSeparatedValuesConverter<T> implements ArgumentConverter<T> {
         String lastInput = Iterables.getLast(COMMA.split(input), "");
         assert lastInput != null;
         List<String> suggestions = delegate.getSuggestions(lastInput, context);
-        if (input.length() > lastInput.length()) {
+        if (input.contains(",")) {
             String prefix = input.substring(0, input.length() - lastInput.length());
             Set<String> entries = ImmutableSet.copyOf(COMMA.split(input));
             suggestions = suggestions

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/SideEffectSetConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/SideEffectSetConverter.java
@@ -1,0 +1,80 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.command.argument;
+
+import com.sk89q.worldedit.util.SideEffect;
+import com.sk89q.worldedit.util.SideEffectSet;
+import com.sk89q.worldedit.util.formatting.text.Component;
+import com.sk89q.worldedit.util.formatting.text.TextComponent;
+import org.enginehub.piston.CommandManager;
+import org.enginehub.piston.converter.ArgumentConverter;
+import org.enginehub.piston.converter.ConversionResult;
+import org.enginehub.piston.converter.FailedConversion;
+import org.enginehub.piston.converter.SuccessfulConversion;
+import org.enginehub.piston.inject.InjectedValueAccess;
+import org.enginehub.piston.inject.Key;
+
+import java.util.List;
+
+public class SideEffectSetConverter implements ArgumentConverter<SideEffectSet> {
+
+    public static void register(CommandManager commandManager) {
+        commandManager.getConverter(Key.of(SideEffect.class)).ifPresent(sideEffectConverter ->
+            commandManager.registerConverter(
+                Key.of(SideEffectSet.class),
+                new SideEffectSetConverter(CommaSeparatedValuesConverter.wrapNoRepeats(sideEffectConverter))
+            ));
+    }
+
+    private final TextComponent choices = TextComponent.of("any side effects");
+    private final CommaSeparatedValuesConverter<SideEffect> sideEffectConverter;
+
+    private SideEffectSetConverter(CommaSeparatedValuesConverter<SideEffect> sideEffectConverter) {
+        this.sideEffectConverter = sideEffectConverter;
+    }
+
+    @Override
+    public Component describeAcceptableArguments() {
+        return choices;
+    }
+
+    @Override
+    public List<String> getSuggestions(String input, InjectedValueAccess context) {
+        return sideEffectConverter.getSuggestions(input, context);
+    }
+
+    @Override
+    public ConversionResult<SideEffectSet> convert(String argument, InjectedValueAccess context) {
+        try {
+            ConversionResult<SideEffect> result = sideEffectConverter.convert(argument, context);
+            if (result.isSuccessful()) {
+                SideEffectSet set = SideEffectSet.none();
+                for (SideEffect sideEffect : result.get()) {
+                    set = set.with(sideEffect, SideEffect.State.ON);
+                }
+                return SuccessfulConversion.fromSingle(set);
+            } else {
+                return result.failureAsAny();
+            }
+        } catch (Exception e) {
+            return FailedConversion.from(e);
+        }
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/SideEffectSetConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/SideEffectSetConverter.java
@@ -32,15 +32,17 @@ import org.enginehub.piston.inject.InjectedValueAccess;
 import org.enginehub.piston.inject.Key;
 
 import java.util.List;
+import java.util.Optional;
 
 public class SideEffectSetConverter implements ArgumentConverter<SideEffectSet> {
 
     public static void register(CommandManager commandManager) {
-        commandManager.getConverter(Key.of(SideEffect.class)).ifPresent(sideEffectConverter ->
-            commandManager.registerConverter(
-                Key.of(SideEffectSet.class),
-                new SideEffectSetConverter(CommaSeparatedValuesConverter.wrapNoRepeats(sideEffectConverter))
-            ));
+        Optional<ArgumentConverter<SideEffect>> sideEffectConverter = commandManager.getConverter(Key.of(SideEffect.class));
+        commandManager.registerConverter(
+            Key.of(SideEffectSet.class),
+            new SideEffectSetConverter(CommaSeparatedValuesConverter.wrapNoRepeats(sideEffectConverter
+                .orElseThrow(() -> new IllegalStateException("SideEffectSetConverter must be registered after SideEffectConverter"))))
+        );
     }
 
     private final TextComponent choices = TextComponent.of("any side effects");

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/SideEffectSetConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/SideEffectSetConverter.java
@@ -32,16 +32,15 @@ import org.enginehub.piston.inject.InjectedValueAccess;
 import org.enginehub.piston.inject.Key;
 
 import java.util.List;
-import java.util.Optional;
 
 public class SideEffectSetConverter implements ArgumentConverter<SideEffectSet> {
 
     public static void register(CommandManager commandManager) {
-        Optional<ArgumentConverter<SideEffect>> sideEffectConverter = commandManager.getConverter(Key.of(SideEffect.class));
+        ArgumentConverter<SideEffect> sideEffectConverter = commandManager.getConverter(Key.of(SideEffect.class)).orElseThrow(()
+            -> new IllegalStateException("SideEffectSetConverter must be registered after SideEffectConverter"));
         commandManager.registerConverter(
             Key.of(SideEffectSet.class),
-            new SideEffectSetConverter(CommaSeparatedValuesConverter.wrapNoRepeats(sideEffectConverter
-                .orElseThrow(() -> new IllegalStateException("SideEffectSetConverter must be registered after SideEffectConverter"))))
+            new SideEffectSetConverter(CommaSeparatedValuesConverter.wrapNoRepeats(sideEffectConverter))
         );
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/SideEffectSetConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/SideEffectSetConverter.java
@@ -36,8 +36,8 @@ import java.util.List;
 public class SideEffectSetConverter implements ArgumentConverter<SideEffectSet> {
 
     public static void register(CommandManager commandManager) {
-        ArgumentConverter<SideEffect> sideEffectConverter = commandManager.getConverter(Key.of(SideEffect.class)).orElseThrow(()
-            -> new IllegalStateException("SideEffectSetConverter must be registered after SideEffectConverter"));
+        ArgumentConverter<SideEffect> sideEffectConverter = commandManager.getConverter(Key.of(SideEffect.class))
+            .orElseThrow(() -> new IllegalStateException("SideEffectSetConverter must be registered after SideEffectConverter"));
         commandManager.registerConverter(
             Key.of(SideEffectSet.class),
             new SideEffectSetConverter(CommaSeparatedValuesConverter.wrapNoRepeats(sideEffectConverter))

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
@@ -81,6 +81,7 @@ import com.sk89q.worldedit.command.argument.OffsetConverter;
 import com.sk89q.worldedit.command.argument.RegionFactoryConverter;
 import com.sk89q.worldedit.command.argument.RegistryConverter;
 import com.sk89q.worldedit.command.argument.SideEffectConverter;
+import com.sk89q.worldedit.command.argument.SideEffectSetConverter;
 import com.sk89q.worldedit.command.argument.VectorConverter;
 import com.sk89q.worldedit.command.argument.WorldConverter;
 import com.sk89q.worldedit.command.argument.ZonedDateTimeConverter;
@@ -221,6 +222,7 @@ public final class PlatformCommandManager {
         RegionFactoryConverter.register(commandManager);
         WorldConverter.register(commandManager);
         SideEffectConverter.register(commandManager);
+        SideEffectSetConverter.register(commandManager);
         HeightConverter.register(commandManager);
         OffsetConverter.register(worldEdit, commandManager);
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/block/ApplySideEffect.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/block/ApplySideEffect.java
@@ -1,0 +1,50 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.function.block;
+
+import com.sk89q.worldedit.WorldEditException;
+import com.sk89q.worldedit.function.RegionFunction;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.util.SideEffectSet;
+import com.sk89q.worldedit.world.World;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Applies the given side effect within a region.
+ */
+public class ApplySideEffect implements RegionFunction {
+
+    private final World world;
+    private final SideEffectSet sideEffectSet;
+
+    public ApplySideEffect(World world, SideEffectSet sideEffectSet) {
+        checkNotNull(world);
+        checkNotNull(sideEffectSet);
+        this.world = world;
+        this.sideEffectSet = sideEffectSet;
+    }
+
+    @Override
+    public boolean apply(BlockVector3 position) throws WorldEditException {
+        world.applySideEffects(position, world.getBlock(position), sideEffectSet);
+        return true;
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/SideEffect.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/SideEffect.java
@@ -29,6 +29,7 @@ public enum SideEffect {
     ENTITY_AI(State.OFF),
     EVENTS(State.OFF);
 
+    // TODO Make these components in WE8
     private final String displayName;
     private final String description;
     private final State defaultValue;
@@ -56,6 +57,7 @@ public enum SideEffect {
         ON,
         DELAYED;
 
+        // TODO Make this a component in WE8
         private final String displayName;
 
         State() {

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -53,7 +53,6 @@
     "worldedit.perf.sideeffect.already-set": "Side effect \"{0}\" is already {1}",
     "worldedit.perf.sideeffect.set-all": "All side effects set to {0}",
     "worldedit.update": "Applied side effects to the selection.",
-    "worldedit.update.single": "Applied side effect \"{0}\" to the selection.",
     "worldedit.reorder.current": "The reorder mode is {0}",
     "worldedit.reorder.set": "The reorder mode is now {0}",
     "worldedit.gmask.disabled": "Global mask disabled.",

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -52,6 +52,8 @@
     "worldedit.perf.sideeffect.get": "Side effect \"{0}\" is set to {1}",
     "worldedit.perf.sideeffect.already-set": "Side effect \"{0}\" is already {1}",
     "worldedit.perf.sideeffect.set-all": "All side effects set to {0}",
+    "worldedit.update": "Applied side effects to the selection.",
+    "worldedit.update.single": "Applied side effect \"{0}\" to the selection.",
     "worldedit.reorder.current": "The reorder mode is {0}",
     "worldedit.reorder.set": "The reorder mode is now {0}",
     "worldedit.gmask.disabled": "Global mask disabled.",


### PR DESCRIPTION
Adds a command to apply a side effect to the given region, or when no side effect is provided, the currently selected ones.

This fits a few use-cases:

* Allows re-calculating lighting (a fix lighting command)
* Allows telling fences, etc, to attempt to re-connect
* Allows triggering block updates (make sand fall, etc)

https://user-images.githubusercontent.com/546754/102883299-87915380-449b-11eb-8e11-4dbd439d2308.mp4

