### PR TITLE
Fix for #1983, fix smooth for negative y values

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/convolution/HeightMap.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/convolution/HeightMap.java
@@ -144,7 +144,7 @@ public class HeightMap {
 
                         // Grow -- start from 1 below top replacing airblocks
                         for (int y = newHeight - 1 - originY; y >= 0; --y) {
-                            int copyFrom = (int) (y * scale);
+                            int copyFrom = (int) Math.floor(y * scale);
                             session.setBlock(BlockVector3.at(xr, originY + y, zr), session.getBlock(BlockVector3.at(xr, originY + copyFrom, zr)));
                             ++blocksChanged;
                         }
@@ -152,7 +152,7 @@ public class HeightMap {
                 } else if (curHeight > newHeight) {
                     // Shrink -- start from bottom
                     for (int y = 0; y < newHeight - originY; ++y) {
-                        int copyFrom = (int) (y * scale);
+                        int copyFrom = (int) Math.floor(y * scale);
                         session.setBlock(BlockVector3.at(xr, originY + y, zr), session.getBlock(BlockVector3.at(xr, originY + copyFrom, zr)));
                         ++blocksChanged;
                     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/convolution/HeightMapFilter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/convolution/HeightMapFilter.java
@@ -120,7 +120,7 @@ public class HeightMapFilter {
                         z += f * inData[offsetY + offsetX];
                     }
                 }
-                outData[index++] = (int) (z + 0.5);
+                outData[index++] = (int) Math.floor(z + 0.5);
             }
         }
         return outData;


### PR DESCRIPTION
Fixes #1983 

the problem is the used cast to int as we have to floor the values:
```java
int zFailed = (int) -20.5; // this will be 20
int zCorrect = (int) Math.floor(-20.5); // this will be -21
```

This works fine for positive y values but with negative values the terrain will be raised by one block

I will create another PR for snowsmooth as the snowsmooth brush is only available in the master/7.3.0 branch