### PR TITLE
Alter the CUI lifecycle to be more consistent and reliable

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
@@ -50,6 +50,7 @@ import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.UUID;
 import javax.annotation.Nullable;
@@ -186,7 +187,7 @@ public class BukkitPlayer extends AbstractPlayerActor {
         if (params.length > 0) {
             send = send + "|" + StringUtil.joinString(params, "|");
         }
-        player.sendPluginMessage(plugin, WorldEditPlugin.CUI_PLUGIN_CHANNEL, send.getBytes(CUIChannelListener.UTF_8_CHARSET));
+        player.sendPluginMessage(plugin, WorldEditPlugin.CUI_PLUGIN_CHANNEL, send.getBytes(StandardCharsets.UTF_8));
     }
 
     public Player getPlayer() {
@@ -246,18 +247,18 @@ public class BukkitPlayer extends AbstractPlayerActor {
 
     @Override
     public SessionKey getSessionKey() {
-        return new SessionKeyImpl(this.player.getUniqueId(), player.getName());
+        return new SessionKeyImpl(this.player);
     }
 
-    private static class SessionKeyImpl implements SessionKey {
+    static class SessionKeyImpl implements SessionKey {
         // If not static, this will leak a reference
 
         private final UUID uuid;
         private final String name;
 
-        private SessionKeyImpl(UUID uuid, String name) {
-            this.uuid = uuid;
-            this.name = name;
+        SessionKeyImpl(Player player) {
+            this.uuid = player.getUniqueId();
+            this.name = player.getName();
         }
 
         @Override

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/CUIChannelListener.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/CUIChannelListener.java
@@ -24,13 +24,13 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.messaging.PluginMessageListener;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Handles incoming WorldEditCui init message.
  */
 public class CUIChannelListener implements PluginMessageListener {
 
-    public static final Charset UTF_8_CHARSET = Charset.forName("UTF-8");
     private final WorldEditPlugin plugin;
 
     public CUIChannelListener(WorldEditPlugin plugin) {
@@ -40,10 +40,9 @@ public class CUIChannelListener implements PluginMessageListener {
     @Override
     public void onPluginMessageReceived(String channel, Player player, byte[] message) {
         LocalSession session = plugin.getSession(player);
-        String text = new String(message, UTF_8_CHARSET);
+        String text = new String(message, StandardCharsets.UTF_8);
         final BukkitPlayer actor = plugin.wrapPlayer(player);
         session.handleCUIInitializationMessage(text, actor);
-        session.describeCUI(actor);
     }
 
 }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditListener.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditListener.java
@@ -23,6 +23,7 @@ package com.sk89q.worldedit.bukkit;
 
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.entity.Player;
+import com.sk89q.worldedit.event.platform.SessionIdleEvent;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.Location;
@@ -36,6 +37,7 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerCommandSendEvent;
 import org.bukkit.event.player.PlayerGameModeChangeEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.enginehub.piston.CommandManager;
 import org.enginehub.piston.inject.InjectedValueStore;
@@ -143,5 +145,10 @@ public class WorldEditListener implements Listener {
                 event.setCancelled(true);
             }
         }
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        plugin.getWorldEdit().getEventBus().post(new SessionIdleEvent(new BukkitPlayer.SessionKeyImpl(event.getPlayer())));
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -78,12 +78,17 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class LocalSession {
 
+    private static final transient int CUI_VERSION_UNINITIALIZED = -1;
     public static transient int MAX_HISTORY_SIZE = 15;
 
     // Non-session related fields
     private transient LocalConfiguration config;
     private final transient AtomicBoolean dirty = new AtomicBoolean();
     private transient int failedCuiAttempts = 0;
+
+    // Single-connection lifetime fields
+    private transient boolean hasCUISupport = false;
+    private transient int cuiVersion = CUI_VERSION_UNINITIALIZED;
 
     // Session related
     private transient RegionSelector selector = new CuboidRegionSelector();
@@ -99,8 +104,6 @@ public class LocalSession {
     private transient boolean useInventory;
     private transient com.sk89q.worldedit.world.snapshot.Snapshot snapshot;
     private transient Snapshot snapshotExperimental;
-    private transient boolean hasCUISupport = false;
-    private transient int cuiVersion = -1;
     private transient SideEffectSet sideEffectSet = SideEffectSet.defaults();
     private transient Mask mask;
     private transient ZoneId timezone = ZoneId.systemDefault();
@@ -907,7 +910,12 @@ public class LocalSession {
      */
     public void handleCUIInitializationMessage(String text, Actor actor) {
         checkNotNull(text);
-        if (this.hasCUISupport || this.failedCuiAttempts > 3) {
+        if (this.hasCUISupport) {
+            // WECUI is a bit aggressive about re-initializing itself
+            // the last attempt to touch handshakes didn't go well, so this will do... for now
+            dispatchCUISelection(actor);
+            return;
+        } else if (this.failedCuiAttempts > 3) {
             return;
         }
 
@@ -1163,5 +1171,16 @@ public class LocalSession {
      */
     public void setLastDistribution(List<Countable<BlockState>> dist) {
         lastDistribution = dist;
+    }
+
+    /**
+     * Call when this session has become inactive.
+     *
+     * <p>This is for internal use only.</p>
+     */
+    public void didBecomeIdle() {
+        this.cuiVersion = CUI_VERSION_UNINITIALIZED;
+        this.hasCUISupport = false;
+        this.failedCuiAttempts = 0;
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -84,9 +84,9 @@ public class LocalSession {
     // Non-session related fields
     private transient LocalConfiguration config;
     private final transient AtomicBoolean dirty = new AtomicBoolean();
-    private transient int failedCuiAttempts = 0;
 
     // Single-connection lifetime fields
+    private transient int failedCuiAttempts = 0;
     private transient boolean hasCUISupport = false;
     private transient int cuiVersion = CUI_VERSION_UNINITIALIZED;
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -973,6 +973,10 @@ public class LocalSession {
      * @param cuiVersion the CUI version
      */
     public void setCUIVersion(int cuiVersion) {
+        if (cuiVersion < 0) {
+            throw new IllegalArgumentException("CUI protocol version must be non-negative, but '" + cuiVersion + "' was received.");
+        }
+
         this.cuiVersion = cuiVersion;
     }
 
@@ -1178,7 +1182,7 @@ public class LocalSession {
      *
      * <p>This is for internal use only.</p>
      */
-    public void didBecomeIdle() {
+    public void onIdle() {
         this.cuiVersion = CUI_VERSION_UNINITIALIZED;
         this.hasCUISupport = false;
         this.failedCuiAttempts = 0;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/event/platform/SessionIdleEvent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/event/platform/SessionIdleEvent.java
@@ -23,9 +23,9 @@ import com.sk89q.worldedit.event.Event;
 import com.sk89q.worldedit.session.SessionKey;
 
 /**
- * An event called when a session becomes idle.
+ * An event fired when a session becomes idle.
  *
- * <p>This can happen when a player leaves the server.
+ * <p>This can happen when a player leaves the server.</p>
  */
 public final class SessionIdleEvent extends Event {
     private final SessionKey key;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/event/platform/SessionIdleEvent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/event/platform/SessionIdleEvent.java
@@ -1,0 +1,45 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.event.platform;
+
+import com.sk89q.worldedit.event.Event;
+import com.sk89q.worldedit.session.SessionKey;
+
+/**
+ * An event called when a session becomes idle.
+ *
+ * <p>This can happen when a player leaves the server.
+ */
+public final class SessionIdleEvent extends Event {
+    private final SessionKey key;
+
+    public SessionIdleEvent(SessionKey key) {
+        this.key = key;
+    }
+
+    /**
+     * Get a key identifying the session that has become idle.
+     *
+     * @return the key for the session
+     */
+    public SessionKey getKey() {
+        return this.key;
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
@@ -138,8 +138,8 @@ public class SessionManager {
         checkNotNull(owner);
         SessionHolder stored = sessions.get(getKey(owner));
         if (stored != null) {
-            if (stored.hasBecomeIdle && stored.key.isActive()) {
-                stored.hasBecomeIdle = false;
+            if (stored.sessionIdle && stored.key.isActive()) {
+                stored.sessionIdle = false;
             }
             return stored.session;
         } else {
@@ -363,12 +363,12 @@ public class SessionManager {
     @Subscribe
     public void onSessionIdle(final SessionIdleEvent event) {
         SessionHolder holder = this.sessions.get(getKey(event.getKey()));
-        if (holder != null && !holder.hasBecomeIdle) {
-            holder.hasBecomeIdle = true;
+        if (holder != null && !holder.sessionIdle) {
+            holder.sessionIdle = true;
             LocalSession session = holder.session;
 
             // Perform any session cleanup for data that should not be persisted.
-            session.didBecomeIdle();
+            session.onIdle();
         }
     }
 
@@ -379,7 +379,7 @@ public class SessionManager {
         private final SessionKey key;
         private final LocalSession session;
         private long lastActive = System.currentTimeMillis();
-        private boolean hasBecomeIdle = false;
+        private boolean sessionIdle = false;
 
         private SessionHolder(SessionKey key, LocalSession session) {
             this.key = key;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
@@ -32,6 +32,7 @@ import com.sk89q.worldedit.command.tool.SelectionWand;
 import com.sk89q.worldedit.command.tool.Tool;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.event.platform.ConfigurationLoadEvent;
+import com.sk89q.worldedit.event.platform.SessionIdleEvent;
 import com.sk89q.worldedit.extension.platform.Locatable;
 import com.sk89q.worldedit.session.request.Request;
 import com.sk89q.worldedit.session.storage.JsonFileSessionStore;
@@ -137,6 +138,9 @@ public class SessionManager {
         checkNotNull(owner);
         SessionHolder stored = sessions.get(getKey(owner));
         if (stored != null) {
+            if (stored.hasBecomeIdle && stored.key.isActive()) {
+                stored.hasBecomeIdle = false;
+            }
             return stored.session;
         } else {
             return null;
@@ -356,6 +360,18 @@ public class SessionManager {
         store = new JsonFileSessionStore(dir);
     }
 
+    @Subscribe
+    public void onSessionIdle(final SessionIdleEvent event) {
+        SessionHolder holder = this.sessions.get(getKey(event.getKey()));
+        if (holder != null && !holder.hasBecomeIdle) {
+            holder.hasBecomeIdle = true;
+            LocalSession session = holder.session;
+
+            // Perform any session cleanup for data that should not be persisted.
+            session.didBecomeIdle();
+        }
+    }
+
     /**
      * Stores the owner of a session, the session, and the last active time.
      */
@@ -363,6 +379,7 @@ public class SessionManager {
         private final SessionKey key;
         private final LocalSession session;
         private long lastActive = System.currentTimeMillis();
+        private boolean hasBecomeIdle = false;
 
         private SessionHolder(SessionKey key, LocalSession session) {
             this.key = key;

--- a/worldedit-fabric/build.gradle.kts
+++ b/worldedit-fabric/build.gradle.kts
@@ -27,7 +27,7 @@ configure<LoomGradleExtension> {
 
 val minecraftVersion = "1.16.3"
 val yarnMappings = "1.16.3+build.1:v2"
-val loaderVersion = "0.9.3+build.207"
+val loaderVersion = "0.10.8"
 
 configurations.all {
     resolutionStrategy {
@@ -53,7 +53,7 @@ dependencies {
     "modImplementation"("net.fabricmc:fabric-loader:$loaderVersion")
 
     // [1] declare fabric-api dependency...
-    "fabricApi"("net.fabricmc.fabric-api:fabric-api:0.20.2+build.402-1.16")
+    "fabricApi"("net.fabricmc.fabric-api:fabric-api:0.29.3+1.16")
 
     // [2] Load the API dependencies from the fabric mod json...
     @Suppress("UNCHECKED_CAST")

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricPlayer.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricPlayer.java
@@ -27,7 +27,6 @@ import com.sk89q.worldedit.extension.platform.AbstractPlayerActor;
 import com.sk89q.worldedit.extent.inventory.BlockBag;
 import com.sk89q.worldedit.fabric.internal.ExtendedPlayerEntity;
 import com.sk89q.worldedit.fabric.internal.NBTConverter;
-import com.sk89q.worldedit.fabric.net.handler.WECUIPacketHandler;
 import com.sk89q.worldedit.internal.cui.CUIEvent;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
@@ -59,6 +58,7 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.UUID;
 import javax.annotation.Nullable;
@@ -128,7 +128,7 @@ public class FabricPlayer extends AbstractPlayerActor {
         if (params.length > 0) {
             send = send + "|" + StringUtil.joinString(params, "|");
         }
-        PacketByteBuf buffer = new PacketByteBuf(Unpooled.copiedBuffer(send.getBytes(WECUIPacketHandler.UTF_8_CHARSET)));
+        PacketByteBuf buffer = new PacketByteBuf(Unpooled.wrappedBuffer(send.getBytes(StandardCharsets.UTF_8)));
         CustomPayloadS2CPacket packet = new CustomPayloadS2CPacket(new Identifier(FabricWorldEdit.MOD_ID, FabricWorldEdit.CUI_PLUGIN_CHANNEL), buffer);
         this.player.networkHandler.sendPacket(packet);
     }
@@ -254,18 +254,18 @@ public class FabricPlayer extends AbstractPlayerActor {
 
     @Override
     public SessionKey getSessionKey() {
-        return new SessionKeyImpl(player.getUuid(), player.getName().getString());
+        return new SessionKeyImpl(player);
     }
 
-    private static class SessionKeyImpl implements SessionKey {
+    static class SessionKeyImpl implements SessionKey {
         // If not static, this will leak a reference
 
         private final UUID uuid;
         private final String name;
 
-        private SessionKeyImpl(UUID uuid, String name) {
-            this.uuid = uuid;
-            this.name = name;
+        SessionKeyImpl(ServerPlayerEntity player) {
+            this.uuid = player.getUuid();
+            this.name = player.getName().getString();
         }
 
         @Override

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricPlayer.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricPlayer.java
@@ -128,7 +128,7 @@ public class FabricPlayer extends AbstractPlayerActor {
         if (params.length > 0) {
             send = send + "|" + StringUtil.joinString(params, "|");
         }
-        PacketByteBuf buffer = new PacketByteBuf(Unpooled.wrappedBuffer(send.getBytes(StandardCharsets.UTF_8)));
+        PacketByteBuf buffer = new PacketByteBuf(Unpooled.copiedBuffer(send, StandardCharsets.UTF_8));
         CustomPayloadS2CPacket packet = new CustomPayloadS2CPacket(new Identifier(FabricWorldEdit.MOD_ID, FabricWorldEdit.CUI_PLUGIN_CHANNEL), buffer);
         this.player.networkHandler.sendPacket(packet);
     }

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricPlayer.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricPlayer.java
@@ -27,6 +27,7 @@ import com.sk89q.worldedit.extension.platform.AbstractPlayerActor;
 import com.sk89q.worldedit.extent.inventory.BlockBag;
 import com.sk89q.worldedit.fabric.internal.ExtendedPlayerEntity;
 import com.sk89q.worldedit.fabric.internal.NBTConverter;
+import com.sk89q.worldedit.fabric.net.handler.WECUIPacketHandler;
 import com.sk89q.worldedit.internal.cui.CUIEvent;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
@@ -42,12 +43,12 @@ import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockTypes;
 import io.netty.buffer.Unpooled;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.packet.s2c.play.BlockEntityUpdateS2CPacket;
 import net.minecraft.network.packet.s2c.play.BlockUpdateS2CPacket;
-import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.MutableText;
@@ -128,9 +129,11 @@ public class FabricPlayer extends AbstractPlayerActor {
         if (params.length > 0) {
             send = send + "|" + StringUtil.joinString(params, "|");
         }
-        PacketByteBuf buffer = new PacketByteBuf(Unpooled.copiedBuffer(send, StandardCharsets.UTF_8));
-        CustomPayloadS2CPacket packet = new CustomPayloadS2CPacket(new Identifier(FabricWorldEdit.MOD_ID, FabricWorldEdit.CUI_PLUGIN_CHANNEL), buffer);
-        this.player.networkHandler.sendPacket(packet);
+        ServerPlayNetworking.send(
+                this.player,
+                WECUIPacketHandler.CUI_IDENTIFIER,
+                new PacketByteBuf(Unpooled.copiedBuffer(send, StandardCharsets.UTF_8))
+        );
     }
 
     @Override

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorldEdit.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorldEdit.java
@@ -43,12 +43,14 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
 import net.fabricmc.fabric.api.event.player.UseBlockCallback;
 import net.fabricmc.fabric.api.event.player.UseItemCallback;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.tag.BlockTags;
 import net.minecraft.tag.ItemTags;
@@ -119,6 +121,7 @@ public class FabricWorldEdit implements ModInitializer {
         ServerLifecycleEvents.SERVER_STARTING.register(this::onStartingServer);
         ServerLifecycleEvents.SERVER_STARTED.register(this::onStartServer);
         ServerLifecycleEvents.SERVER_STOPPING.register(this::onStopServer);
+        ServerPlayConnectionEvents.DISCONNECT.register(this::onPlayerDisconnect);
         AttackBlockCallback.EVENT.register(this::onLeftClickBlock);
         UseBlockCallback.EVENT.register(this::onRightClickBlock);
         UseItemCallback.EVENT.register(this::onRightClickAir);
@@ -304,10 +307,9 @@ public class FabricWorldEdit implements ModInitializer {
 
     // TODO Pass empty left click to server
 
-    // TODO: Use the fabric-networking-api-v1 event when updating
-    public void onPlayerDisconnect(ServerPlayerEntity player) {
+    private void onPlayerDisconnect(ServerPlayNetworkHandler handler, MinecraftServer server) {
         WorldEdit.getInstance().getEventBus()
-                .post(new SessionIdleEvent(new FabricPlayer.SessionKeyImpl(player)));
+                .post(new SessionIdleEvent(new FabricPlayer.SessionKeyImpl(handler.player)));
     }
 
     /**

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorldEdit.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorldEdit.java
@@ -23,6 +23,7 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.event.platform.PlatformReadyEvent;
+import com.sk89q.worldedit.event.platform.SessionIdleEvent;
 import com.sk89q.worldedit.extension.platform.Capability;
 import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.extension.platform.PlatformManager;
@@ -302,6 +303,12 @@ public class FabricWorldEdit implements ModInitializer {
     }
 
     // TODO Pass empty left click to server
+
+    // TODO: Use the fabric-networking-api-v1 event when updating
+    public void onPlayerDisconnect(ServerPlayerEntity player) {
+        WorldEdit.getInstance().getEventBus()
+                .post(new SessionIdleEvent(new FabricPlayer.SessionKeyImpl(player)));
+    }
 
     /**
      * Get the configuration.

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/mixin/MixinServerPlayerEntity.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/mixin/MixinServerPlayerEntity.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit.fabric.mixin;
 
+import com.sk89q.worldedit.fabric.FabricWorldEdit;
 import com.sk89q.worldedit.fabric.internal.ExtendedPlayerEntity;
 import net.minecraft.network.packet.c2s.play.ClientSettingsC2SPacket;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -36,6 +37,11 @@ public abstract class MixinServerPlayerEntity implements ExtendedPlayerEntity {
     public void setClientSettings(ClientSettingsC2SPacket clientSettingsC2SPacket,
                                   CallbackInfo callbackInfo) {
         this.language = ((AccessorClientSettingsC2SPacket) clientSettingsC2SPacket).getLanguage();
+    }
+
+    @Inject(method = "onDisconnect", at = @At(value = "HEAD"))
+    public void callDisconnect(final CallbackInfo ci) {
+        FabricWorldEdit.inst.onPlayerDisconnect((ServerPlayerEntity) (Object) this);
     }
 
     @Override

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/mixin/MixinServerPlayerEntity.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/mixin/MixinServerPlayerEntity.java
@@ -19,7 +19,6 @@
 
 package com.sk89q.worldedit.fabric.mixin;
 
-import com.sk89q.worldedit.fabric.FabricWorldEdit;
 import com.sk89q.worldedit.fabric.internal.ExtendedPlayerEntity;
 import net.minecraft.network.packet.c2s.play.ClientSettingsC2SPacket;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -37,11 +36,6 @@ public abstract class MixinServerPlayerEntity implements ExtendedPlayerEntity {
     public void setClientSettings(ClientSettingsC2SPacket clientSettingsC2SPacket,
                                   CallbackInfo callbackInfo) {
         this.language = ((AccessorClientSettingsC2SPacket) clientSettingsC2SPacket).getLanguage();
-    }
-
-    @Inject(method = "onDisconnect", at = @At(value = "HEAD"))
-    public void callDisconnect(final CallbackInfo ci) {
-        FabricWorldEdit.inst.onPlayerDisconnect((ServerPlayerEntity) (Object) this);
     }
 
     @Override

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/net/handler/WECUIPacketHandler.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/net/handler/WECUIPacketHandler.java
@@ -34,22 +34,15 @@ public final class WECUIPacketHandler {
     private WECUIPacketHandler() {
     }
 
-    public static final Charset UTF_8_CHARSET = StandardCharsets.UTF_8;
     private static final Identifier CUI_IDENTIFIER = new Identifier(FabricWorldEdit.MOD_ID, FabricWorldEdit.CUI_PLUGIN_CHANNEL);
 
     public static void init() {
         ServerSidePacketRegistry.INSTANCE.register(CUI_IDENTIFIER, (packetContext, packetByteBuf) -> {
             ServerPlayerEntity player = (ServerPlayerEntity) packetContext.getPlayer();
             LocalSession session = FabricWorldEdit.inst.getSession(player);
-
-            if (session.hasCUISupport()) {
-                return;
-            }
-
-            String text = packetByteBuf.toString(UTF_8_CHARSET);
+            String text = packetByteBuf.toString(StandardCharsets.UTF_8);
             final FabricPlayer actor = FabricAdapter.adaptPlayer(player);
             session.handleCUIInitializationMessage(text, actor);
-            session.describeCUI(actor);
         });
     }
 }

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/net/handler/WECUIPacketHandler.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/net/handler/WECUIPacketHandler.java
@@ -23,25 +23,22 @@ import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.fabric.FabricAdapter;
 import com.sk89q.worldedit.fabric.FabricPlayer;
 import com.sk89q.worldedit.fabric.FabricWorldEdit;
-import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
-import net.minecraft.server.network.ServerPlayerEntity;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.util.Identifier;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 public final class WECUIPacketHandler {
     private WECUIPacketHandler() {
     }
 
-    private static final Identifier CUI_IDENTIFIER = new Identifier(FabricWorldEdit.MOD_ID, FabricWorldEdit.CUI_PLUGIN_CHANNEL);
+    public static final Identifier CUI_IDENTIFIER = new Identifier(FabricWorldEdit.MOD_ID, FabricWorldEdit.CUI_PLUGIN_CHANNEL);
 
     public static void init() {
-        ServerSidePacketRegistry.INSTANCE.register(CUI_IDENTIFIER, (packetContext, packetByteBuf) -> {
-            ServerPlayerEntity player = (ServerPlayerEntity) packetContext.getPlayer();
+        ServerPlayNetworking.registerGlobalReceiver(CUI_IDENTIFIER, (server, player, handler, buf, responder) -> {
             LocalSession session = FabricWorldEdit.inst.getSession(player);
-            String text = packetByteBuf.toString(StandardCharsets.UTF_8);
-            final FabricPlayer actor = FabricAdapter.adaptPlayer(player);
+            String text = buf.toString(StandardCharsets.UTF_8);
+            FabricPlayer actor = FabricAdapter.adaptPlayer(player);
             session.handleCUIInitializationMessage(text, actor);
         });
     }

--- a/worldedit-fabric/src/main/resources/fabric.mod.json
+++ b/worldedit-fabric/src/main/resources/fabric.mod.json
@@ -33,7 +33,7 @@
         "fabric-command-api-v1": "*",
         "fabric-lifecycle-events-v1": "*",
         "fabric-events-interaction-v0": "*",
-        "fabric-networking-v0": "*"
+        "fabric-networking-api-v1": "*"
     },
     "suggests": {
         "fabric-permissions-api-v0": "*"

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePlayer.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePlayer.java
@@ -26,7 +26,6 @@ import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.extension.platform.AbstractPlayerActor;
 import com.sk89q.worldedit.extent.inventory.BlockBag;
 import com.sk89q.worldedit.forge.internal.NBTConverter;
-import com.sk89q.worldedit.forge.net.handler.WECUIPacketHandler;
 import com.sk89q.worldedit.internal.cui.CUIEvent;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
@@ -129,7 +128,7 @@ public class ForgePlayer extends AbstractPlayerActor {
         if (params.length > 0) {
             send = send + "|" + StringUtil.joinString(params, "|");
         }
-        PacketBuffer buffer = new PacketBuffer(Unpooled.wrappedBuffer(send.getBytes(StandardCharsets.UTF_8)));
+        PacketBuffer buffer = new PacketBuffer(Unpooled.copiedBuffer(send, StandardCharsets.UTF_8));
         SCustomPayloadPlayPacket packet = new SCustomPayloadPlayPacket(new ResourceLocation(ForgeWorldEdit.MOD_ID, ForgeWorldEdit.CUI_PLUGIN_CHANNEL), buffer);
         this.player.connection.sendPacket(packet);
     }

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePlayer.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePlayer.java
@@ -59,6 +59,7 @@ import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.util.text.TextFormatting;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.UUID;
 import javax.annotation.Nullable;
@@ -128,7 +129,7 @@ public class ForgePlayer extends AbstractPlayerActor {
         if (params.length > 0) {
             send = send + "|" + StringUtil.joinString(params, "|");
         }
-        PacketBuffer buffer = new PacketBuffer(Unpooled.copiedBuffer(send.getBytes(WECUIPacketHandler.UTF_8_CHARSET)));
+        PacketBuffer buffer = new PacketBuffer(Unpooled.wrappedBuffer(send.getBytes(StandardCharsets.UTF_8)));
         SCustomPayloadPlayPacket packet = new SCustomPayloadPlayPacket(new ResourceLocation(ForgeWorldEdit.MOD_ID, ForgeWorldEdit.CUI_PLUGIN_CHANNEL), buffer);
         this.player.connection.sendPacket(packet);
     }
@@ -258,18 +259,18 @@ public class ForgePlayer extends AbstractPlayerActor {
 
     @Override
     public SessionKey getSessionKey() {
-        return new SessionKeyImpl(player.getUniqueID(), player.getName().getString());
+        return new SessionKeyImpl(player);
     }
 
-    private static class SessionKeyImpl implements SessionKey {
+    static class SessionKeyImpl implements SessionKey {
         // If not static, this will leak a reference
 
         private final UUID uuid;
         private final String name;
 
-        private SessionKeyImpl(UUID uuid, String name) {
-            this.uuid = uuid;
-            this.name = name;
+        SessionKeyImpl(ServerPlayerEntity player) {
+            this.uuid = player.getUniqueID();
+            this.name = player.getName().getString();
         }
 
         @Override

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
@@ -24,6 +24,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.event.platform.PlatformReadyEvent;
+import com.sk89q.worldedit.event.platform.SessionIdleEvent;
 import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.forge.net.handler.InternalPacketHandler;
 import com.sk89q.worldedit.forge.net.handler.WECUIPacketHandler;
@@ -48,6 +49,7 @@ import net.minecraft.util.registry.Registry;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.CommandEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent.LeftClickEmpty;
 import net.minecraftforge.eventbus.api.Event;
@@ -291,6 +293,14 @@ public class ForgeWorldEdit {
             adaptPlayer(parseResults.getContext().getSource().asPlayer()),
             parseResults.getReader().getString()
         ));
+    }
+
+    @SubscribeEvent
+    public void onPlayerLogOut(PlayerEvent.PlayerLoggedOutEvent event) {
+        if (event.getPlayer() instanceof ServerPlayerEntity) {
+            WorldEdit.getInstance().getEventBus()
+                    .post(new SessionIdleEvent(new ForgePlayer.SessionKeyImpl((ServerPlayerEntity) event.getPlayer())));
+        }
     }
 
     /**

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/net/handler/WECUIPacketHandler.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/net/handler/WECUIPacketHandler.java
@@ -27,6 +27,7 @@ import net.minecraftforge.fml.network.NetworkEvent.ClientCustomPayloadEvent;
 import net.minecraftforge.fml.network.event.EventNetworkChannel;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static com.sk89q.worldedit.forge.ForgeAdapter.adaptPlayer;
 
@@ -34,7 +35,6 @@ public final class WECUIPacketHandler {
     private WECUIPacketHandler() {
     }
 
-    public static final Charset UTF_8_CHARSET = Charset.forName("UTF-8");
     private static final int PROTOCOL_VERSION = 1;
     private static final EventNetworkChannel HANDLER = PacketHandlerUtil
             .buildLenientHandler(ForgeWorldEdit.CUI_PLUGIN_CHANNEL, PROTOCOL_VERSION)
@@ -47,15 +47,9 @@ public final class WECUIPacketHandler {
     public static void onPacketData(ClientCustomPayloadEvent event) {
         ServerPlayerEntity player = event.getSource().get().getSender();
         LocalSession session = ForgeWorldEdit.inst.getSession(player);
-
-        if (session.hasCUISupport()) {
-            return;
-        }
-
-        String text = event.getPayload().toString(UTF_8_CHARSET);
+        String text = event.getPayload().toString(StandardCharsets.UTF_8);
         final ForgePlayer actor = adaptPlayer(player);
         session.handleCUIInitializationMessage(text, actor);
-        session.describeCUI(actor);
     }
 
 }

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/CUIChannelHandler.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/CUIChannelHandler.java
@@ -53,14 +53,9 @@ public class CUIChannelHandler implements RawDataListener {
 
             LocalSession session = SpongeWorldEdit.inst().getSession(player);
 
-            if (session.hasCUISupport()) {
-                return;
-            }
-
             final SpongePlayer actor = SpongeWorldEdit.inst().wrapPlayer(player);
             session.handleCUIInitializationMessage(new String(data.readBytes(data.available()), StandardCharsets.UTF_8),
                     actor);
-            session.describeCUI(actor);
         }
     }
 }

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongePlayer.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongePlayer.java
@@ -239,18 +239,18 @@ public class SpongePlayer extends AbstractPlayerActor {
 
     @Override
     public SessionKey getSessionKey() {
-        return new SessionKeyImpl(player.getUniqueId(), player.getName());
+        return new SessionKeyImpl(player);
     }
 
-    private static class SessionKeyImpl implements SessionKey {
+    static class SessionKeyImpl implements SessionKey {
         // If not static, this will leak a reference
 
         private final UUID uuid;
         private final String name;
 
-        private SessionKeyImpl(UUID uuid, String name) {
-            this.uuid = uuid;
-            this.name = name;
+        SessionKeyImpl(Player player) {
+            this.uuid = player.getUniqueId();
+            this.name = player.getName();
         }
 
         @Override

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorldEdit.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorldEdit.java
@@ -24,6 +24,7 @@ import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.event.platform.PlatformReadyEvent;
+import com.sk89q.worldedit.event.platform.SessionIdleEvent;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extension.platform.Capability;
 import com.sk89q.worldedit.extension.platform.Platform;
@@ -51,6 +52,7 @@ import org.spongepowered.api.event.game.state.GamePreInitializationEvent;
 import org.spongepowered.api.event.game.state.GameStartedServerEvent;
 import org.spongepowered.api.event.game.state.GameStoppingServerEvent;
 import org.spongepowered.api.event.item.inventory.InteractItemEvent;
+import org.spongepowered.api.event.network.ClientConnectionEvent;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.plugin.Plugin;
@@ -292,6 +294,12 @@ public class SpongeWorldEdit {
                 event.setCancelled(true);
             }
         }
+    }
+
+    @Listener
+    public void onPlayerQuit(ClientConnectionEvent.Disconnect event) {
+        WorldEdit.getInstance().getEventBus()
+                .post(new SessionIdleEvent(new SpongePlayer.SessionKeyImpl(event.getTargetEntity())));
     }
 
     public static ItemStack toSpongeItemStack(BaseItemStack item) {


### PR DESCRIPTION
This handling reduces the platform-specific behaviour of CUI handshakes, and ensures that the appropriate state is maintained when a client connection ends but a LocalSession remains cached.

The underlying issue here is that the lifetime of a LocalSession is longer than the lifetime of any single client connection, and if the session thinks it already has CUI support enabled it wouldn't fully re-initialize the selection. 

This issue can be reproduced on either a dedicated server, or as a player on an existing LAN world, by creating a non-cuboid selection, logging out and logging back in. The selection will no longer be visible, and the CUI will have logged some errors.

If we assume that once a player has connected from a client with CUI support once they will always continue connecting from a client with CUI support the change is a bit more straightforward -- just resend a full selection initialization every time the client sends a CUI handshake packet. However, it is entirely possible for a player to connect from a modded client, quit, and then shortly after connect from a vanilla client. When that happens, we don't want to send selection data to a client that will, at best, ignore it. To do that, player quits have to be tracked in order to clear out selection data as soon as a player disconnects.

## Further work

While this PR will make things work for now, there is potential to improve the handshake from the client's side. Currently the client just sends the handshake packet without waiting for a `minecraft:register`packet from the server, and resets when it detects a "world change". Every time the client sends a handshake, it resets its state, expecting a full re-initialization from the server. I'd like to make this more reliant on the `minecraft:register` channel, but would need to test behaviour across proxies, multiworld, and the various platforms WE supports.

This fixes mikroskeem/WorldEditCUI#13