### PR TITLE
Fix Sponge rotation adapter

### DIFF
--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeAdapter.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeAdapter.java
@@ -147,8 +147,8 @@ public class SpongeAdapter {
         return new Location(
             adapt(location.world()),
             position,
-            (float) rotation.x(),
-            (float) rotation.y()
+            (float) rotation.y(),
+            (float) rotation.x()
         );
     }
 


### PR DESCRIPTION
Pitch and yaw are currently inverted in worldedit-sponge. This makes most player rotation based actions totally broken: compass teleportation, `//expand` etc.