### PR TITLE
Bump FG & Loom to 1.19.2

### DIFF
--- a/worldedit-fabric/build.gradle.kts
+++ b/worldedit-fabric/build.gradle.kts
@@ -21,8 +21,8 @@ applyShadowConfiguration()
 apply(plugin = "fabric-loom")
 apply(plugin = "java-library")
 
-val minecraftVersion = "1.19.1"
-val loaderVersion = "0.14.8"
+val minecraftVersion = "1.19.2"
+val loaderVersion = "0.14.9"
 
 val fabricApiConfiguration: Configuration = configurations.create("fabricApi")
 
@@ -48,7 +48,7 @@ dependencies {
     "modImplementation"("net.fabricmc:fabric-loader:$loaderVersion")
 
     // [1] declare fabric-api dependency...
-    "fabricApi"("net.fabricmc.fabric-api:fabric-api:0.58.5+1.19.1")
+    "fabricApi"("net.fabricmc.fabric-api:fabric-api:0.59.0+1.19.2")
 
     // [2] Load the API dependencies from the fabric mod json...
     @Suppress("UNCHECKED_CAST")

--- a/worldedit-forge/build.gradle.kts
+++ b/worldedit-forge/build.gradle.kts
@@ -12,11 +12,11 @@ plugins {
 applyPlatformAndCoreConfiguration(javaRelease = 17)
 applyShadowConfiguration()
 
-val minecraftVersion = "1.19.1"
+val minecraftVersion = "1.19.2"
 val nextMajorMinecraftVersion: String = minecraftVersion.split('.').let { (useless, major) ->
     "$useless.${major.toInt() + 1}"
 }
-val forgeVersion = "42.0.0"
+val forgeVersion = "43.0.0"
 
 val apiClasspath = configurations.create("apiClasspath") {
     isCanBeResolved = true


### PR DESCRIPTION
The existing version works on 1.19.2 on both Forge & Fabric, this PR is purely bumping them for dependency reasons