### PR TITLE
Add support for Y-offsets with back direction

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -555,7 +555,12 @@ public final class WorldEdit {
 
             case "b":
             case "back":
-                return getDirectionRelative(player, 180);
+                Direction dir = getDirectionRelative(player, 180);
+                if (dir.isUpright()) {
+                    // If this is an upright direction, flip it.
+                    dir = dir == Direction.UP ? Direction.DOWN : Direction.UP;
+                }
+                return dir;
 
             case "l":
             case "left":


### PR DESCRIPTION
The direction system in WE doesn't really support up/down directions properly; this adds a hack to make it allow `back` to be used with UP/DOWN. Realistically the system should be changed to actually support the Y axis rather than just being flat directions, but that'd be a much more breaking change.

Adds https://github.com/EngineHub/WorldEdit/issues/2154