### PR TITLE
Work around invalid legacy values in schematics

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/MCEditSchematicReader.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/MCEditSchematicReader.java
@@ -420,7 +420,12 @@ public class MCEditSchematicReader extends NBTSchematicReader {
     }
 
     private BlockState getBlockState(int id, int data) {
-        return LegacyMapper.getInstance().getBlockFromLegacy(id, data);
+        BlockState foundBlock = LegacyMapper.getInstance().getBlockFromLegacy(id, data);
+        if (foundBlock == null && data != 0) {
+            // Some schematics contain invalid data values, so try without the data value
+            return LegacyMapper.getInstance().getBlockFromLegacy(id, 0);
+        }
+        return foundBlock;
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/LegacyMapper.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/LegacyMapper.java
@@ -154,7 +154,7 @@ public final class LegacyMapper {
     @Nullable
     public ItemType getItemFromLegacy(int legacyId, int data) {
         ItemType foundItem = stringToItemMap.get(legacyId + ":" + data);
-        if (foundItem == null) {
+        if (foundItem == null && data != 0) {
             // Some schematics contain invalid data values, so try without the data value
             return stringToItemMap.get(legacyId + ":" + 0);
         }
@@ -179,7 +179,7 @@ public final class LegacyMapper {
     @Nullable
     public BlockState getBlockFromLegacy(int legacyId, int data) {
         BlockState foundBlock = stringToBlockMap.get(legacyId + ":" + data);
-        if (foundBlock == null) {
+        if (foundBlock == null && data != 0) {
             // Some schematics contain invalid data values, so try without the data value
             return stringToBlockMap.get(legacyId + ":" + 0);
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/LegacyMapper.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/LegacyMapper.java
@@ -178,7 +178,12 @@ public final class LegacyMapper {
 
     @Nullable
     public BlockState getBlockFromLegacy(int legacyId, int data) {
-        return stringToBlockMap.get(legacyId + ":" + data);
+        BlockState foundBlock = stringToBlockMap.get(legacyId + ":" + data);
+        if (foundBlock == null) {
+            // Some schematics contain invalid data values, so try without the data value
+            return stringToBlockMap.get(legacyId + ":" + 0);
+        }
+        return foundBlock;
     }
 
     @Nullable

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/LegacyMapper.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/LegacyMapper.java
@@ -153,12 +153,7 @@ public final class LegacyMapper {
 
     @Nullable
     public ItemType getItemFromLegacy(int legacyId, int data) {
-        ItemType foundItem = stringToItemMap.get(legacyId + ":" + data);
-        if (foundItem == null && data != 0) {
-            // Some schematics contain invalid data values, so try without the data value
-            return stringToItemMap.get(legacyId + ":" + 0);
-        }
-        return foundItem;
+        return stringToItemMap.get(legacyId + ":" + data);
     }
 
     @Nullable
@@ -178,12 +173,7 @@ public final class LegacyMapper {
 
     @Nullable
     public BlockState getBlockFromLegacy(int legacyId, int data) {
-        BlockState foundBlock = stringToBlockMap.get(legacyId + ":" + data);
-        if (foundBlock == null && data != 0) {
-            // Some schematics contain invalid data values, so try without the data value
-            return stringToBlockMap.get(legacyId + ":" + 0);
-        }
-        return foundBlock;
+        return stringToBlockMap.get(legacyId + ":" + data);
     }
 
     @Nullable

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/LegacyMapper.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/LegacyMapper.java
@@ -153,7 +153,12 @@ public final class LegacyMapper {
 
     @Nullable
     public ItemType getItemFromLegacy(int legacyId, int data) {
-        return stringToItemMap.get(legacyId + ":" + data);
+        ItemType foundItem = stringToItemMap.get(legacyId + ":" + data);
+        if (foundItem == null) {
+            // Some schematics contain invalid data values, so try without the data value
+            return stringToItemMap.get(legacyId + ":" + 0);
+        }
+        return foundItem;
     }
 
     @Nullable


### PR DESCRIPTION
Not 100% happy about this; but currently a lot of legacy schematics include entirely broken blocks (Eg, `1:5` rather than `1:0`) because they used broken or poor quality world editing tools to alter the world. These are invalid post-1.13, but we can default to the default state for these blocks to at least recover _some_ of the data that was meant to be here, rather than skipping it entirely.