### PR TITLE
Apply update flag on later change

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1.17.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_17_R1_2/PaperweightWorldNativeAccess.java
+++ b/worldedit-bukkit/adapters/adapter-1.17.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_17_R1_2/PaperweightWorldNativeAccess.java
@@ -153,6 +153,12 @@ public class PaperweightWorldNativeAccess implements WorldNativeAccess<LevelChun
         }
     }
 
+    @Override
+    public void updateBlock(BlockPos pos, net.minecraft.world.level.block.state.BlockState oldState, net.minecraft.world.level.block.state.BlockState newState) {
+        ServerLevel world = getWorld();
+        newState.onPlace(world, pos, oldState, false);
+    }
+
     private void fireNeighborChanged(BlockPos pos, ServerLevel world, Block block, BlockPos neighborPos) {
         world.getBlockState(neighborPos).neighborChanged(world, neighborPos, block, pos, false);
     }

--- a/worldedit-bukkit/adapters/adapter-1.18/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_18_R1/PaperweightWorldNativeAccess.java
+++ b/worldedit-bukkit/adapters/adapter-1.18/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_18_R1/PaperweightWorldNativeAccess.java
@@ -153,6 +153,12 @@ public class PaperweightWorldNativeAccess implements WorldNativeAccess<LevelChun
         }
     }
 
+    @Override
+    public void updateBlock(BlockPos pos, net.minecraft.world.level.block.state.BlockState oldState, net.minecraft.world.level.block.state.BlockState newState) {
+        ServerLevel world = getWorld();
+        newState.onPlace(world, pos, oldState, false);
+    }
+
     private void fireNeighborChanged(BlockPos pos, ServerLevel world, Block block, BlockPos neighborPos) {
         world.getBlockState(neighborPos).neighborChanged(world, neighborPos, block, pos, false);
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/wna/WorldNativeAccess.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/wna/WorldNativeAccess.java
@@ -146,6 +146,8 @@ public interface WorldNativeAccess<NC, NBS, NP> {
 
     void notifyNeighbors(NP pos, NBS oldState, NBS newState);
 
+    default void updateBlock(NP pos, NBS oldState, NBS newState) {}
+
     void updateNeighbors(NP pos, NBS oldState, NBS newState, int recursionLimit);
 
     void onBlockStateChange(NP pos, NBS oldState, NBS newState);
@@ -184,6 +186,10 @@ public interface WorldNativeAccess<NC, NBS, NP> {
 
         // Seems used only for PoI updates
         onBlockStateChange(pos, oldState, blockState1);
+
+        if (sideEffectSet.shouldApply(SideEffect.UPDATE)) {
+            updateBlock(pos, oldState, newState);
+        }
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/wna/WorldNativeAccess.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/wna/WorldNativeAccess.java
@@ -97,6 +97,10 @@ public interface WorldNativeAccess<NC, NBS, NP> {
         NBS oldData = toNative(previousType);
         NBS newData = getBlockState(chunk, pos);
 
+        if (sideEffectSet.shouldApply(SideEffect.UPDATE)) {
+            updateBlock(pos, oldData, newData);
+        }
+
         if (sideEffectSet.getState(SideEffect.LIGHTING) == SideEffect.State.ON) {
             updateLightingForBlock(pos);
         }
@@ -187,10 +191,6 @@ public interface WorldNativeAccess<NC, NBS, NP> {
 
         // Seems used only for PoI updates
         onBlockStateChange(pos, oldState, blockState1);
-
-        if (sideEffectSet.shouldApply(SideEffect.UPDATE)) {
-            updateBlock(pos, oldState, newState);
-        }
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/wna/WorldNativeAccess.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/wna/WorldNativeAccess.java
@@ -146,7 +146,8 @@ public interface WorldNativeAccess<NC, NBS, NP> {
 
     void notifyNeighbors(NP pos, NBS oldState, NBS newState);
 
-    default void updateBlock(NP pos, NBS oldState, NBS newState) {}
+    default void updateBlock(NP pos, NBS oldState, NBS newState) {
+    }
 
     void updateNeighbors(NP pos, NBS oldState, NBS newState, int recursionLimit);
 

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/internal/FabricWorldNativeAccess.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/internal/FabricWorldNativeAccess.java
@@ -142,6 +142,12 @@ public class FabricWorldNativeAccess implements WorldNativeAccess<LevelChunk, Bl
     }
 
     @Override
+    public void updateBlock(BlockPos pos, BlockState oldState, BlockState newState) {
+        Level world = getWorld();
+        newState.onPlace(world, pos, oldState, false);
+    }
+
+    @Override
     public void updateNeighbors(BlockPos pos, BlockState oldState, BlockState newState, int recursionLimit) {
         Level world = getWorld();
         oldState.updateIndirectNeighbourShapes(world, pos, NOTIFY, recursionLimit);

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/internal/ForgeWorldNativeAccess.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/internal/ForgeWorldNativeAccess.java
@@ -146,6 +146,12 @@ public class ForgeWorldNativeAccess implements WorldNativeAccess<LevelChunk, Blo
     }
 
     @Override
+    public void updateBlock(BlockPos pos, BlockState oldState, BlockState newState) {
+        ServerLevel world = getWorld();
+        newState.onPlace(world, pos, oldState, false);
+    }
+
+    @Override
     public void updateNeighbors(BlockPos pos, BlockState oldState, BlockState newState, int recursionLimit) {
         ServerLevel world = getWorld();
         oldState.updateIndirectNeighbourShapes(world, pos, NOTIFY, recursionLimit);

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/internal/SpongeWorldNativeAccess.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/internal/SpongeWorldNativeAccess.java
@@ -138,6 +138,12 @@ public class SpongeWorldNativeAccess implements WorldNativeAccess<LevelChunk, Bl
     }
 
     @Override
+    public void updateBlock(BlockPos pos, BlockState oldState, BlockState newState) {
+        ServerLevel world = getWorld();
+        newState.onPlace(world, pos, oldState, false);
+    }
+
+    @Override
     public void updateNeighbors(BlockPos pos, BlockState oldState, BlockState newState, int recursionLimit) {
         ServerLevel world = getWorld();
         oldState.updateNeighbourShapes(world, pos, NOTIFY, recursionLimit);


### PR DESCRIPTION
Allows the UPDATE side effect to be applied later. It's default for now to not break the old adapters, but can be made non-default in 7.3.0

Fixes https://github.com/EngineHub/WorldEdit/issues/2027