### PR TITLE
Only show full stacktrace with permission

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/ErrorReporting.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/ErrorReporting.java
@@ -30,12 +30,12 @@ import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
  */
 public class ErrorReporting {
     public static void trigger(Actor actor, Throwable error) {
-        actor.printError(TranslatableComponent.of("worldedit.command.error.report"));
-        actor.print(
-            TextComponent.builder(error.getClass().getName() + ": " + error.getMessage())
-                .hoverEvent(HoverEvent.showText(TextComponent.of(Throwables.getStackTraceAsString(error))))
-                .build()
-        );
+        actor.printError(TranslatableComponent.of("worledit.command.error.report"));
+        TextComponent.Builder errorBuilder = TextComponent.builder(error.getClass().getName() + ": " + error.getMessage());
+        if (actor.hasPermission("worldedit.error.detailed")) {
+            errorBuilder = errorBuilder.hoverEvent(HoverEvent.showText(TextComponent.of(Throwables.getStackTraceAsString(error))));
+        }
+        actor.print(errorBuilder.build());
     }
 
     private ErrorReporting() {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/ErrorReporting.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/ErrorReporting.java
@@ -30,7 +30,7 @@ import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
  */
 public class ErrorReporting {
     public static void trigger(Actor actor, Throwable error) {
-        actor.printError(TranslatableComponent.of("worledit.command.error.report"));
+        actor.printError(TranslatableComponent.of("worldedit.command.error.report"));
         TextComponent.Builder errorBuilder = TextComponent.builder(error.getClass().getName() + ": " + error.getMessage());
         if (actor.hasPermission("worldedit.error.detailed")) {
             errorBuilder = errorBuilder.hoverEvent(HoverEvent.showText(TextComponent.of(Throwables.getStackTraceAsString(error))));


### PR DESCRIPTION
Supersedes https://github.com/EngineHub/WorldEdit/pull/2004

When the actor has permission, an on-hover stacktrace is added to the error output message.