### PR TITLE
Re-add class shutter with tweaks.

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/scripting/MinecraftHidingClassShutter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/scripting/MinecraftHidingClassShutter.java
@@ -1,0 +1,32 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.scripting;
+
+import org.mozilla.javascript.ClassShutter;
+
+/**
+ * Hides Minecraft's obfuscated names from scripts.
+ */
+class MinecraftHidingClassShutter implements ClassShutter {
+    @Override
+    public boolean visibleToScripts(String fullClassName) {
+        return fullClassName.contains(".") || fullClassName.length() >= 4;
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/scripting/RhinoCraftScriptEngine.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/scripting/RhinoCraftScriptEngine.java
@@ -48,6 +48,7 @@ public class RhinoCraftScriptEngine implements CraftScriptEngine {
     public Object evaluate(String script, String filename, Map<String, Object> args) throws Throwable {
         RhinoContextFactory factory = new RhinoContextFactory(timeLimit);
         Context cx = factory.enterContext();
+        cx.setClassShutter(new MinecraftHidingClassShutter());
         ScriptableObject scriptable = new ImporterTopLevel(cx);
         Scriptable scope = cx.initStandardObjects(scriptable);
 


### PR DESCRIPTION
We want to hide default-package classes, such as "com", "io", etc. which are common names
in Mojang obf classes but also common package names, without hiding generated default-package
classes such as described in #1895.

This reverts commit 6008fe73