### PR TITLE
Add divide command

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -233,6 +233,31 @@ public class RegionCommands {
     }
 
     @Command(
+        name = "/divide",
+        desc = "Divides the region into N sections and places blocks at these points"
+    )
+    @Logging(REGION)
+    @CommandPermissions("worldedit.region.divide")
+    public int divide(Actor actor, EditSession editSession, @Selection Region region,
+                      @Arg(desc = "The number to divide by")
+                          int number,
+                      @Arg(desc = "The pattern of blocks to set")
+                          Pattern pattern) throws WorldEditException {
+        // TODO support other region types
+        if (!(region instanceof CuboidRegion)) {
+            actor.printError(TranslatableComponent.of("worldedit.line.invalid-type"));
+            return 0;
+        }
+        checkCommandArgument(number >= 0, "Division factor must be >= 0");
+
+        CuboidRegion cuboidRegion = (CuboidRegion) region;
+
+        int affected = editSession.divide(pattern, cuboidRegion.getPos1(), cuboidRegion.getPos2(), number);
+        actor.printInfo(TranslatableComponent.of("worldedit.divide.changed", TextComponent.of(affected)));
+        return affected;
+    }
+
+    @Command(
         name = "/naturalize",
         desc = "3 layers of dirt on top then rock below"
     )

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -212,6 +212,8 @@
     "worldedit.overlay.overlaid": "{0} blocks have been overlaid.",
     "worldedit.naturalize.naturalized": "{0} block(s) have been made to look more natural.",
     "worldedit.center.changed": "Center set. ({0} blocks changed)",
+    "worldedit.divide.changed": "Division points set. ({0} blocks changed)",
+    "worldedit.divide.invalid-type": "//divide only works with cuboid selections",
     "worldedit.smooth.changed": "Terrain's height map smoothed. {0} blocks changed.",
     "worldedit.snowsmooth.changed": "Snow's height map smoothed. {0} blocks changed.",
     "worldedit.move.moved": "{0} blocks moved.",


### PR DESCRIPTION
This PR adds a relatively simple yet useful command:
**//divide [number] [pattern]**.

This command performs a similar task to the existing **//center [pattern]** command, but gives the user more control by allowing the player to specify a division factor. This command would divide the selected region by the provided quantity and set those blocks to the provided pattern.