### PR TITLE
Switch to maven-publish

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,7 +6,12 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenLocal {
+        content {
+            includeModule("net.fabricmc", "fabric-loom")
+        }
+    }
+    mavenCentral()
     gradlePluginPortal()
     maven {
         name = "Forge Maven"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,11 +6,6 @@ plugins {
 }
 
 repositories {
-    mavenLocal {
-        content {
-            includeModule("net.fabricmc", "fabric-loom")
-        }
-    }
     mavenCentral()
     gradlePluginPortal()
     maven {

--- a/buildSrc/src/main/kotlin/ArtifactoryConfig.kt
+++ b/buildSrc/src/main/kotlin/ArtifactoryConfig.kt
@@ -35,6 +35,6 @@ fun Project.applyRootArtifactoryConfig() {
 
 fun Project.applyCommonArtifactoryConfig() {
     tasks.named<ArtifactoryTask>("artifactoryPublish") {
-        publishConfigs("archives")
+        publications("maven")
     }
 }

--- a/buildSrc/src/main/kotlin/LibsConfig.kt
+++ b/buildSrc/src/main/kotlin/LibsConfig.kt
@@ -31,7 +31,6 @@ fun Project.applyLibrariesConfiguration() {
 
     configurations {
         create("shade")
-        getByName("archives").extendsFrom(getByName("default"))
     }
 
     group = "${rootProject.group}.worldedit-libs"
@@ -94,17 +93,6 @@ fun Project.applyLibrariesConfiguration() {
 
     tasks.named("assemble").configure {
         dependsOn("jar", "sourcesJar")
-    }
-
-    artifacts {
-        val jar = tasks.named("jar")
-        add("archives", jar) {
-            builtBy(jar)
-        }
-        val sourcesJar = tasks.named("sourcesJar")
-        add("archives", sourcesJar) {
-            builtBy(sourcesJar)
-        }
     }
 
     project.apply<LibsConfigPluginHack>()

--- a/buildSrc/src/main/kotlin/LibsConfig.kt
+++ b/buildSrc/src/main/kotlin/LibsConfig.kt
@@ -1,21 +1,31 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ModuleDependency
-import org.gradle.api.internal.HasConvention
-import org.gradle.api.plugins.MavenRepositoryHandlerConvention
-import org.gradle.api.tasks.Upload
+import org.gradle.api.attributes.Bundling
+import org.gradle.api.attributes.Category
+import org.gradle.api.attributes.DocsType
+import org.gradle.api.attributes.LibraryElements
+import org.gradle.api.attributes.Usage
+import org.gradle.api.attributes.java.TargetJvmVersion
+import org.gradle.api.component.AdhocComponentWithVariants
+import org.gradle.api.component.SoftwareComponentFactory
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.get
-import org.gradle.kotlin.dsl.getPlugin
 import org.gradle.kotlin.dsl.invoke
+import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
+import javax.inject.Inject
 
 fun Project.applyLibrariesConfiguration() {
     applyCommonConfiguration()
     apply(plugin = "java-base")
-    apply(plugin = "maven")
+    apply(plugin = "maven-publish")
     apply(plugin = "com.github.johnrengelman.shadow")
     apply(plugin = "com.jfrog.artifactory")
 
@@ -88,7 +98,7 @@ fun Project.applyLibrariesConfiguration() {
 
     artifacts {
         val jar = tasks.named("jar")
-        add("default", jar) {
+        add("archives", jar) {
             builtBy(jar)
         }
         val sourcesJar = tasks.named("sourcesJar")
@@ -97,15 +107,86 @@ fun Project.applyLibrariesConfiguration() {
         }
     }
 
-    tasks.register<Upload>("install") {
-        configuration = configurations["archives"]
-        (repositories as HasConvention).convention.getPlugin<MavenRepositoryHandlerConvention>().mavenInstaller {
-            pom.version = project.version.toString()
-            pom.artifactId = project.name
+    project.apply<LibsConfigPluginHack>()
+
+    val libsComponent = project.components["libs"] as AdhocComponentWithVariants
+
+    val apiElements = project.configurations.register("apiElements") {
+        isVisible = false
+        description = "API elements for libs"
+        isCanBeResolved = false
+        isCanBeConsumed = true
+        attributes {
+            attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_API))
+            attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category.LIBRARY))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.SHADOWED))
+            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements.JAR))
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+        }
+        outgoing.artifact(tasks.named("jar"))
+    }
+
+    val runtimeElements = project.configurations.register("runtimeElements") {
+        isVisible = false
+        description = "Runtime elements for libs"
+        isCanBeResolved = false
+        isCanBeConsumed = true
+        attributes {
+            attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_RUNTIME))
+            attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category.LIBRARY))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.SHADOWED))
+            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements.JAR))
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+        }
+        outgoing.artifact(tasks.named("jar"))
+    }
+
+    val sourcesElements = project.configurations.register("sourcesElements") {
+        isVisible = false
+        description = "Source elements for libs"
+        isCanBeResolved = false
+        isCanBeConsumed = true
+        attributes {
+            attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_RUNTIME))
+            attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category.DOCUMENTATION))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.SHADOWED))
+            attribute(DocsType.DOCS_TYPE_ATTRIBUTE, project.objects.named(DocsType.SOURCES))
+        }
+        outgoing.artifact(tasks.named("sourcesJar"))
+    }
+
+    libsComponent.addVariantsFromConfiguration(apiElements.get()) {
+        mapToMavenScope("compile")
+    }
+
+    libsComponent.addVariantsFromConfiguration(runtimeElements.get()) {
+        mapToMavenScope("runtime")
+    }
+
+    libsComponent.addVariantsFromConfiguration(sourcesElements.get()) {
+        mapToMavenScope("runtime")
+    }
+
+    configure<PublishingExtension> {
+        publications {
+            register<MavenPublication>("maven") {
+                from(libsComponent)
+            }
         }
     }
 
     applyCommonArtifactoryConfig()
+}
+
+// A horrible hack because `softwareComponentFactory` has to be gotten via plugin
+// gradle why
+internal open class LibsConfigPluginHack @Inject constructor(
+    private val softwareComponentFactory: SoftwareComponentFactory
+) : Plugin<Project> {
+    override fun apply(project: Project) {
+        val libsComponents = softwareComponentFactory.adhoc("libs")
+        project.components.add(libsComponents)
+    }
 }
 
 fun Project.constrainDependenciesToLibsCore() {

--- a/buildSrc/src/main/kotlin/PlatformConfig.kt
+++ b/buildSrc/src/main/kotlin/PlatformConfig.kt
@@ -1,6 +1,9 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.plugins.quality.CheckstyleExtension
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.javadoc.Javadoc
@@ -10,17 +13,24 @@ import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.get
-import org.gradle.kotlin.dsl.getByName
 import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.the
 import org.gradle.kotlin.dsl.withType
+import kotlin.collections.flatMap
+import kotlin.collections.joinToString
+import kotlin.collections.listOf
+import kotlin.collections.map
+import kotlin.collections.mutableMapOf
+import kotlin.collections.plus
+import kotlin.collections.set
 
 fun Project.applyPlatformAndCoreConfiguration() {
     applyCommonConfiguration()
     apply(plugin = "java")
     apply(plugin = "eclipse")
     apply(plugin = "idea")
-    apply(plugin = "maven")
+    apply(plugin = "maven-publish")
     apply(plugin = "checkstyle")
     apply(plugin = "com.github.johnrengelman.shadow")
     apply(plugin = "com.jfrog.artifactory")
@@ -69,38 +79,30 @@ fun Project.applyPlatformAndCoreConfiguration() {
         }
     }
 
-    tasks.register<Jar>("javadocJar") {
-        dependsOn("javadoc")
-        archiveClassifier.set("javadoc")
-        from(tasks.getByName<Javadoc>("javadoc").destinationDir)
-    }
-
-    tasks.named("assemble").configure {
-        dependsOn("javadocJar")
-    }
-
-    artifacts {
-        add("archives", tasks.named("jar"))
-        add("archives", tasks.named("javadocJar"))
-    }
+    the<JavaPluginExtension>().withJavadocJar()
 
     if (name == "worldedit-core" || name == "worldedit-bukkit") {
-        tasks.register<Jar>("sourcesJar") {
-            dependsOn("classes")
-            archiveClassifier.set("sources")
-            from(sourceSets["main"].allSource)
-        }
-
-        artifacts {
-            add("archives", tasks.named("sourcesJar"))
-        }
-        tasks.named("assemble").configure {
-            dependsOn("sourcesJar")
-        }
+        the<JavaPluginExtension>().withSourcesJar()
     }
 
     tasks.named("check").configure {
         dependsOn("checkstyleMain", "checkstyleTest")
+    }
+
+    configure<PublishingExtension> {
+        publications {
+            register<MavenPublication>("maven") {
+                from(components["java"])
+                versionMapping {
+                    usage("java-api") {
+                        fromResolutionOf("runtimeClasspath")
+                    }
+                    usage("java-runtime") {
+                        fromResolutionResult()
+                    }
+                }
+            }
+        }
     }
 
     applyCommonArtifactoryConfig()

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ version=7.2.5-SNAPSHOT
 org.gradle.jvmargs=-Xmx1512M
 org.gradle.parallel=true
 
-loom.version=0.7.local
+loom.version=0.7.19
 mixin.version=0.9.2+mixin.0.8.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ version=7.2.5-SNAPSHOT
 org.gradle.jvmargs=-Xmx1512M
 org.gradle.parallel=true
 
-loom.version=0.6.50
+loom.version=0.7.local
 mixin.version=0.9.2+mixin.0.8.2

--- a/worldedit-fabric/build.gradle.kts
+++ b/worldedit-fabric/build.gradle.kts
@@ -4,11 +4,6 @@ import net.fabricmc.loom.task.RemapJarTask
 
 buildscript {
     repositories {
-        mavenLocal {
-            content {
-                includeModule("net.fabricmc", "fabric-loom")
-            }
-        }
         mavenCentral()
         maven {
             name = "Fabric"
@@ -43,11 +38,6 @@ configurations.all {
 val fabricApiConfiguration: Configuration = configurations.create("fabricApi")
 
 repositories {
-    mavenLocal {
-        content {
-            includeModule("net.fabricmc", "fabric-loom")
-        }
-    }
     maven {
         name = "Fabric"
         url = uri("https://maven.fabricmc.net/")


### PR DESCRIPTION
This theoretically fixes the issue with deploying POMs (will need to be tested after merging) and fixes many other issues with the current POMs regarding the version specifications. It also allows us to publish the richer Gradle metadata, and prepares for eventual unification under a core EngineHub Gradle plugin.