### PR TITLE
Speed up Fast Reorder Mode and make it default

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -213,7 +213,7 @@ public class EditSession implements Extent, AutoCloseable {
 
     private final @Nullable List<TracingExtent> tracingExtents;
 
-    private ReorderMode reorderMode = ReorderMode.MULTI_STAGE;
+    private ReorderMode reorderMode = ReorderMode.FAST;
 
     private Mask oldMask;
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -108,7 +108,7 @@ public class LocalSession {
     private transient Mask mask;
     private transient ZoneId timezone = ZoneId.systemDefault();
     private transient BlockVector3 cuiTemporaryBlock;
-    private transient EditSession.ReorderMode reorderMode = EditSession.ReorderMode.MULTI_STAGE;
+    private transient EditSession.ReorderMode reorderMode = EditSession.ReorderMode.FAST;
     private transient List<Countable<BlockState>> lastDistribution;
     private transient World worldOverride;
     private transient boolean tickingWatchdog = true;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/SideEffectConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/SideEffectConverter.java
@@ -59,7 +59,9 @@ public class SideEffectConverter implements ArgumentConverter<SideEffect> {
 
     @Override
     public List<String> getSuggestions(String input, InjectedValueAccess context) {
-        return limitByPrefix(getSideEffects().stream().map(sideEffect -> sideEffect.name().toLowerCase(Locale.US)), input);
+        return limitByPrefix(getSideEffects().stream()
+            .filter(SideEffect::isExposed)
+            .map(sideEffect -> sideEffect.name().toLowerCase(Locale.US)), input);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/SideEffectExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/SideEffectExtent.java
@@ -32,10 +32,13 @@ import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -49,6 +52,11 @@ public class SideEffectExtent extends AbstractDelegateExtent {
     private final Set<BlockVector2> dirtyChunks = new HashSet<>();
     private SideEffectSet sideEffectSet = SideEffectSet.defaults();
     private boolean postEditSimulation;
+
+    private static final SideEffectSet INTERNAL_NONE = new SideEffectSet(
+        Arrays.stream(SideEffect.values())
+            .collect(Collectors.toMap(Function.identity(), state -> SideEffect.State.OFF))
+    );
 
     /**
      * Create a new instance.
@@ -86,7 +94,7 @@ public class SideEffectExtent extends AbstractDelegateExtent {
             positions.put(location, world.getBlock(location));
         }
 
-        return world.setBlock(location, block, postEditSimulation ? SideEffectSet.none() : sideEffectSet);
+        return world.setBlock(location, block, postEditSimulation ? INTERNAL_NONE : sideEffectSet);
     }
 
     public boolean commitRequired() {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/wna/WorldNativeAccess.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/wna/WorldNativeAccess.java
@@ -167,7 +167,7 @@ public interface WorldNativeAccess<NC, NBS, NP> {
         if (isChunkTicking(chunk)) {
             if (sideEffectSet.shouldApply(SideEffect.ENTITY_AI)) {
                 notifyBlockUpdate(pos, oldState, newState);
-            } else {
+            } else if (sideEffectSet.shouldApply(SideEffect.NETWORK)) {
                 // If we want to skip entity AI, just mark the block for sending
                 markBlockChanged(pos);
             }
@@ -183,7 +183,9 @@ public interface WorldNativeAccess<NC, NBS, NP> {
         }
 
         // Seems used only for PoI updates
-        onBlockStateChange(pos, oldState, blockState1);
+        if (sideEffectSet.shouldApply(SideEffect.POI_UPDATE)) {
+            onBlockStateChange(pos, oldState, blockState1);
+        }
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/SideEffect.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/SideEffect.java
@@ -28,7 +28,13 @@ public enum SideEffect {
     VALIDATION(State.OFF, true),
     ENTITY_AI(State.OFF, true),
     EVENTS(State.OFF, true),
+    /**
+     * Internal use only.
+     */
     POI_UPDATE(State.ON, false),
+    /**
+     * Internal use only.
+     */
     NETWORK(State.ON, false);
 
     // TODO Make these components in WE8

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/SideEffect.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/SideEffect.java
@@ -62,6 +62,11 @@ public enum SideEffect {
         return this.defaultValue;
     }
 
+    /**
+     * Determines if this side effect is considered API.
+     *
+     * @return if the side effect is exposed via API
+     */
     public boolean isExposed() {
         return exposed;
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/SideEffect.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/SideEffect.java
@@ -22,22 +22,26 @@ package com.sk89q.worldedit.util;
 import java.util.Locale;
 
 public enum SideEffect {
-    LIGHTING(State.ON),
-    NEIGHBORS(State.ON),
-    UPDATE(State.ON),
-    VALIDATION(State.OFF),
-    ENTITY_AI(State.OFF),
-    EVENTS(State.OFF);
+    LIGHTING(State.ON, true),
+    NEIGHBORS(State.ON, true),
+    UPDATE(State.ON, true),
+    VALIDATION(State.OFF, true),
+    ENTITY_AI(State.OFF, true),
+    EVENTS(State.OFF, true),
+    POI_UPDATE(State.ON, false),
+    NETWORK(State.ON, false);
 
     // TODO Make these components in WE8
     private final String displayName;
     private final String description;
     private final State defaultValue;
+    private final boolean exposed;
 
-    SideEffect(State defaultValue) {
+    SideEffect(State defaultValue, boolean exposed) {
         this.displayName = "worldedit.sideeffect." + this.name().toLowerCase(Locale.US);
         this.description = "worldedit.sideeffect." + this.name().toLowerCase(Locale.US) + ".description";
         this.defaultValue = defaultValue;
+        this.exposed = exposed;
     }
 
     public String getDisplayName() {
@@ -50,6 +54,10 @@ public enum SideEffect {
 
     public State getDefaultValue() {
         return this.defaultValue;
+    }
+
+    public boolean isExposed() {
+        return exposed;
     }
 
     public enum State {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/SideEffectSet.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/SideEffectSet.java
@@ -32,7 +32,9 @@ import java.util.stream.Collectors;
 public class SideEffectSet {
     private static final SideEffectSet DEFAULT = new SideEffectSet(ImmutableMap.of());
     private static final SideEffectSet NONE = new SideEffectSet(
-        Arrays.stream(SideEffect.values()).collect(Collectors.toMap(Function.identity(), state -> SideEffect.State.OFF))
+        Arrays.stream(SideEffect.values())
+            .filter(SideEffect::isExposed)
+            .collect(Collectors.toMap(Function.identity(), state -> SideEffect.State.OFF))
     );
 
     private final Map<SideEffect, SideEffect.State> sideEffects;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/SideEffectBox.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/SideEffectBox.java
@@ -41,6 +41,7 @@ public class SideEffectBox extends PaginationBox {
     private static final LazyReference<List<SideEffect>> SIDE_EFFECTS = LazyReference.from(() ->
         WorldEdit.getInstance().getPlatformManager().getSupportedSideEffects()
             .stream()
+            .filter(SideEffect::isExposed)
             .sorted(Comparator.comparing(effect ->
                 WorldEditText.reduceToText(
                     TranslatableComponent.of(effect.getDisplayName()),


### PR DESCRIPTION
Makes the fast reorder mode slightly faster than the multi-stage one by not duplicating effort with a few things. Also make it the default, due to being faster and more reliable (especially with mods).

Not entirely happy with impl yet.