### PR TITLE
Cache properties to reduce startup memory

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1.17.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_17_R1_2/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.17.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_17_R1_2/PaperweightAdapter.java
@@ -500,6 +500,26 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property, Property<?>> propertyCache = CacheBuilder.newBuilder().build(new CacheLoader<net.minecraft.world.level.block.state.properties.Property, Property<?>>() {
+        @Override
+        public Property<?> load(net.minecraft.world.level.block.state.properties.Property state) throws Exception {
+            if (state instanceof net.minecraft.world.level.block.state.properties.BooleanProperty) {
+                return new BooleanProperty(state.getName(), ImmutableList.copyOf(state.getPossibleValues()));
+            } else if (state instanceof DirectionProperty) {
+                return new DirectionalProperty(state.getName(),
+                    (List<Direction>) state.getPossibleValues().stream().map(e -> Direction.valueOf(((StringRepresentable) e).getSerializedName().toUpperCase(Locale.ROOT))).collect(Collectors.toList()));
+            } else if (state instanceof net.minecraft.world.level.block.state.properties.EnumProperty) {
+                return new EnumProperty(state.getName(),
+                    (List<String>) state.getPossibleValues().stream().map(e -> ((StringRepresentable) e).getSerializedName()).collect(Collectors.toList()));
+            } else if (state instanceof net.minecraft.world.level.block.state.properties.IntegerProperty) {
+                return new IntegerProperty(state.getName(), ImmutableList.copyOf(state.getPossibleValues()));
+            } else {
+                throw new IllegalArgumentException("WorldEdit needs an update to support " + state.getClass().getSimpleName());
+            }
+        }
+    });
+
+    @SuppressWarnings({ "rawtypes" })
     @Override
     public Map<String, ? extends Property<?>> getProperties(BlockType blockType) {
         Map<String, Property<?>> properties = Maps.newTreeMap(String::compareTo);
@@ -507,21 +527,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         StateDefinition<Block, net.minecraft.world.level.block.state.BlockState> blockStateList =
             block.getStateDefinition();
         for (net.minecraft.world.level.block.state.properties.Property state : blockStateList.getProperties()) {
-            Property property;
-            if (state instanceof net.minecraft.world.level.block.state.properties.BooleanProperty) {
-                property = new BooleanProperty(state.getName(), ImmutableList.copyOf(state.getPossibleValues()));
-            } else if (state instanceof DirectionProperty) {
-                property = new DirectionalProperty(state.getName(),
-                    (List<Direction>) state.getPossibleValues().stream().map(e -> Direction.valueOf(((StringRepresentable) e).getSerializedName().toUpperCase(Locale.ROOT))).collect(Collectors.toList()));
-            } else if (state instanceof net.minecraft.world.level.block.state.properties.EnumProperty) {
-                property = new EnumProperty(state.getName(),
-                    (List<String>) state.getPossibleValues().stream().map(e -> ((StringRepresentable) e).getSerializedName()).collect(Collectors.toList()));
-            } else if (state instanceof net.minecraft.world.level.block.state.properties.IntegerProperty) {
-                property = new IntegerProperty(state.getName(), ImmutableList.copyOf(state.getPossibleValues()));
-            } else {
-                throw new IllegalArgumentException("WorldEdit needs an update to support " + state.getClass().getSimpleName());
-            }
-
+            Property<?> property = propertyCache.getUnchecked(state);
             properties.put(property.getName(), property);
         }
         return properties;

--- a/worldedit-bukkit/adapters/adapter-1.17.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_17_R1_2/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.17.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_17_R1_2/PaperweightAdapter.java
@@ -23,7 +23,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.mojang.datafixers.util.Either;
@@ -151,6 +150,7 @@ import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
@@ -500,7 +500,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property, Property<?>> propertyCache = CacheBuilder.newBuilder().build(new CacheLoader<net.minecraft.world.level.block.state.properties.Property, Property<?>>() {
+    private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property, Property<?>> PROPERTY_CACHE = CacheBuilder.newBuilder().build(new CacheLoader<net.minecraft.world.level.block.state.properties.Property, Property<?>>() {
         @Override
         public Property<?> load(net.minecraft.world.level.block.state.properties.Property state) throws Exception {
             if (state instanceof net.minecraft.world.level.block.state.properties.BooleanProperty) {
@@ -522,12 +522,12 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     @SuppressWarnings({ "rawtypes" })
     @Override
     public Map<String, ? extends Property<?>> getProperties(BlockType blockType) {
-        Map<String, Property<?>> properties = Maps.newTreeMap(String::compareTo);
+        Map<String, Property<?>> properties = new TreeMap<>();
         Block block = getBlockFromType(blockType);
         StateDefinition<Block, net.minecraft.world.level.block.state.BlockState> blockStateList =
             block.getStateDefinition();
         for (net.minecraft.world.level.block.state.properties.Property state : blockStateList.getProperties()) {
-            Property<?> property = propertyCache.getUnchecked(state);
+            Property<?> property = PROPERTY_CACHE.getUnchecked(state);
             properties.put(property.getName(), property);
         }
         return properties;

--- a/worldedit-bukkit/adapters/adapter-1.18.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_18_R2/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.18.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_18_R2/PaperweightAdapter.java
@@ -23,7 +23,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.mojang.datafixers.util.Either;
@@ -151,6 +150,7 @@ import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
@@ -491,7 +491,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property, Property<?>> propertyCache = CacheBuilder.newBuilder().build(new CacheLoader<net.minecraft.world.level.block.state.properties.Property, Property<?>>() {
+    private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property, Property<?>> PROPERTY_CACHE = CacheBuilder.newBuilder().build(new CacheLoader<net.minecraft.world.level.block.state.properties.Property, Property<?>>() {
         @Override
         public Property<?> load(net.minecraft.world.level.block.state.properties.Property state) throws Exception {
             if (state instanceof net.minecraft.world.level.block.state.properties.BooleanProperty) {
@@ -513,12 +513,12 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     @SuppressWarnings({ "rawtypes" })
     @Override
     public Map<String, ? extends Property<?>> getProperties(BlockType blockType) {
-        Map<String, Property<?>> properties = Maps.newTreeMap(String::compareTo);
+        Map<String, Property<?>> properties = new TreeMap<>();
         Block block = getBlockFromType(blockType);
         StateDefinition<Block, net.minecraft.world.level.block.state.BlockState> blockStateList =
             block.getStateDefinition();
         for (net.minecraft.world.level.block.state.properties.Property state : blockStateList.getProperties()) {
-            Property<?> property = propertyCache.getUnchecked(state);
+            Property<?> property = PROPERTY_CACHE.getUnchecked(state);
             properties.put(property.getName(), property);
         }
         return properties;

--- a/worldedit-bukkit/adapters/adapter-1.18.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_18_R2/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.18.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_18_R2/PaperweightAdapter.java
@@ -491,6 +491,26 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property, Property<?>> propertyCache = CacheBuilder.newBuilder().build(new CacheLoader<net.minecraft.world.level.block.state.properties.Property, Property<?>>() {
+        @Override
+        public Property<?> load(net.minecraft.world.level.block.state.properties.Property state) throws Exception {
+            if (state instanceof net.minecraft.world.level.block.state.properties.BooleanProperty) {
+                return new BooleanProperty(state.getName(), ImmutableList.copyOf(state.getPossibleValues()));
+            } else if (state instanceof DirectionProperty) {
+                return new DirectionalProperty(state.getName(),
+                    (List<Direction>) state.getPossibleValues().stream().map(e -> Direction.valueOf(((StringRepresentable) e).getSerializedName().toUpperCase(Locale.ROOT))).collect(Collectors.toList()));
+            } else if (state instanceof net.minecraft.world.level.block.state.properties.EnumProperty) {
+                return new EnumProperty(state.getName(),
+                    (List<String>) state.getPossibleValues().stream().map(e -> ((StringRepresentable) e).getSerializedName()).collect(Collectors.toList()));
+            } else if (state instanceof net.minecraft.world.level.block.state.properties.IntegerProperty) {
+                return new IntegerProperty(state.getName(), ImmutableList.copyOf(state.getPossibleValues()));
+            } else {
+                throw new IllegalArgumentException("WorldEdit needs an update to support " + state.getClass().getSimpleName());
+            }
+        }
+    });
+
+    @SuppressWarnings({ "rawtypes" })
     @Override
     public Map<String, ? extends Property<?>> getProperties(BlockType blockType) {
         Map<String, Property<?>> properties = Maps.newTreeMap(String::compareTo);
@@ -498,21 +518,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         StateDefinition<Block, net.minecraft.world.level.block.state.BlockState> blockStateList =
             block.getStateDefinition();
         for (net.minecraft.world.level.block.state.properties.Property state : blockStateList.getProperties()) {
-            Property property;
-            if (state instanceof net.minecraft.world.level.block.state.properties.BooleanProperty) {
-                property = new BooleanProperty(state.getName(), ImmutableList.copyOf(state.getPossibleValues()));
-            } else if (state instanceof DirectionProperty) {
-                property = new DirectionalProperty(state.getName(),
-                    (List<Direction>) state.getPossibleValues().stream().map(e -> Direction.valueOf(((StringRepresentable) e).getSerializedName().toUpperCase(Locale.ROOT))).collect(Collectors.toList()));
-            } else if (state instanceof net.minecraft.world.level.block.state.properties.EnumProperty) {
-                property = new EnumProperty(state.getName(),
-                    (List<String>) state.getPossibleValues().stream().map(e -> ((StringRepresentable) e).getSerializedName()).collect(Collectors.toList()));
-            } else if (state instanceof net.minecraft.world.level.block.state.properties.IntegerProperty) {
-                property = new IntegerProperty(state.getName(), ImmutableList.copyOf(state.getPossibleValues()));
-            } else {
-                throw new IllegalArgumentException("WorldEdit needs an update to support " + state.getClass().getSimpleName());
-            }
-
+            Property<?> property = propertyCache.getUnchecked(state);
             properties.put(property.getName(), property);
         }
         return properties;

--- a/worldedit-bukkit/adapters/adapter-1.18/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_18_R1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.18/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_18_R1/PaperweightAdapter.java
@@ -23,7 +23,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.mojang.datafixers.util.Either;

--- a/worldedit-bukkit/adapters/adapter-1.18/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_18_R1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.18/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_18_R1/PaperweightAdapter.java
@@ -491,6 +491,26 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property, Property<?>> propertyCache = CacheBuilder.newBuilder().build(new CacheLoader<net.minecraft.world.level.block.state.properties.Property, Property<?>>() {
+        @Override
+        public Property<?> load(net.minecraft.world.level.block.state.properties.Property state) throws Exception {
+            if (state instanceof net.minecraft.world.level.block.state.properties.BooleanProperty) {
+                return new BooleanProperty(state.getName(), ImmutableList.copyOf(state.getPossibleValues()));
+            } else if (state instanceof DirectionProperty) {
+                return new DirectionalProperty(state.getName(),
+                    (List<Direction>) state.getPossibleValues().stream().map(e -> Direction.valueOf(((StringRepresentable) e).getSerializedName().toUpperCase(Locale.ROOT))).collect(Collectors.toList()));
+            } else if (state instanceof net.minecraft.world.level.block.state.properties.EnumProperty) {
+                return new EnumProperty(state.getName(),
+                    (List<String>) state.getPossibleValues().stream().map(e -> ((StringRepresentable) e).getSerializedName()).collect(Collectors.toList()));
+            } else if (state instanceof net.minecraft.world.level.block.state.properties.IntegerProperty) {
+                return new IntegerProperty(state.getName(), ImmutableList.copyOf(state.getPossibleValues()));
+            } else {
+                throw new IllegalArgumentException("WorldEdit needs an update to support " + state.getClass().getSimpleName());
+            }
+        }
+    });
+
+    @SuppressWarnings({ "rawtypes" })
     @Override
     public Map<String, ? extends Property<?>> getProperties(BlockType blockType) {
         Map<String, Property<?>> properties = Maps.newTreeMap(String::compareTo);
@@ -498,21 +518,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         StateDefinition<Block, net.minecraft.world.level.block.state.BlockState> blockStateList =
             block.getStateDefinition();
         for (net.minecraft.world.level.block.state.properties.Property state : blockStateList.getProperties()) {
-            Property property;
-            if (state instanceof net.minecraft.world.level.block.state.properties.BooleanProperty) {
-                property = new BooleanProperty(state.getName(), ImmutableList.copyOf(state.getPossibleValues()));
-            } else if (state instanceof DirectionProperty) {
-                property = new DirectionalProperty(state.getName(),
-                    (List<Direction>) state.getPossibleValues().stream().map(e -> Direction.valueOf(((StringRepresentable) e).getSerializedName().toUpperCase(Locale.ROOT))).collect(Collectors.toList()));
-            } else if (state instanceof net.minecraft.world.level.block.state.properties.EnumProperty) {
-                property = new EnumProperty(state.getName(),
-                    (List<String>) state.getPossibleValues().stream().map(e -> ((StringRepresentable) e).getSerializedName()).collect(Collectors.toList()));
-            } else if (state instanceof net.minecraft.world.level.block.state.properties.IntegerProperty) {
-                property = new IntegerProperty(state.getName(), ImmutableList.copyOf(state.getPossibleValues()));
-            } else {
-                throw new IllegalArgumentException("WorldEdit needs an update to support " + state.getClass().getSimpleName());
-            }
-
+            Property<?> property = propertyCache.getUnchecked(state);
             properties.put(property.getName(), property);
         }
         return properties;

--- a/worldedit-bukkit/adapters/adapter-1.18/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_18_R1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.18/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_18_R1/PaperweightAdapter.java
@@ -151,6 +151,7 @@ import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
@@ -491,7 +492,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property, Property<?>> propertyCache = CacheBuilder.newBuilder().build(new CacheLoader<net.minecraft.world.level.block.state.properties.Property, Property<?>>() {
+    private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property, Property<?>> PROPERTY_CACHE = CacheBuilder.newBuilder().build(new CacheLoader<net.minecraft.world.level.block.state.properties.Property, Property<?>>() {
         @Override
         public Property<?> load(net.minecraft.world.level.block.state.properties.Property state) throws Exception {
             if (state instanceof net.minecraft.world.level.block.state.properties.BooleanProperty) {
@@ -513,12 +514,12 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     @SuppressWarnings({ "rawtypes" })
     @Override
     public Map<String, ? extends Property<?>> getProperties(BlockType blockType) {
-        Map<String, Property<?>> properties = Maps.newTreeMap(String::compareTo);
+        Map<String, Property<?>> properties = new TreeMap<>();
         Block block = getBlockFromType(blockType);
         StateDefinition<Block, net.minecraft.world.level.block.state.BlockState> blockStateList =
             block.getStateDefinition();
         for (net.minecraft.world.level.block.state.properties.Property state : blockStateList.getProperties()) {
-            Property<?> property = propertyCache.getUnchecked(state);
+            Property<?> property = PROPERTY_CACHE.getUnchecked(state);
             properties.put(property.getName(), property);
         }
         return properties;

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/internal/FabricTransmogrifier.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/internal/FabricTransmogrifier.java
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
  */
 public class FabricTransmogrifier {
 
-    private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property<?>, Property<?>> propertyCache = CacheBuilder.newBuilder().build(new CacheLoader<>() {
+    private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property<?>, Property<?>> PROPERTY_CACHE = CacheBuilder.newBuilder().build(new CacheLoader<>() {
         @Override
         public Property<?> load(net.minecraft.world.level.block.state.properties.Property<?> property) throws Exception {
             if (property instanceof net.minecraft.world.level.block.state.properties.BooleanProperty) {
@@ -74,7 +74,7 @@ public class FabricTransmogrifier {
     });
 
     public static Property<?> transmogToWorldEditProperty(net.minecraft.world.level.block.state.properties.Property<?> property) {
-        return propertyCache.getUnchecked(property);
+        return PROPERTY_CACHE.getUnchecked(property);
     }
 
     private static Map<Property<?>, Object> transmogToWorldEditProperties(BlockType block, Map<net.minecraft.world.level.block.state.properties.Property<?>, Comparable<?>> mcProps) {

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/internal/ForgeTransmogrifier.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/internal/ForgeTransmogrifier.java
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
  */
 public class ForgeTransmogrifier {
 
-    private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property<?>, Property<?>> propertyCache = CacheBuilder.newBuilder().build(new CacheLoader<>() {
+    private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property<?>, Property<?>> PROPERTY_CACHE = CacheBuilder.newBuilder().build(new CacheLoader<>() {
         @Override
         public Property<?> load(net.minecraft.world.level.block.state.properties.Property<?> property) throws Exception {
             if (property instanceof net.minecraft.world.level.block.state.properties.BooleanProperty) {
@@ -74,7 +74,7 @@ public class ForgeTransmogrifier {
     });
 
     public static Property<?> transmogToWorldEditProperty(net.minecraft.world.level.block.state.properties.Property<?> property) {
-        return propertyCache.getUnchecked(property);
+        return PROPERTY_CACHE.getUnchecked(property);
     }
 
     public static Map<Property<?>, Object> transmogToWorldEditProperties(BlockType block, Map<net.minecraft.world.level.block.state.properties.Property<?>, Comparable<?>> mcProps) {

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/internal/ForgeTransmogrifier.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/internal/ForgeTransmogrifier.java
@@ -19,6 +19,9 @@
 
 package com.sk89q.worldedit.forge.internal;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.sk89q.worldedit.forge.ForgeAdapter;
 import com.sk89q.worldedit.registry.state.BooleanProperty;
@@ -44,27 +47,34 @@ import java.util.stream.Collectors;
  */
 public class ForgeTransmogrifier {
 
+    private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property<?>, Property<?>> propertyCache = CacheBuilder.newBuilder().build(new CacheLoader<>() {
+        @Override
+        public Property<?> load(net.minecraft.world.level.block.state.properties.Property<?> property) throws Exception {
+            if (property instanceof net.minecraft.world.level.block.state.properties.BooleanProperty) {
+                return new BooleanProperty(property.getName(), ImmutableList.copyOf(((net.minecraft.world.level.block.state.properties.BooleanProperty) property).getPossibleValues()));
+            }
+            if (property instanceof net.minecraft.world.level.block.state.properties.IntegerProperty) {
+                return new IntegerProperty(property.getName(), ImmutableList.copyOf(((net.minecraft.world.level.block.state.properties.IntegerProperty) property).getPossibleValues()));
+            }
+            if (property instanceof DirectionProperty) {
+                return new DirectionalProperty(property.getName(), ((DirectionProperty) property).getPossibleValues().stream()
+                    .map(ForgeAdapter::adaptEnumFacing)
+                    .collect(Collectors.toList()));
+            }
+            if (property instanceof net.minecraft.world.level.block.state.properties.EnumProperty) {
+                // Note: do not make x.getSerializedName a method reference.
+                // It will cause runtime bootstrap exceptions.
+                //noinspection Convert2MethodRef
+                return new EnumProperty(property.getName(), ((net.minecraft.world.level.block.state.properties.EnumProperty<?>) property).getPossibleValues().stream()
+                    .map(x -> x.getSerializedName())
+                    .collect(Collectors.toList()));
+            }
+            return new IPropertyAdapter<>(property);
+        }
+    });
+
     public static Property<?> transmogToWorldEditProperty(net.minecraft.world.level.block.state.properties.Property<?> property) {
-        if (property instanceof net.minecraft.world.level.block.state.properties.BooleanProperty) {
-            return new BooleanProperty(property.getName(), ImmutableList.copyOf(((net.minecraft.world.level.block.state.properties.BooleanProperty) property).getPossibleValues()));
-        }
-        if (property instanceof net.minecraft.world.level.block.state.properties.IntegerProperty) {
-            return new IntegerProperty(property.getName(), ImmutableList.copyOf(((net.minecraft.world.level.block.state.properties.IntegerProperty) property).getPossibleValues()));
-        }
-        if (property instanceof DirectionProperty) {
-            return new DirectionalProperty(property.getName(), ((DirectionProperty) property).getPossibleValues().stream()
-                .map(ForgeAdapter::adaptEnumFacing)
-                .collect(Collectors.toList()));
-        }
-        if (property instanceof net.minecraft.world.level.block.state.properties.EnumProperty) {
-            // Note: do not make x.getSerializedName a method reference.
-            // It will cause runtime bootstrap exceptions.
-            //noinspection Convert2MethodRef
-            return new EnumProperty(property.getName(), ((net.minecraft.world.level.block.state.properties.EnumProperty<?>) property).getPossibleValues().stream()
-                .map(x -> x.getSerializedName())
-                .collect(Collectors.toList()));
-        }
-        return new IPropertyAdapter<>(property);
+        return propertyCache.getUnchecked(property);
     }
 
     public static Map<Property<?>, Object> transmogToWorldEditProperties(BlockType block, Map<net.minecraft.world.level.block.state.properties.Property<?>, Comparable<?>> mcProps) {

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/internal/SpongeTransmogrifier.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/internal/SpongeTransmogrifier.java
@@ -51,7 +51,7 @@ import java.util.stream.Collectors;
  */
 public class SpongeTransmogrifier {
 
-    private static final LoadingCache<StateProperty<?>, Property<?>> propertyCache = CacheBuilder.newBuilder().build(new CacheLoader<StateProperty<?>, Property<?>>() {
+    private static final LoadingCache<StateProperty<?>, Property<?>> PROPERTY_CACHE = CacheBuilder.newBuilder().build(new CacheLoader<StateProperty<?>, Property<?>>() {
         @Override
         public Property<?> load(StateProperty<?> property) throws Exception {
             if (property instanceof BooleanStateProperty) {
@@ -77,7 +77,7 @@ public class SpongeTransmogrifier {
     });
 
     public static Property<?> transmogToWorldEditProperty(StateProperty<?> property) {
-        return propertyCache.getUnchecked(property);
+        return PROPERTY_CACHE.getUnchecked(property);
     }
 
     private static Map<Property<?>, Object> transmogToWorldEditProperties(BlockType block, Map<StateProperty<?>, ?> mcProps) {


### PR DESCRIPTION
I don't personally believe this is the best solution here, but a better one would be breaking (Removing public constructor for properties and having a BooleanProperty.create function that returns a cached version if it exists). That'd be a WE8 change though (And one I believe we should do)

Very dirty test of loading the fabric server (with no other mods, vanilla blocks only) before and after showed a decrease in total allocation from 3228MB -> 2560MB