### PR TITLE
Feature to measure length of points in a polygon selection [Feature Request]

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -81,6 +81,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -347,7 +348,7 @@ public final class WorldEdit {
             }
 
             return filePath.toFile();
-        } catch (IOException e) {
+        } catch (IOException | InvalidPathException e) {
             throw new FilenameResolutionException(filename, TranslatableComponent.of("worldedit.error.file-resolution.resolve-failed"));
         }
     }


### PR DESCRIPTION
something that may be called //length that would measure, say, if I had 5 random points, it would measure the distance from 1-2, then 2-3, then 3-4, then 4-5, add all of them and output the answer. maybe you could add two optional inputs, one for where to start measuring from and one for where to end measuring from. If the values are blank it's assumed to be the first and last points in the selection respectively.