### PR TITLE
Increase default BlockState count

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/block/BlockStateIdAccess.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/block/BlockStateIdAccess.java
@@ -32,7 +32,7 @@ import static com.google.common.base.Preconditions.checkState;
 public final class BlockStateIdAccess {
 
     private static final int INVALID_ID = -1;
-    private static final int EXPECTED_BLOCK_COUNT = 2 << 13;
+    private static final int EXPECTED_BLOCK_COUNT = 2 << 14;
     private static final Int2ObjectOpenHashMap<BlockState> TO_STATE =
         new Int2ObjectOpenHashMap<>(EXPECTED_BLOCK_COUNT);
 


### PR DESCRIPTION
Bumps default blockstate count to prevent an extra resize of the map

Fixes https://github.com/EngineHub/WorldEdit/issues/2098