### PR TITLE
Ignore suggestions when uppercase characters are used in props

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/util/SuggestionHelper.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/util/SuggestionHelper.java
@@ -70,6 +70,9 @@ public final class SuggestionHelper {
         if (type == null) {
             return Stream.empty();
         }
+        if (!props.toLowerCase(Locale.ROOT).equals(props)) {
+            return Stream.empty();
+        }
         final Map<String, ? extends Property<?>> propertyMap = type.getPropertyMap();
         Set<String> matchedProperties = new HashSet<>();
         String[] propParts = props.split(",", -1);


### PR DESCRIPTION
Skip doing suggestions on block properties when uppercase letters are used.

This is a temporary fix to prevent errors before a proper fix is done.

Fixes https://github.com/EngineHub/WorldEdit/issues/1701