### PR TITLE
Catch InvalidPathException in safeFile handler

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -81,6 +81,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -347,7 +348,7 @@ public final class WorldEdit {
             }
 
             return filePath.toFile();
-        } catch (IOException e) {
+        } catch (IOException | InvalidPathException e) {
             throw new FilenameResolutionException(filename, TranslatableComponent.of("worldedit.error.file-resolution.resolve-failed"));
         }
     }


### PR DESCRIPTION
Uses a nicer error when invalid filesystem names are used throughout various file operations, such as schematics

Closes https://github.com/EngineHub/WorldEdit/issues/2158