### PR TITLE
Fixed //stack erroring when given a count of 0

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -371,6 +371,8 @@ public class RegionCommands {
                         boolean blockUnits,
                      @ArgFlag(name = 'm', desc = "Set the include mask, non-matching blocks become air")
                          Mask mask) throws WorldEditException {
+        checkCommandArgument(count >= 1, "Count must be >= 1");
+
         Mask combinedMask;
         if (ignoreAirBlocks) {
             if (mask == null) {


### PR DESCRIPTION
Adds validation to the stack command to prevent less than 1 stacks

Fixes https://github.com/EngineHub/WorldEdit/issues/2088