### PR TITLE
Correct ellipsoid region selector initialization

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/EllipsoidRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/EllipsoidRegionSelector.java
@@ -79,6 +79,7 @@ public class EllipsoidRegionSelector implements RegionSelector, CUIRegion {
             final EllipsoidRegionSelector ellipsoidRegionSelector = (EllipsoidRegionSelector) oldSelector;
 
             region = new EllipsoidRegion(ellipsoidRegionSelector.getIncompleteRegion());
+            started = ellipsoidRegionSelector.started;
         } else {
             Region oldRegion;
             try {
@@ -93,6 +94,7 @@ public class EllipsoidRegionSelector implements RegionSelector, CUIRegion {
             BlockVector3 center = pos1.add(pos2).divide(2).floor();
             region.setCenter(center);
             region.setRadius(pos2.subtract(center).toVector3());
+            started = true;
         }
     }
 


### PR DESCRIPTION
When the previous selection was a non-ellipsoidal region, the
started flag would not be appropriately set until a new selection
had been started.

## Reproduction

1. Make a cuboid selection (or any other type really)
2. Change to an ellipsoid with `/sel ellipsoid`
3. Try to modify the selection with a right-click.

Without this fix, step 3 will fail, requiring starting a whole new selection to make modifications.