### PR TITLE
[1.16.5] Updated to Forge Permission API

### DIFF
--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePermissionsProvider.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePermissionsProvider.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit.forge;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.world.GameType;
 import net.minecraftforge.fml.server.ServerLifecycleHooks;
+import net.minecraftforge.server.permission.DefaultPermissionLevel;
 import net.minecraftforge.server.permission.PermissionAPI;
 
 public interface ForgePermissionsProvider {
@@ -48,6 +49,7 @@ public interface ForgePermissionsProvider {
 
         @Override
         public void registerPermission(String permission) {
+            PermissionAPI.registerNode(permission, DefaultPermissionLevel.OP, "");
         }
     }
 

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePermissionsProvider.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePermissionsProvider.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit.forge;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.world.GameType;
 import net.minecraftforge.fml.server.ServerLifecycleHooks;
+import net.minecraftforge.server.permission.PermissionAPI;
 
 public interface ForgePermissionsProvider {
 
@@ -41,8 +42,8 @@ public interface ForgePermissionsProvider {
         public boolean hasPermission(ServerPlayerEntity player, String permission) {
             ForgeConfiguration configuration = platform.getConfiguration();
             return configuration.cheatMode
-                || ServerLifecycleHooks.getCurrentServer().getPlayerList().canSendCommands(player.getGameProfile())
-                || (configuration.creativeEnable && player.interactionManager.getGameType() == GameType.CREATIVE);
+                || PermissionAPI.hasPermission(player, permission)
+                || (configuration.creativeEnable && player.interactionManager.isCreative());
         }
 
         @Override

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePermissionsProvider.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePermissionsProvider.java
@@ -20,9 +20,7 @@
 package com.sk89q.worldedit.forge;
 
 import net.minecraft.entity.player.ServerPlayerEntity;
-import net.minecraft.world.GameType;
 import net.minecraftforge.fml.server.ServerLifecycleHooks;
-import net.minecraftforge.server.permission.DefaultPermissionLevel;
 import net.minecraftforge.server.permission.PermissionAPI;
 
 public interface ForgePermissionsProvider {

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePermissionsProvider.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePermissionsProvider.java
@@ -43,13 +43,13 @@ public interface ForgePermissionsProvider {
         public boolean hasPermission(ServerPlayerEntity player, String permission) {
             ForgeConfiguration configuration = platform.getConfiguration();
             return configuration.cheatMode
+                || ServerLifecycleHooks.getCurrentServer().getPlayerList().canSendCommands(player.getGameProfile())
                 || PermissionAPI.hasPermission(player, permission)
                 || (configuration.creativeEnable && player.interactionManager.isCreative());
         }
 
         @Override
         public void registerPermission(String permission) {
-            PermissionAPI.registerNode(permission, DefaultPermissionLevel.OP, "");
         }
     }
 


### PR DESCRIPTION
My original plan was to also make a PR for 1.18.2, however the PermissionAPI has drastically changed, and I'm not too experienced in 1.18 yet.

I'm hoping this is the right way to create a PR for 1.16.

This is a simple change, that replaces the `canSendCommands` call with the permission api call.
This allows for permission mods to replace the PermissionAPI and have their own checks. Under the hood, the permission API call, if no permission value found, it calls the `ServerLifecycleHooks.getCurrentServer().getPlayerList().canSendCommands(player.getGameProfile())`

This was tested with FTBRanks for 1.16.5, where I gave a group the permissions for `worldedit.wand` and `worldedit.selection.pos`
If the 2nd permission wasn't given it popped up with the WE perm error message, which to me indicated that it worked, plus I could only run the `//wand` command and nothing else.