### PR TITLE
Fix CLI Mess

### DIFF
--- a/worldedit-cli/build.gradle.kts
+++ b/worldedit-cli/build.gradle.kts
@@ -9,6 +9,9 @@ applyShadowConfiguration()
 addJarManifest(WorldEditKind.Standalone("com.sk89q.worldedit.cli.CLIWorldEdit"))
 
 dependencies {
+    "compileOnly"(project(":worldedit-libs:core:ap"))
+    "annotationProcessor"(project(":worldedit-libs:core:ap"))
+    "annotationProcessor"("com.google.guava:guava:${Versions.GUAVA}")
     "api"(project(":worldedit-core"))
     "implementation"(platform("org.apache.logging.log4j:log4j-bom:2.14.1") {
         because("We control Log4J on this platform")

--- a/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIExtraCommands.java
+++ b/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIExtraCommands.java
@@ -1,3 +1,22 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.sk89q.worldedit.cli;
 
 import com.sk89q.worldedit.LocalSession;

--- a/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIExtraCommands.java
+++ b/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIExtraCommands.java
@@ -1,0 +1,43 @@
+package com.sk89q.worldedit.cli;
+
+import com.sk89q.worldedit.LocalSession;
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.extension.platform.Actor;
+import com.sk89q.worldedit.regions.selector.CuboidRegionSelector;
+import com.sk89q.worldedit.util.formatting.text.TextComponent;
+import com.sk89q.worldedit.util.task.Task;
+import com.sk89q.worldedit.world.World;
+import org.enginehub.piston.annotation.Command;
+import org.enginehub.piston.annotation.CommandContainer;
+
+import java.util.concurrent.ExecutionException;
+
+@CommandContainer
+public class CLIExtraCommands {
+    @Command(
+        name = "selectworld",
+        desc = "Select the entire world"
+    )
+    public void selectWorld(Actor actor, World world, LocalSession session) {
+        session.setRegionSelector(world, new CuboidRegionSelector(
+            world, world.getMinimumPoint(), world.getMaximumPoint()
+        ));
+        actor.printInfo(TextComponent.of("Selected the entire world."));
+    }
+
+    @Command(
+        name = "await",
+        desc = "Await all pending tasks"
+    )
+    public void await() {
+        for (Task<?> task : WorldEdit.getInstance().getSupervisor().getTasks()) {
+            try {
+                task.get();
+            } catch (InterruptedException e) {
+                WorldEdit.logger.warn("Interrupted awaiting task", e);
+            } catch (ExecutionException e) {
+                WorldEdit.logger.warn("Error awaiting task", e);
+            }
+        }
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
@@ -277,7 +277,7 @@ public final class PlatformCommandManager {
      * Internal use only.
      */
     public <CI> void registerSubCommands(String name, List<String> aliases, String desc,
-                                          CommandRegistration<CI> registration, CI instance) {
+                                         CommandRegistration<CI> registration, CI instance) {
         registerSubCommands(name, aliases, desc, registration, instance, m -> {
         });
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
@@ -273,7 +273,10 @@ public final class PlatformCommandManager {
             });
     }
 
-    private <CI> void registerSubCommands(String name, List<String> aliases, String desc,
+    /**
+     * Internal use only.
+     */
+    public <CI> void registerSubCommands(String name, List<String> aliases, String desc,
                                           CommandRegistration<CI> registration, CI instance) {
         registerSubCommands(name, aliases, desc, registration, instance, m -> {
         });


### PR DESCRIPTION
Now loads MCEdit schematics, supports selecting the world with `//cli selectworld`, waiting for async tasks to finish with `//cli await`, and handles `PlatformsRegisteredEvent`.