### PR TITLE
Add caching for Gradle Build

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,11 +13,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 16
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: 16
+        cache: 'gradle'
+        distribution: 'temurin'
     - name: Build with Gradle
-      run: ./gradlew build -s
+      run: ./gradlew build -s --no-daemon
     - uses: actions/upload-artifact@v2
       name: Archive Reports
       if: always()


### PR DESCRIPTION
This reduced build times by around 50% when there was a cache hit.