### PR TITLE
Require 16 in API

### DIFF
--- a/buildSrc/src/main/kotlin/LibsConfig.kt
+++ b/buildSrc/src/main/kotlin/LibsConfig.kt
@@ -111,7 +111,7 @@ fun Project.applyLibrariesConfiguration() {
             attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category.LIBRARY))
             attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.SHADOWED))
             attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements.JAR))
-            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 16)
         }
         outgoing.artifact(tasks.named("jar"))
     }
@@ -126,7 +126,7 @@ fun Project.applyLibrariesConfiguration() {
             attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category.LIBRARY))
             attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.SHADOWED))
             attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements.JAR))
-            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 16)
         }
         outgoing.artifact(tasks.named("jar"))
     }

--- a/buildSrc/src/main/kotlin/PlatformConfig.kt
+++ b/buildSrc/src/main/kotlin/PlatformConfig.kt
@@ -44,7 +44,6 @@ fun Project.applyPlatformAndCoreConfiguration() {
             val disabledLint = listOf(
                 "processing", "path", "fallthrough", "serial"
             )
-            options.release.set(8)
             options.compilerArgs.addAll(listOf("-Xlint:all") + disabledLint.map { "-Xlint:-$it" })
             options.isDeprecation = true
             options.encoding = "UTF-8"
@@ -82,7 +81,6 @@ fun Project.applyPlatformAndCoreConfiguration() {
     }
 
     configure<JavaPluginExtension> {
-        disableAutoTargetJvm()
         withJavadocJar()
     }
 


### PR DESCRIPTION
Minecraft 1.17 requires it, and 7.3.0 will drop everything but 1.17 support most likely.