### PR TITLE
Ensure that all chunks are loaded when copying entities

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
@@ -47,6 +47,7 @@ import com.sk89q.worldedit.world.weather.WeatherType;
 import com.sk89q.worldedit.world.weather.WeatherTypes;
 import io.papermc.lib.PaperLib;
 import org.apache.logging.log4j.Logger;
+import org.bukkit.Chunk;
 import org.bukkit.Effect;
 import org.bukkit.TreeType;
 import org.bukkit.World;
@@ -115,6 +116,16 @@ public class BukkitWorld extends AbstractWorld {
     }
 
     @Override
+    public void ensureLoaded(Region region) {
+        for (BlockVector2 chunkCoordinates : region.getBoundingBox().getChunks()) {
+            Chunk chunk = getWorld().getChunkAt(chunkCoordinates.getBlockX(), chunkCoordinates.getBlockZ());
+            if (!chunk.isLoaded()) {
+                chunk.load(false);
+            }
+        }
+    }
+
+    @Override
     public List<com.sk89q.worldedit.entity.Entity> getEntities(Region region) {
         World world = getWorld();
 
@@ -127,6 +138,8 @@ public class BukkitWorld extends AbstractWorld {
         }
         return entities;
     }
+
+
 
     @Override
     public List<com.sk89q.worldedit.entity.Entity> getEntities() {

--- a/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/schematic/ClipboardWorld.java
+++ b/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/schematic/ClipboardWorld.java
@@ -123,6 +123,11 @@ public class ClipboardWorld extends AbstractWorld implements Clipboard, CLIWorld
     }
 
     @Override
+    public void ensureLoaded(Region region) {
+        // nothing to do here
+    }
+
+    @Override
     public List<? extends Entity> getEntities(Region region) {
         return clipboard.getEntities(region);
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -864,6 +864,11 @@ public class EditSession implements Extent, AutoCloseable {
     }
 
     @Override
+    public void ensureLoaded(Region region) {
+        bypassNone.ensureLoaded(region);
+    }
+
+    @Override
     public List<? extends Entity> getEntities(Region region) {
         return bypassNone.getEntities(region);
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/AbstractDelegateExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/AbstractDelegateExtent.java
@@ -85,6 +85,11 @@ public abstract class AbstractDelegateExtent implements Extent {
     }
 
     @Override
+    public void ensureLoaded(Region region) {
+        extent.ensureLoaded(region);
+    }
+
+    @Override
     public List<? extends Entity> getEntities() {
         return extent.getEntities();
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/Extent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/Extent.java
@@ -62,7 +62,7 @@ public interface Extent extends InputExtent, OutputExtent {
      *
      * <p>If the extent is not wholly loaded (i.e. a world being simulated in the
      * game will not have every chunk loaded), then this list may not be
-     * incomplete.</p>
+     * complete.</p>
      *
      * @param region the region in which entities must be contained
      * @return a list of entities
@@ -70,11 +70,20 @@ public interface Extent extends InputExtent, OutputExtent {
     List<? extends Entity> getEntities(Region region);
 
     /**
+     * Checks all chunks in the provided region and load them if not yet loaded.
+     *
+     * @param region The region to load all chunks in
+     */
+    default void ensureLoaded(Region region) {
+        // no default implementation to ensure legacy compatability
+    }
+
+    /**
      * Get a list of all entities.
      *
      * <p>If the extent is not wholly loaded (i.e. a world being simulated in the
      * game will not have every chunk loaded), then this list may not be
-     * incomplete.</p>
+     * complete.</p>
      *
      * @return a list of entities
      */

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/BlockArrayClipboard.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/BlockArrayClipboard.java
@@ -99,6 +99,11 @@ public class BlockArrayClipboard implements Clipboard {
     }
 
     @Override
+    public void ensureLoaded(Region region) {
+        // nothing to do here
+    }
+
+    @Override
     public List<? extends Entity> getEntities(Region region) {
         List<Entity> filtered = new ArrayList<>();
         for (Entity entity : entities) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/WatchdogTickingExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/WatchdogTickingExtent.java
@@ -115,6 +115,12 @@ public class WatchdogTickingExtent extends AbstractDelegateExtent {
     }
 
     @Override
+    public void ensureLoaded(Region region) {
+        onOperation();
+        super.ensureLoaded(region);
+    }
+
+    @Override
     public List<? extends Entity> getEntities() {
         onOperation();
         return super.getEntities();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/operation/ForwardExtentCopy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/operation/ForwardExtentCopy.java
@@ -312,6 +312,7 @@ public class ForwardExtentCopy implements Operation {
             if (copyingEntities) {
                 ExtentEntityCopy entityCopy = new ExtentEntityCopy(from.toVector3(), destination, to.toVector3(), currentTransform);
                 entityCopy.setRemoving(removingEntities);
+                source.ensureLoaded(region);
                 List<? extends Entity> entities = Lists.newArrayList(source.getEntities(region));
                 entities.removeIf(entity -> {
                     EntityProperties properties = entity.getFacet(EntityProperties.class);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/request/RequestExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/request/RequestExtent.java
@@ -59,6 +59,11 @@ public class RequestExtent implements Extent {
     }
 
     @Override
+    public void ensureLoaded(Region region) {
+        getExtent().ensureLoaded(region);
+    }
+
+    @Override
     public List<? extends Entity> getEntities(Region region) {
         return getExtent().getEntities(region);
     }


### PR DESCRIPTION
When using the ForwardExtendCopy to copy entities along with blocks on a Bukkit 1.16.5 server, entities in unloaded chunks won't be copied. 
I think this problem only occurs with the Bukkit implementation, however I have not tested in on sponge etc...

To solve this, I have added a new method to the Extend interface which can be used to load all chunks in a specific region. 
As the method has a default implementation, legacy compatibility is ensured. This method is called before entities are copied. 

Signed-off-by: lukas81298 <lukas81298@gommehd.net>