### PR TITLE
Show stack trace only when user has detailed error permission

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/ErrorReporting.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/ErrorReporting.java
@@ -30,10 +30,8 @@ import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
  */
 public class ErrorReporting {
     public static void trigger(Actor actor, Throwable error) {
-        boolean showDetailedError = actor.hasPermission("worldedit.error.detailed");
-
         actor.printError(TranslatableComponent.of("worldedit.command.error.report"));
-        if (showDetailedError) {
+        if (actor.hasPermission("worldedit.error.detailed")) {
             actor.print(
                 TextComponent.builder(error.getClass().getName() + ": " + error.getMessage())
                     .hoverEvent(HoverEvent.showText(TextComponent.of(Throwables.getStackTraceAsString(error))))

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/ErrorReporting.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/ErrorReporting.java
@@ -32,9 +32,8 @@ public class ErrorReporting {
     public static void trigger(Actor actor, Throwable error) {
         boolean showDetailedError = actor.hasPermission("worldedit.error.detailed");
 
-        actor.printError(TranslatableComponent.of("worldedit.command.error"));
+        actor.printError(TranslatableComponent.of("worldedit.command.error.report"));
         if (showDetailedError) {
-            actor.printError(TranslatableComponent.of("worldedit.command.error.report"));
             actor.print(
                 TextComponent.builder(error.getClass().getName() + ": " + error.getMessage())
                     .hoverEvent(HoverEvent.showText(TextComponent.of(Throwables.getStackTraceAsString(error))))

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/ErrorReporting.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/ErrorReporting.java
@@ -30,12 +30,17 @@ import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
  */
 public class ErrorReporting {
     public static void trigger(Actor actor, Throwable error) {
-        actor.printError(TranslatableComponent.of("worldedit.command.error.report"));
-        actor.print(
-            TextComponent.builder(error.getClass().getName() + ": " + error.getMessage())
-                .hoverEvent(HoverEvent.showText(TextComponent.of(Throwables.getStackTraceAsString(error))))
-                .build()
-        );
+        boolean showDetailedError = actor.hasPermission("worldedit.error.detailed");
+
+        actor.printError(TranslatableComponent.of("worldedit.command.error"));
+        if (showDetailedError) {
+            actor.printError(TranslatableComponent.of("worldedit.command.error.report"));
+            actor.print(
+                TextComponent.builder(error.getClass().getName() + ": " + error.getMessage())
+                    .hoverEvent(HoverEvent.showText(TextComponent.of(Throwables.getStackTraceAsString(error))))
+                    .build()
+            );
+        }
     }
 
     private ErrorReporting() {

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -263,6 +263,7 @@
     "worldedit.command.time-elapsed": "{0}s elapsed (history: {1} changed; {2} blocks/sec).",
     "worldedit.command.permissions": "You are not permitted to do that. Are you in the right mode?",
     "worldedit.command.player-only": "This command must be used with a player.",
+    "worldedit.command.error": "An unexpected error occurred trying to run your command",    
     "worldedit.command.error.report": "Please report this error: [See console]",
     "worldedit.pastebin.uploading": "(Please wait... sending output to pastebin...)",
     "worldedit.session.cant-find-session": "Unable to find session for {0}",

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -263,7 +263,6 @@
     "worldedit.command.time-elapsed": "{0}s elapsed (history: {1} changed; {2} blocks/sec).",
     "worldedit.command.permissions": "You are not permitted to do that. Are you in the right mode?",
     "worldedit.command.player-only": "This command must be used with a player.",
-    "worldedit.command.error": "An unexpected error occurred trying to run your command",    
     "worldedit.command.error.report": "Please report this error: [See console]",
     "worldedit.pastebin.uploading": "(Please wait... sending output to pastebin...)",
     "worldedit.session.cant-find-session": "Unable to find session for {0}",


### PR DESCRIPTION
This PR adds the functionality that error stack traces only get shown to players if they have the `worldedit.error.detailed` permission otherwise a general error message gets sent to the actor.

This feature was added as stack traces can expose the underlying platform and code base the server runs on. Bad actors could abuse this behavior to gather information and find matching vulnerabilities.