### PR TITLE
Fix Cycler tool not using full block data

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockDataCyler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockDataCyler.java
@@ -34,7 +34,7 @@ import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.World;
-import com.sk89q.worldedit.world.block.BlockState;
+import com.sk89q.worldedit.world.block.BaseBlock;
 
 import java.util.HashMap;
 import java.util.List;
@@ -60,7 +60,7 @@ public class BlockDataCyler implements DoubleActionBlockTool {
         World world = (World) clicked.getExtent();
 
         BlockVector3 blockPoint = clicked.toVector().toBlockPoint();
-        BlockState block = world.getBlock(blockPoint);
+        BaseBlock block = world.getFullBlock(blockPoint);
 
         if (!config.allowedDataCycleBlocks.isEmpty()
                 && !player.hasPermission("worldedit.override.data-cycler")
@@ -85,7 +85,7 @@ public class BlockDataCyler implements DoubleActionBlockTool {
                 index = (index + 1) % currentProperty.getValues().size();
                 @SuppressWarnings("unchecked")
                 Property<Object> objProp = (Property<Object>) currentProperty;
-                BlockState newBlock = block.with(objProp, currentProperty.getValues().get(index));
+                BaseBlock newBlock = block.with(objProp, currentProperty.getValues().get(index));
 
                 try (EditSession editSession = session.createEditSession(player)) {
                     editSession.disableBuffering();


### PR DESCRIPTION
Use the full block to retain NBT data

Fixes #1867 