### PR TITLE
Move slower translation to *Transmogrifiers

### DIFF
--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricAdapter.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricAdapter.java
@@ -142,6 +142,7 @@ public final class FabricAdapter {
     }
 
     /**
+     * Adapts property.
      * @deprecated without replacement, use the block adapter methods
      */
     @Deprecated
@@ -150,6 +151,7 @@ public final class FabricAdapter {
     }
 
     /**
+     * Adapts properties.
      * @deprecated without replacement, use the block adapter methods
      */
     @Deprecated

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricBlockRegistry.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricBlockRegistry.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit.fabric;
 
+import com.sk89q.worldedit.fabric.internal.FabricTransmogrifier;
 import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
@@ -60,7 +61,7 @@ public class FabricBlockRegistry extends BundledBlockRegistry {
                 .getDefaultState()
                 .getProperties();
         for (net.minecraft.state.property.Property<?> key : propertyKeys) {
-            map.put(key.getName(), FabricAdapter.adaptProperty(key));
+            map.put(key.getName(), FabricTransmogrifier.transmogToWorldEditProperty(key));
         }
         return map;
     }

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorld.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorld.java
@@ -589,11 +589,6 @@ public class FabricWorld extends AbstractWorld {
                 .getChunk(position.getBlockX() >> 4, position.getBlockZ() >> 4)
                 .getBlockState(FabricAdapter.toBlockPos(position));
 
-        BlockState matchingBlock = BlockStateIdAccess.getBlockStateById(Block.getRawIdFromState(mcState));
-        if (matchingBlock != null) {
-            return matchingBlock;
-        }
-
         return FabricAdapter.adapt(mcState);
     }
 

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/internal/FabricTransmogrifier.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/internal/FabricTransmogrifier.java
@@ -1,3 +1,22 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.sk89q.worldedit.fabric.internal;
 
 import com.google.common.collect.ImmutableList;

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/internal/FabricTransmogrifier.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/internal/FabricTransmogrifier.java
@@ -1,0 +1,100 @@
+package com.sk89q.worldedit.fabric.internal;
+
+import com.google.common.collect.ImmutableList;
+import com.sk89q.worldedit.fabric.FabricAdapter;
+import com.sk89q.worldedit.registry.state.BooleanProperty;
+import com.sk89q.worldedit.registry.state.DirectionalProperty;
+import com.sk89q.worldedit.registry.state.EnumProperty;
+import com.sk89q.worldedit.registry.state.IntegerProperty;
+import com.sk89q.worldedit.registry.state.Property;
+import com.sk89q.worldedit.util.Direction;
+import com.sk89q.worldedit.world.block.BlockType;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.state.StateManager;
+import net.minecraft.state.property.DirectionProperty;
+import net.minecraft.util.StringIdentifiable;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+/**
+ * Raw, un-cached transformations.
+ */
+public class FabricTransmogrifier {
+
+    public static Property<?> transmogToWorldEditProperty(net.minecraft.state.property.Property<?> property) {
+        if (property instanceof net.minecraft.state.property.BooleanProperty) {
+            return new BooleanProperty(property.getName(), ImmutableList.copyOf(((net.minecraft.state.property.BooleanProperty) property).getValues()));
+        }
+        if (property instanceof net.minecraft.state.property.IntProperty) {
+            return new IntegerProperty(property.getName(), ImmutableList.copyOf(((net.minecraft.state.property.IntProperty) property).getValues()));
+        }
+        if (property instanceof DirectionProperty) {
+            return new DirectionalProperty(property.getName(), ((DirectionProperty) property).getValues().stream()
+                .map(FabricAdapter::adaptEnumFacing)
+                .collect(Collectors.toList()));
+        }
+        if (property instanceof net.minecraft.state.property.EnumProperty) {
+            // Note: do not make x.asString a method reference.
+            // It will cause runtime bootstrap exceptions.
+            return new EnumProperty(property.getName(), ((net.minecraft.state.property.EnumProperty<?>) property).getValues().stream()
+                .map(x -> x.asString())
+                .collect(Collectors.toList()));
+        }
+        return new PropertyAdapter<>(property);
+    }
+
+    private static Map<Property<?>, Object> transmogToWorldEditProperties(BlockType block, Map<net.minecraft.state.property.Property<?>, Comparable<?>> mcProps) {
+        Map<Property<?>, Object> props = new TreeMap<>(Comparator.comparing(Property::getName));
+        for (Map.Entry<net.minecraft.state.property.Property<?>, Comparable<?>> prop : mcProps.entrySet()) {
+            Object value = prop.getValue();
+            if (prop.getKey() instanceof DirectionProperty) {
+                value = FabricAdapter.adaptEnumFacing((net.minecraft.util.math.Direction) value);
+            } else if (prop.getKey() instanceof net.minecraft.state.property.EnumProperty) {
+                value = ((StringIdentifiable) value).asString();
+            }
+            props.put(block.getProperty(prop.getKey().getName()), value);
+        }
+        return props;
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static net.minecraft.block.BlockState transmogToMinecraftProperties(StateManager<Block, BlockState> stateContainer,
+                                                                  net.minecraft.block.BlockState newState, Map<Property<?>, Object> states) {
+        for (Map.Entry<Property<?>, Object> state : states.entrySet()) {
+            net.minecraft.state.property.Property property = stateContainer.getProperty(state.getKey().getName());
+            Comparable value = (Comparable) state.getValue();
+            // we may need to adapt this value, depending on the source prop
+            if (property instanceof DirectionProperty) {
+                Direction dir = (Direction) value;
+                value = FabricAdapter.adapt(dir);
+            } else if (property instanceof net.minecraft.state.property.EnumProperty) {
+                String enumName = (String) value;
+                value = ((net.minecraft.state.property.EnumProperty<?>) property).parse((String) value).orElseGet(() -> {
+                    throw new IllegalStateException("Enum property " + property.getName() + " does not contain " + enumName);
+                });
+            }
+
+            newState = newState.with(property, value);
+        }
+        return newState;
+    }
+
+    public static net.minecraft.block.BlockState transmogToMinecraft(com.sk89q.worldedit.world.block.BlockState blockState) {
+        Block mcBlock = FabricAdapter.adapt(blockState.getBlockType());
+        net.minecraft.block.BlockState newState = mcBlock.getDefaultState();
+        Map<Property<?>, Object> states = blockState.getStates();
+        return transmogToMinecraftProperties(mcBlock.getStateManager(), newState, states);
+    }
+
+    public static com.sk89q.worldedit.world.block.BlockState transmogToWorldEdit(net.minecraft.block.BlockState blockState) {
+        BlockType blockType = FabricAdapter.adapt(blockState.getBlock());
+        return blockType.getState(transmogToWorldEditProperties(blockType, blockState.getEntries()));
+    }
+
+    private FabricTransmogrifier() {
+    }
+}

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/internal/PropertyAdapter.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/internal/PropertyAdapter.java
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.sk89q.worldedit.fabric;
+package com.sk89q.worldedit.fabric.internal;
 
 import com.google.common.collect.ImmutableList;
 import com.sk89q.worldedit.registry.state.Property;

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeAdapter.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeAdapter.java
@@ -131,6 +131,7 @@ public final class ForgeAdapter {
     }
 
     /**
+     * Adapts property.
      * @deprecated without replacement, use the block adapter methods
      */
     @Deprecated
@@ -139,6 +140,7 @@ public final class ForgeAdapter {
     }
 
     /**
+     * Adapts properties.
      * @deprecated without replacement, use the block adapter methods
      */
     @Deprecated

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeAdapter.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeAdapter.java
@@ -19,17 +19,14 @@
 
 package com.sk89q.worldedit.forge;
 
-import com.google.common.collect.ImmutableList;
 import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.jnbt.Tag;
 import com.sk89q.worldedit.blocks.BaseItemStack;
+import com.sk89q.worldedit.forge.internal.ForgeTransmogrifier;
 import com.sk89q.worldedit.forge.internal.NBTConverter;
+import com.sk89q.worldedit.internal.block.BlockStateIdAccess;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
-import com.sk89q.worldedit.registry.state.BooleanProperty;
-import com.sk89q.worldedit.registry.state.DirectionalProperty;
-import com.sk89q.worldedit.registry.state.EnumProperty;
-import com.sk89q.worldedit.registry.state.IntegerProperty;
 import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.world.World;
@@ -46,7 +43,6 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.state.DirectionProperty;
-import net.minecraft.state.StateContainer;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
@@ -60,7 +56,6 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -135,30 +130,18 @@ public final class ForgeAdapter {
         return new BlockPos(vector.getBlockX(), vector.getBlockY(), vector.getBlockZ());
     }
 
+    /**
+     * @deprecated without replacement, use the block adapter methods
+     */
+    @Deprecated
     public static Property<?> adaptProperty(net.minecraft.state.Property<?> property) {
-        if (property instanceof net.minecraft.state.BooleanProperty) {
-            return new BooleanProperty(property.getName(), ImmutableList.copyOf(((net.minecraft.state.BooleanProperty) property).getAllowedValues()));
-        }
-        if (property instanceof net.minecraft.state.IntegerProperty) {
-            return new IntegerProperty(property.getName(), ImmutableList.copyOf(((net.minecraft.state.IntegerProperty) property).getAllowedValues()));
-        }
-        if (property instanceof DirectionProperty) {
-            return new DirectionalProperty(property.getName(), ((DirectionProperty) property).getAllowedValues().stream()
-                    .map(ForgeAdapter::adaptEnumFacing)
-                    .collect(Collectors.toList()));
-        }
-        if (property instanceof net.minecraft.state.EnumProperty) {
-            // Note: do not make x.getName a method reference.
-            // It will cause runtime bootstrap exceptions.
-            // Temporary: func_176610_l == getName
-            //noinspection Convert2MethodRef
-            return new EnumProperty(property.getName(), ((net.minecraft.state.EnumProperty<?>) property).getAllowedValues().stream()
-                    .map(x -> x.func_176610_l())
-                    .collect(Collectors.toList()));
-        }
-        return new IPropertyAdapter<>(property);
+        return ForgeTransmogrifier.transmogToWorldEditProperty(property);
     }
 
+    /**
+     * @deprecated without replacement, use the block adapter methods
+     */
+    @Deprecated
     public static Map<Property<?>, Object> adaptProperties(BlockType block, Map<net.minecraft.state.Property<?>, Comparable<?>> mcProps) {
         Map<Property<?>, Object> props = new TreeMap<>(Comparator.comparing(Property::getName));
         for (Map.Entry<net.minecraft.state.Property<?>, Comparable<?>> prop : mcProps.entrySet()) {
@@ -173,37 +156,21 @@ public final class ForgeAdapter {
         return props;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    private static net.minecraft.block.BlockState applyProperties(StateContainer<Block, net.minecraft.block.BlockState> stateContainer, net.minecraft.block.BlockState newState, Map<Property<?>, Object> states) {
-        for (Map.Entry<Property<?>, Object> state : states.entrySet()) {
-            net.minecraft.state.Property property = stateContainer.getProperty(state.getKey().getName());
-            Comparable value = (Comparable) state.getValue();
-            // we may need to adapt this value, depending on the source prop
-            if (property instanceof DirectionProperty) {
-                Direction dir = (Direction) value;
-                value = adapt(dir);
-            } else if (property instanceof net.minecraft.state.EnumProperty) {
-                String enumName = (String) value;
-                value = ((net.minecraft.state.EnumProperty<?>) property).parseValue((String) value).orElseGet(() -> {
-                    throw new IllegalStateException("Enum property " + property.getName() + " does not contain " + enumName);
-                });
-            }
-
-            newState = newState.with(property, value);
-        }
-        return newState;
-    }
-
     public static net.minecraft.block.BlockState adapt(BlockState blockState) {
-        Block mcBlock = adapt(blockState.getBlockType());
-        net.minecraft.block.BlockState newState = mcBlock.getDefaultState();
-        Map<Property<?>, Object> states = blockState.getStates();
-        return applyProperties(mcBlock.getStateContainer(), newState, states);
+        int blockStateId = BlockStateIdAccess.getBlockStateId(blockState);
+        if (!BlockStateIdAccess.isValidInternalId(blockStateId)) {
+            return ForgeTransmogrifier.transmogToMinecraft(blockState);
+        }
+        return Block.getStateById(blockStateId);
     }
 
     public static BlockState adapt(net.minecraft.block.BlockState blockState) {
-        BlockType blockType = adapt(blockState.getBlock());
-        return blockType.getState(adaptProperties(blockType, blockState.getValues()));
+        int blockStateId = Block.getStateId(blockState);
+        BlockState worldEdit = BlockStateIdAccess.getBlockStateById(blockStateId);
+        if (worldEdit == null) {
+            return ForgeTransmogrifier.transmogToWorldEdit(blockState);
+        }
+        return worldEdit;
     }
 
     public static Block adapt(BlockType blockType) {

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeBlockRegistry.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeBlockRegistry.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit.forge;
 
+import com.sk89q.worldedit.forge.internal.ForgeTransmogrifier;
 import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
@@ -64,7 +65,7 @@ public class ForgeBlockRegistry extends BundledBlockRegistry {
             // func_235904_r_ == getProperties
             .func_235904_r_();
         for (net.minecraft.state.Property<?> key : propertyKeys) {
-            map.put(key.getName(), ForgeAdapter.adaptProperty(key));
+            map.put(key.getName(), ForgeTransmogrifier.transmogToWorldEditProperty(key));
         }
         return map;
     }

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java
@@ -600,11 +600,6 @@ public class ForgeWorld extends AbstractWorld {
                 .getChunk(position.getBlockX() >> 4, position.getBlockZ() >> 4)
                 .getBlockState(ForgeAdapter.toBlockPos(position));
 
-        BlockState matchingBlock = BlockStateIdAccess.getBlockStateById(Block.getStateId(mcState));
-        if (matchingBlock != null) {
-            return matchingBlock;
-        }
-
         return ForgeAdapter.adapt(mcState);
     }
 

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/internal/ForgeTransmogrifier.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/internal/ForgeTransmogrifier.java
@@ -1,3 +1,22 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.sk89q.worldedit.forge.internal;
 
 import com.google.common.collect.ImmutableList;
@@ -95,6 +114,7 @@ public class ForgeTransmogrifier {
         BlockType blockType = ForgeAdapter.adapt(blockState.getBlock());
         return blockType.getState(transmogToWorldEditProperties(blockType, blockState.getValues()));
     }
+
     private ForgeTransmogrifier() {
     }
 }

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/internal/ForgeTransmogrifier.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/internal/ForgeTransmogrifier.java
@@ -1,0 +1,100 @@
+package com.sk89q.worldedit.forge.internal;
+
+import com.google.common.collect.ImmutableList;
+import com.sk89q.worldedit.forge.ForgeAdapter;
+import com.sk89q.worldedit.registry.state.BooleanProperty;
+import com.sk89q.worldedit.registry.state.DirectionalProperty;
+import com.sk89q.worldedit.registry.state.EnumProperty;
+import com.sk89q.worldedit.registry.state.IntegerProperty;
+import com.sk89q.worldedit.registry.state.Property;
+import com.sk89q.worldedit.util.Direction;
+import com.sk89q.worldedit.world.block.BlockType;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.state.DirectionProperty;
+import net.minecraft.state.StateContainer;
+import net.minecraft.util.IStringSerializable;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+/**
+ * Raw, un-cached transformations.
+ */
+public class ForgeTransmogrifier {
+
+    public static Property<?> transmogToWorldEditProperty(net.minecraft.state.Property<?> property) {
+        if (property instanceof net.minecraft.state.BooleanProperty) {
+            return new BooleanProperty(property.getName(), ImmutableList.copyOf(((net.minecraft.state.BooleanProperty) property).getAllowedValues()));
+        }
+        if (property instanceof net.minecraft.state.IntegerProperty) {
+            return new IntegerProperty(property.getName(), ImmutableList.copyOf(((net.minecraft.state.IntegerProperty) property).getAllowedValues()));
+        }
+        if (property instanceof DirectionProperty) {
+            return new DirectionalProperty(property.getName(), ((DirectionProperty) property).getAllowedValues().stream()
+                .map(ForgeAdapter::adaptEnumFacing)
+                .collect(Collectors.toList()));
+        }
+        if (property instanceof net.minecraft.state.EnumProperty) {
+            // Note: do not make x.getName a method reference.
+            // It will cause runtime bootstrap exceptions.
+            // Temporary: func_176610_l == getName
+            //noinspection Convert2MethodRef
+            return new EnumProperty(property.getName(), ((net.minecraft.state.EnumProperty<?>) property).getAllowedValues().stream()
+                .map(x -> x.func_176610_l())
+                .collect(Collectors.toList()));
+        }
+        return new IPropertyAdapter<>(property);
+    }
+
+    public static Map<Property<?>, Object> transmogToWorldEditProperties(BlockType block, Map<net.minecraft.state.Property<?>, Comparable<?>> mcProps) {
+        Map<Property<?>, Object> props = new TreeMap<>(Comparator.comparing(Property::getName));
+        for (Map.Entry<net.minecraft.state.Property<?>, Comparable<?>> prop : mcProps.entrySet()) {
+            Object value = prop.getValue();
+            if (prop.getKey() instanceof DirectionProperty) {
+                value = ForgeAdapter.adaptEnumFacing((net.minecraft.util.Direction) value);
+            } else if (prop.getKey() instanceof net.minecraft.state.EnumProperty) {
+                value = ((IStringSerializable) value).func_176610_l();
+            }
+            props.put(block.getProperty(prop.getKey().getName()), value);
+        }
+        return props;
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static net.minecraft.block.BlockState transmogToMinecraftProperties(StateContainer<Block, BlockState> stateContainer, net.minecraft.block.BlockState newState, Map<Property<?>, Object> states) {
+        for (Map.Entry<Property<?>, Object> state : states.entrySet()) {
+            net.minecraft.state.Property property = stateContainer.getProperty(state.getKey().getName());
+            Comparable value = (Comparable) state.getValue();
+            // we may need to adapt this value, depending on the source prop
+            if (property instanceof DirectionProperty) {
+                Direction dir = (Direction) value;
+                value = ForgeAdapter.adapt(dir);
+            } else if (property instanceof net.minecraft.state.EnumProperty) {
+                String enumName = (String) value;
+                value = ((net.minecraft.state.EnumProperty<?>) property).parseValue((String) value).orElseGet(() -> {
+                    throw new IllegalStateException("Enum property " + property.getName() + " does not contain " + enumName);
+                });
+            }
+
+            newState = newState.with(property, value);
+        }
+        return newState;
+    }
+
+    public static net.minecraft.block.BlockState transmogToMinecraft(com.sk89q.worldedit.world.block.BlockState blockState) {
+        Block mcBlock = ForgeAdapter.adapt(blockState.getBlockType());
+        net.minecraft.block.BlockState newState = mcBlock.getDefaultState();
+        Map<Property<?>, Object> states = blockState.getStates();
+        return transmogToMinecraftProperties(mcBlock.getStateContainer(), newState, states);
+    }
+
+    public static com.sk89q.worldedit.world.block.BlockState transmogToWorldEdit(net.minecraft.block.BlockState blockState) {
+        BlockType blockType = ForgeAdapter.adapt(blockState.getBlock());
+        return blockType.getState(transmogToWorldEditProperties(blockType, blockState.getValues()));
+    }
+    private ForgeTransmogrifier() {
+    }
+}

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/internal/IPropertyAdapter.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/internal/IPropertyAdapter.java
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.sk89q.worldedit.forge;
+package com.sk89q.worldedit.forge.internal;
 
 import com.google.common.collect.ImmutableList;
 import com.sk89q.worldedit.registry.state.Property;


### PR DESCRIPTION
Adapters now use the fast method for adapting if available. Un-cached accessors are stored in *Transmogrifier classes.

Fixes #1671.