### PR TITLE
Fix legacy error message output for WorldGuard commands

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/command/exception/ExceptionConverterHelper.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/command/exception/ExceptionConverterHelper.java
@@ -78,7 +78,7 @@ public abstract class ExceptionConverterHelper implements ExceptionConverter {
                         throw (CommandException) e.getCause();
                     }
                     if (e.getCause() instanceof com.sk89q.minecraft.util.commands.CommandException) {
-                        throw new CommandException(e.getCause(), ImmutableList.of());
+                        throw new CommandExecutionException(e.getCause(), ImmutableList.of());
                     }
                     throw new CommandExecutionException(e, ImmutableList.of());
                 } catch (IllegalArgumentException | IllegalAccessException e) {


### PR DESCRIPTION
Currently no error message will be displayed for WorldGuard commands.

E.g. a `/rg addmember <rg> invalid-username` doesn't show the correct error message.

With this change the method "AsyncCommandBuilder$tryExtractOldCommandException" will convert the legacy message correctly.