### PR TITLE
Add a new blockBreakEffect method and deprecate World#playEffect

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
@@ -371,6 +371,14 @@ public class BukkitWorld extends AbstractWorld {
     }
 
     @Override
+    public boolean playBreakBlockEffect(Vector3 position, com.sk89q.worldedit.world.block.BlockState block) {
+        World world = getWorld();
+
+        world.playEffect(BukkitAdapter.adapt(world, position), Effect.STEP_SOUND, BukkitAdapter.adapt(block.getBlockType())); // Bukkit doesn't use a blockstate, instead uses material
+        return true;
+    }
+
+    @Override
     public WeatherType getWeather() {
         if (getWorld().isThundering()) {
             return WeatherTypes.THUNDER_STORM;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/AbstractWorld.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/AbstractWorld.java
@@ -31,9 +31,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.SideEffectSet;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
-import com.sk89q.worldedit.world.block.BlockType;
-import com.sk89q.worldedit.world.block.BlockTypes;
+import com.sk89q.worldedit.world.block.*;
 import com.sk89q.worldedit.world.weather.WeatherType;
 import com.sk89q.worldedit.world.weather.WeatherTypes;
 
@@ -104,7 +102,12 @@ public abstract class AbstractWorld implements World {
     }
 
     @Override
-    public boolean queueBlockBreakEffect(Platform server, BlockVector3 position, BlockType blockType, double priority) {
+    public boolean playBreakBlockEffect(Vector3 position, BlockState block) {
+        return false;
+    }
+
+    @Override
+    public boolean queueBlockBreakEffect(Platform server, BlockVector3 position, BlockState blockState, double priority) {
         if (taskId == -1) {
             taskId = server.schedule(0, 1, () -> {
                 int max = Math.max(1, Math.min(30, effectQueue.size() / 3));
@@ -122,7 +125,7 @@ public abstract class AbstractWorld implements World {
             return false;
         }
 
-        effectQueue.offer(new QueuedEffect(position.toVector3(), blockType, priority));
+        effectQueue.offer(new QueuedEffect(position.toVector3(), blockState, priority));
 
         return true;
     }
@@ -162,18 +165,17 @@ public abstract class AbstractWorld implements World {
 
     private class QueuedEffect implements Comparable<QueuedEffect> {
         private final Vector3 position;
-        private final BlockType blockType;
+        private final BlockState blockState;
         private final double priority;
 
-        private QueuedEffect(Vector3 position, BlockType blockType, double priority) {
+        private QueuedEffect(Vector3 position, BlockState blockState, double priority) {
             this.position = position;
-            this.blockType = blockType;
+            this.blockState = blockState;
             this.priority = priority;
         }
 
-        @SuppressWarnings("deprecation")
         public void play() {
-            playEffect(position, 2001, blockType.getLegacyId());
+            playBreakBlockEffect(position, blockState);
         }
 
         @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
@@ -307,8 +307,21 @@ public interface World extends Extent, Keyed {
      * @param type the effect type
      * @param data the effect data
      * @return true if the effect was played
+     * @deprecated magic numbers
      */
+    @Deprecated
     boolean playEffect(Vector3 position, int type, int data);
+
+
+    /**
+     * Plays a block break effect and sound at
+     * the given position.
+     *
+     * @param position position
+     * @param block block
+     * @return true if the effect was played
+     */
+     boolean playBreakBlockEffect(Vector3 position, BlockState block);
 
     /**
      * Queue a block break effect.
@@ -318,8 +331,23 @@ public interface World extends Extent, Keyed {
      * @param blockType the block type
      * @param priority the priority
      * @return true if the effect was played
+     * @deprecated use a blockstate instead of block type
      */
-    boolean queueBlockBreakEffect(Platform server, BlockVector3 position, BlockType blockType, double priority);
+    @Deprecated
+    default boolean queueBlockBreakEffect(Platform server, BlockVector3 position, BlockType blockType, double priority) {
+        return queueBlockBreakEffect(server, position, blockType.getDefaultState(), priority);
+    }
+
+    /**
+     * Queue a block break effect.
+     *
+     * @param server the server
+     * @param position the position
+     * @param blockState the block state
+     * @param priority the priority
+     * @return true if the effect was played
+     */
+    boolean queueBlockBreakEffect(Platform server, BlockVector3 position, BlockState blockState, double priority);
 
     /**
      * Gets the weather type of the world.

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorld.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorld.java
@@ -86,6 +86,8 @@ import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.LevelEvent;
 import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.ChunkAccess;
@@ -491,6 +493,12 @@ public class FabricWorld extends AbstractWorld {
     public boolean playEffect(Vector3 position, int type, int data) {
         // TODO update sound API
         // getWorld().playSound(type, FabricAdapter.toBlockPos(position.toBlockPoint()), data);
+        return true;
+    }
+
+    @Override
+    public boolean playBreakBlockEffect(Vector3 position, BlockState block) {
+        getWorld().globalLevelEvent(LevelEvent.PARTICLES_DESTROY_BLOCK, FabricAdapter.toBlockPos(position.toBlockPoint()), Block.getId(FabricAdapter.adapt(block)));
         return true;
     }
 

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java
@@ -83,6 +83,8 @@ import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.LevelEvent;
 import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.ChunkAccess;
@@ -474,6 +476,12 @@ public class ForgeWorld extends AbstractWorld {
     public boolean playEffect(Vector3 position, int type, int data) {
         // TODO update sound API
         // getWorld().play(type, ForgeAdapter.toBlockPos(position.toBlockPoint()), data);
+        return true;
+    }
+
+    @Override
+    public boolean playBreakBlockEffect(Vector3 position, BlockState block) {
+        getWorld().globalLevelEvent(LevelEvent.PARTICLES_DESTROY_BLOCK, ForgeAdapter.toBlockPos(position.toBlockPoint()), Block.getId(ForgeAdapter.adapt(block)));
         return true;
     }
 


### PR DESCRIPTION
- Fixes the break effect used for super pickaxe using legacy ids
- Fixes block break effect not displaying on fabric/forge
- Allows you to now queue block effects of a blockstate rather than blocktype.


Please give feedback on the deprecation of ``World#playEffect`` and the old ``World#queueBlockBreakEffect`` method.
I was also split between making a separate method for the block break effect or making some kind of generic ``playEffect(Vector3 pos, int effect, T data)`` method that would do a bunch of instanceof checks to correctly adapt the data.
If a generic play effect method is preferred rather than a specific playBreakBlockEffect method, let me know!