### PR TITLE
Improve mask api

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/BiomeMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/BiomeMask.java
@@ -96,10 +96,4 @@ public class BiomeMask extends AbstractMask {
         return biomes.contains(biome);
     }
 
-    @Nullable
-    @Override
-    public Mask2D toMask2D() {
-        return null;
-    }
-
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/BlockCategoryMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/BlockCategoryMask.java
@@ -44,10 +44,4 @@ public class BlockCategoryMask extends AbstractExtentMask {
     public boolean test(BlockVector3 vector) {
         return category.contains(getExtent().getBlock(vector));
     }
-
-    @Nullable
-    @Override
-    public Mask2D toMask2D() {
-        return null;
-    }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/BlockMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/BlockMask.java
@@ -105,10 +105,4 @@ public class BlockMask extends AbstractExtentMask {
         return false;
     }
 
-    @Nullable
-    @Override
-    public Mask2D toMask2D() {
-        return null;
-    }
-
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/BlockStateMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/BlockStateMask.java
@@ -61,10 +61,4 @@ public class BlockStateMask extends AbstractExtentMask {
         return checkProps.entrySet().stream()
                 .allMatch(entry -> block.getState(entry.getKey()) == entry.getValue());
     }
-
-    @Nullable
-    @Override
-    public Mask2D toMask2D() {
-        return null;
-    }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/BlockTypeMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/BlockTypeMask.java
@@ -96,10 +96,4 @@ public class BlockTypeMask extends AbstractExtentMask {
     public boolean test(BlockVector3 vector) {
         return blocks.contains(getExtent().getBlock(vector).getBlockType());
     }
-
-    @Nullable
-    @Override
-    public Mask2D toMask2D() {
-        return null;
-    }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/BoundedHeightMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/BoundedHeightMask.java
@@ -51,10 +51,4 @@ public class BoundedHeightMask extends AbstractMask {
         return vector.getY() >= minY && vector.getY() <= maxY;
     }
 
-    @Nullable
-    @Override
-    public Mask2D toMask2D() {
-        return null;
-    }
-
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/ExistingBlockMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/ExistingBlockMask.java
@@ -44,10 +44,4 @@ public class ExistingBlockMask extends AbstractExtentMask {
         return !getExtent().getBlock(vector).getBlockType().getMaterial().isAir();
     }
 
-    @Nullable
-    @Override
-    public Mask2D toMask2D() {
-        return null;
-    }
-
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/Mask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/Mask.java
@@ -26,10 +26,12 @@ import javax.annotation.Nullable;
 /**
  * Tests whether a given vector meets a criteria.
  */
+@FunctionalInterface
 public interface Mask {
 
     /**
-     * Returns true if the criteria is met.
+     * Returns true if the criteria is met and
+     * placement is allowed for the block.
      *
      * @param vector the vector to test
      * @return true if the criteria is met
@@ -42,6 +44,8 @@ public interface Mask {
      * @return a 2D mask version or {@code null} if this mask can't be 2D
      */
     @Nullable
-    Mask2D toMask2D();
+    default Mask2D toMask2D() {
+        return null;
+    }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/Mask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/Mask.java
@@ -30,8 +30,7 @@ import javax.annotation.Nullable;
 public interface Mask {
 
     /**
-     * Returns true if the criteria is met and
-     * placement is allowed for the block.
+     * Returns true if the criteria is met.
      *
      * @param vector the vector to test
      * @return true if the criteria is met

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/RegionMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/RegionMask.java
@@ -66,10 +66,4 @@ public class RegionMask extends AbstractMask {
         return region.contains(vector);
     }
 
-    @Nullable
-    @Override
-    public Mask2D toMask2D() {
-        return null;
-    }
-
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/SolidBlockMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/SolidBlockMask.java
@@ -38,10 +38,4 @@ public class SolidBlockMask extends AbstractExtentMask {
         return block.getBlockType().getMaterial().isMovementBlocker();
     }
 
-    @Nullable
-    @Override
-    public Mask2D toMask2D() {
-        return null;
-    }
-
 }


### PR DESCRIPTION
Makes **toMask2D()** a default method, which spares some clutter on client code.
From there on, allows the Mask interface also to be used as a functional interface.

As discussed on discord, here is the PR.