### PR TITLE
Allow updates for mojang dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/CommonConfig.kt
+++ b/buildSrc/src/main/kotlin/CommonConfig.kt
@@ -46,15 +46,15 @@ fun Project.applyCommonConfiguration() {
                     continue
                 }
                 add(conf.name, "com.google.guava:guava") {
-                    version { strictly(Versions.GUAVA) }
+                    version { require(Versions.GUAVA) }
                     because("Mojang provides Guava")
                 }
                 add(conf.name, "com.google.code.gson:gson") {
-                    version { strictly(Versions.GSON) }
+                    version { require(Versions.GSON) }
                     because("Mojang provides Gson")
                 }
                 add(conf.name, "it.unimi.dsi:fastutil") {
-                    version { strictly(Versions.FAST_UTIL) }
+                    version { require(Versions.FAST_UTIL) }
                     because("Mojang provides FastUtil")
                 }
             }


### PR DESCRIPTION
Paper 1.17 uses Fast Util 8.2.2, WorldEdit depend strictly on 8.2.1

As discussed in Discord, this should fix compilation issues from worldguard