### PR TITLE
Address issue template deprecations

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,9 +1,6 @@
 name: Bug report
 description: Report a way in which WorldEdit is not working as intended
-title: ''
 labels: ['type:bug', 'status:pending']
-assignees: []
-issue_body: true
 
 body:
 - type: markdown
@@ -55,6 +52,6 @@ body:
   validations:
     required: true
 
-- type: markdown
+- type: textarea
   attributes:
     value: Add any additional context you can provide below.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,9 +1,6 @@
 name: Feature request
 description: Suggest an idea for WorldEdit
-title: ''
 labels: ['type:feature-request', 'status:pending']
-assignees: []
-issue_body: true
 
 body:
 - type: markdown
@@ -39,6 +36,6 @@ body:
   validations:
     required: false
 
-- type: markdown
+- type: textarea
   attributes:
     value: Add any additional context you can provide below.


### PR DESCRIPTION
A few recently introduced strings for issue templates were deprecated and scheduled for removal making templates no longer work properly.
![](https://i.imgur.com/eW2Mojd.png)