### PR TITLE
Add parsing support for block NBT

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/util/StringUtil.java
+++ b/worldedit-core/src/main/java/com/sk89q/util/StringUtil.java
@@ -325,9 +325,6 @@ public final class StringUtil {
         return parseListInQuotes(input, delimiter, quoteOpen, quoteClose, false);
     }
 
-    public static Pattern BLOCK_QUOTE_OPEN_PATTERN = Pattern.compile("[\\[{]");
-    public static Pattern BLOCK_QUOTE_CLOSE_PATTERN = Pattern.compile("[]}]");
-
     public static List<String> parseListInQuotes(String[] input, char delimiter, char quoteOpen, char quoteClose, boolean appendLeftover) {
         List<String> parsableBlocks = new ArrayList<>();
         StringBuilder buffer = new StringBuilder();

--- a/worldedit-core/src/main/java/com/sk89q/util/StringUtil.java
+++ b/worldedit-core/src/main/java/com/sk89q/util/StringUtil.java
@@ -24,6 +24,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * String utilities.
@@ -305,9 +307,26 @@ public final class StringUtil {
         return type;
     }
 
+    private static int indexOfRegEx(String input, Pattern pattern) {
+        Matcher m = pattern.matcher(input);
+        return m.find() ? m.start() : -1;
+    }
+
+    private static int lastIndexOfRegEx(String input, Pattern pattern) {
+        // Reverse the input string and run a forwards search on the backwards string
+        StringBuilder builder = new StringBuilder(input).reverse();
+        int reverseIndex = indexOfRegEx(builder.toString(), pattern);
+
+        // If it wasn't found return -1, otherwise take length - index - 1.
+        return (reverseIndex == -1) ? -1 : (input.length() - reverseIndex - 1);
+    }
+
     public static List<String> parseListInQuotes(String[] input, char delimiter, char quoteOpen, char quoteClose) {
         return parseListInQuotes(input, delimiter, quoteOpen, quoteClose, false);
     }
+
+    public static Pattern BLOCK_QUOTE_OPEN_PATTERN = Pattern.compile("[\\[{]");
+    public static Pattern BLOCK_QUOTE_CLOSE_PATTERN = Pattern.compile("[]}]");
 
     public static List<String> parseListInQuotes(String[] input, char delimiter, char quoteOpen, char quoteClose, boolean appendLeftover) {
         List<String> parsableBlocks = new ArrayList<>();
@@ -323,6 +342,43 @@ public final class StringUtil {
                 parsableBlocks.add(split);
             } else {
                 buffer.append(split).append(delimiter);
+            }
+        }
+        if (appendLeftover && buffer.length() != 0) {
+            parsableBlocks.add(buffer.delete(buffer.length() - 1, buffer.length()).toString());
+        }
+
+        return parsableBlocks;
+    }
+
+    public static List<String> parseListInQuotes(String[] input, char delimiter, char[] quoteOpen, char[] quoteClose, boolean appendLeftover) {
+        List<String> parsableBlocks = new ArrayList<>();
+        StringBuilder buffer = new StringBuilder();
+        int quotes = quoteOpen.length;
+        if (quotes != quoteClose.length) {
+            throw new Error("Mismatched quoteOpen and quoteClose lengths");
+        }
+        for (String split : input) {
+            boolean quoteHandled = false;
+            for (int i = 0; i < quotes; i++) {
+                if (split.indexOf(quoteOpen[i]) != -1 && split.indexOf(quoteClose[i]) == -1) {
+                    buffer.append(split).append(delimiter);
+                    quoteHandled = true;
+                    break;
+                } else if (split.indexOf(quoteClose[i]) != -1 && split.indexOf(quoteOpen[i]) == -1) {
+                    buffer.append(split);
+                    parsableBlocks.add(buffer.toString());
+                    buffer = new StringBuilder();
+                    quoteHandled = true;
+                    break;
+                }
+            }
+            if (!quoteHandled) {
+                if (buffer.length() == 0) {
+                    parsableBlocks.add(split);
+                } else {
+                    buffer.append(split).append(delimiter);
+                }
             }
         }
         if (appendLeftover && buffer.length() != 0) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/BlockFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/BlockFactory.java
@@ -59,7 +59,7 @@ public class BlockFactory extends AbstractFactory<BaseBlock> {
     public Set<BaseBlock> parseFromListInput(String input, ParserContext context) throws InputParseException {
         Set<BaseBlock> blocks = new HashSet<>();
         String[] splits = input.split(",");
-        for (String token : StringUtil.parseListInQuotes(splits, ',', '[', ']', true)) {
+        for (String token : StringUtil.parseListInQuotes(splits, ',', new char[] {'[', '{' }, new char[] {']', '}'}, true)) {
             blocks.add(parseFromInput(token, context));
         }
         return blocks;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultBlockParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultBlockParser.java
@@ -289,7 +289,7 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
 
             int stateStart = blockAndExtraData[0].indexOf('[');
             int nbtStart = blockAndExtraData[0].indexOf('{');
-            int typeEnd = stateStart == -1 ? nbtStart : stateStart;
+            int typeEnd = stateStart == -1 ? nbtStart : nbtStart == -1 ? stateStart : Math.min(nbtStart, stateStart);
 
             if (typeEnd == -1) {
                 typeString = blockAndExtraData[0];
@@ -298,7 +298,7 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
             }
 
             String stateString = null;
-            if (stateStart != -1) {
+            if (stateStart != -1 && (nbtStart == -1 || stateStart < nbtStart)) {
                 if (stateStart + 1 >= blockAndExtraData[0].length()) {
                     throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.hanging-lbracket", TextComponent.of(stateStart)));
                 }
@@ -434,7 +434,7 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
             return baseBlock;
         }
 
-        if (DeprecationUtil.isSign(blockType)) {
+        if (DeprecationUtil.isSign(blockType) && blockAndExtraData.length > 1) {
             // Allow special sign text syntax
             String[] text = new String[4];
             text[0] = blockAndExtraData.length > 1 ? blockAndExtraData[1] : "";
@@ -444,7 +444,7 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
             @SuppressWarnings("deprecation")
             SignBlock signBlock = new SignBlock(state, text);
             return signBlock;
-        } else if (blockType == BlockTypes.SPAWNER) {
+        } else if (blockType == BlockTypes.SPAWNER && (blockAndExtraData.length > 1 || blockNbtData != null)) {
             // Allow setting mob spawn type
             String mobName;
             if (blockAndExtraData.length > 1) {
@@ -463,7 +463,7 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
             @SuppressWarnings("deprecation")
             MobSpawnerBlock mobSpawnerBlock = new MobSpawnerBlock(state, mobName);
             return mobSpawnerBlock;
-        } else if (blockType == BlockTypes.PLAYER_HEAD || blockType == BlockTypes.PLAYER_WALL_HEAD) {
+        } else if ((blockType == BlockTypes.PLAYER_HEAD || blockType == BlockTypes.PLAYER_WALL_HEAD) && (blockAndExtraData.length > 1 || blockNbtData != null)) {
             // allow setting type/player/rotation
             if (blockAndExtraData.length <= 1) {
                 @SuppressWarnings("deprecation")

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultBlockParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultBlockParser.java
@@ -399,11 +399,10 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
             if (nbtString != null) {
                 LinCompoundTag otherTag;
                 try {
-                    System.out.println(nbtString);
                     otherTag = LinStringIO.readFromStringUsing(nbtString, LinCompoundTag::readFrom);
                 } catch (NbtParseException e) {
                     throw new NoMatchException(TranslatableComponent.of(
-                        "worldedit.error.invalid-nbt",
+                        "worldedit.error.parser.invalid-nbt",
                         TextComponent.of(input),
                         TextComponent.of(e.getMessage())
                     ));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultBlockParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultBlockParser.java
@@ -302,7 +302,7 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
                 if (stateStart + 1 >= blockAndExtraData[0].length()) {
                     throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.hanging-lbracket", TextComponent.of(stateStart)));
                 }
-                int stateEnd = blockAndExtraData[0].lastIndexOf(']');
+                int stateEnd = blockAndExtraData[0].indexOf(']');
                 if (stateEnd < 0) {
                     throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.missing-rbracket"));
                 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultItemParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultItemParser.java
@@ -89,11 +89,11 @@ public class DefaultItemParser extends InputParser<BaseItem> {
             } else {
                 typeString = input.substring(0, nbtStart);
                 if (nbtStart + 1 >= input.length()) {
-                    throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.hanging-lbracket", TextComponent.of(nbtStart)));
+                    throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.hanging-lbrace", TextComponent.of(nbtStart)));
                 }
                 int stateEnd = input.lastIndexOf('}');
                 if (stateEnd < 0) {
-                    throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.missing-rbracket"));
+                    throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.missing-rbrace"));
                 }
                 nbtString = input.substring(nbtStart);
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/RandomPatternParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/RandomPatternParser.java
@@ -43,7 +43,7 @@ public class RandomPatternParser extends InputParser<Pattern> {
     @Override
     public Stream<String> getSuggestions(String input, ParserContext context) {
         String[] splits = input.split(",", -1);
-        List<String> patterns = StringUtil.parseListInQuotes(splits, ',', '[', ']', true);
+        List<String> patterns = StringUtil.parseListInQuotes(splits, ',', new char[] {'[', '{' }, new char[] {']', '}'}, true);
         // get suggestions for the last token only
         String percent = null;
         String token = patterns.get(patterns.size() - 1);
@@ -65,7 +65,7 @@ public class RandomPatternParser extends InputParser<Pattern> {
         RandomPattern randomPattern = new RandomPattern();
 
         String[] splits = input.split(",", -1);
-        List<String> patterns = StringUtil.parseListInQuotes(splits, ',', '[', ']', true);
+        List<String> patterns = StringUtil.parseListInQuotes(splits, ',', new char[] {'[', '{' }, new char[] {']', '}'}, true);
         if (patterns.size() == 1) {
             return null; // let a 'single'-pattern parser handle it
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/wna/WorldNativeAccess.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/wna/WorldNativeAccess.java
@@ -67,12 +67,14 @@ public interface WorldNativeAccess<NC, NBS, NP> {
             if (block instanceof BaseBlock baseBlock) {
                 LinCompoundTag tag = baseBlock.getNbt();
                 if (tag != null) {
-                    tag = tag.toBuilder()
-                        .putString("id", baseBlock.getNbtId())
+                    LinCompoundTag.Builder tagBuilder = tag.toBuilder()
                         .putInt("x", position.getX())
                         .putInt("y", position.getY())
-                        .putInt("z", position.getZ())
-                        .build();
+                        .putInt("z", position.getZ());
+                    if (!baseBlock.getNbtId().isBlank()) {
+                        tagBuilder.putString("id", baseBlock.getNbtId());
+                    }
+                    tag = tagBuilder.build();
 
                     // update if TE changed as well
                     successful = updateTileEntity(pos, tag);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BaseBlock.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BaseBlock.java
@@ -27,6 +27,7 @@ import com.sk89q.worldedit.util.concurrency.LazyReference;
 import org.enginehub.linbus.format.snbt.LinStringIO;
 import org.enginehub.linbus.stream.exception.NbtWriteException;
 import org.enginehub.linbus.tree.LinCompoundTag;
+import org.enginehub.linbus.tree.LinStringTag;
 import org.enginehub.linbus.tree.LinTagType;
 
 import java.util.Map;
@@ -121,7 +122,8 @@ public class BaseBlock implements BlockStateHolder<BaseBlock>, TileEntityBlock {
         if (nbtData == null) {
             return "";
         }
-        return nbtData.getValue().getTag("id", LinTagType.stringTag()).value();
+        LinStringTag idTag = nbtData.getValue().findTag("id", LinTagType.stringTag());
+        return idTag != null ? idTag.value() : "";
     }
 
     @Nullable

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -401,6 +401,8 @@
     "worldedit.error.parser.negate-nothing": "Cannot negate nothing!",
     "worldedit.error.parser.hanging-lbracket": "Invalid format. Hanging bracket at '{0}'.",
     "worldedit.error.parser.missing-rbracket": "State is missing trailing ']'",
+    "worldedit.error.parser.hanging-lbrace": "Invalid format. Hanging brace at '{0}'.",
+    "worldedit.error.parser.missing-rbrace": "NBT is missing trailing '}'",
     "worldedit.error.parser.missing-random-type": "Missing the type after the % symbol for '{0}'",
     "worldedit.error.parser.clipboard.missing-coordinates": "Clipboard offset needs x,y,z coordinates.",
     "worldedit.error.parser.player-only": "Input '{0}' requires a player!",


### PR DESCRIPTION
Adds block NBT parsing support. 

Test with `//set chest{'Lock':'cake'}`, then notice you can only open the chest with an item named `cake`

Test with `//set oak_sign[rotation=12]{'is_waxed':1,'front_text':{'messages':['{"text":"a"}','{"text":"a"}','{"text":"a"}','{"text":"a","color":"red"}']}}` for a waxed sign with 'a' on every line where the last line is red