### PR TITLE
Make BukkitWorld lazier for frequent use-case

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/AbstractWorld.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/AbstractWorld.java
@@ -46,7 +46,7 @@ import javax.annotation.Nullable;
  */
 public abstract class AbstractWorld implements World {
 
-    private final PriorityQueue<QueuedEffect> effectQueue = new PriorityQueue<>();
+    private PriorityQueue<QueuedEffect> effectQueue;
     private int taskId = -1;
 
     @Override
@@ -105,6 +105,10 @@ public abstract class AbstractWorld implements World {
 
     @Override
     public boolean queueBlockBreakEffect(Platform server, BlockVector3 position, BlockType blockType, double priority) {
+        if (this.effectQueue == null) {
+            this.effectQueue = new PriorityQueue<>();
+        }
+
         if (taskId == -1) {
             taskId = server.schedule(0, 1, () -> {
                 int max = Math.max(1, Math.min(30, effectQueue.size() / 3));


### PR DESCRIPTION
The adapters are used quite frequently by plugins using the WorldEdit
API, with BukkitWorld being one of the more common ones among plugins
such as WorldGuard. As a new BukkitWorld may need to be initialized
every time a physics (redstone and others) event happens, there is a
significant cost to anything put inside the constructor for BukkitWorld.

This commit attempts to reduce the initialization cost by storing a
reference to the world's name instead of holding a WeakReference, which
may actually fix bugs relating to code assuming the world is still
loaded because the reference was not collected yet.

As well it lazily initializes the WorldNativeAccess when it's needed,
which is usually only for modifications that are actually applied to the
world. It does the same for the effect queue. These changes should be
beneficial to everyone, and significantly improve allocations.

A real-world example of a problem this fixes:
![image](https://user-images.githubusercontent.com/3516420/120868935-cd7a3980-c55a-11eb-96af-b50629280975.png)

20% of the allocations on this server are due to redstone triggering WorldGuard to create a BukkitWorld. I personally believe this fix belongs in WorldEdit however, as there shouldn't be a penalty for using a wrapper class.