### PR TITLE
Ignore structure void by default and use a flag to paste it

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/BrushCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/BrushCommands.java
@@ -222,6 +222,8 @@ public class BrushCommands {
     public void clipboardBrush(Player player, LocalSession session,
                                @Switch(name = 'a', desc = "Don't paste air from the clipboard")
                                    boolean ignoreAir,
+                               @Switch(name = 'v', desc = "Include structure void blocks")
+                                   boolean pasteStructureVoid,
                                @Switch(name = 'o', desc = "Paste starting at the target location, instead of centering on it")
                                    boolean usingOrigin,
                                @Switch(name = 'e', desc = "Paste entities if available")
@@ -243,9 +245,9 @@ public class BrushCommands {
         worldEdit.checkMaxBrushRadius(size.getBlockY() / 2D - 1);
         worldEdit.checkMaxBrushRadius(size.getBlockZ() / 2D - 1);
 
-        BrushTool tool = session.forceBrush(
+        session.forceBrush(
             player.getItemInHand(HandSide.MAIN_HAND).getType(),
-            new ClipboardBrush(newHolder, ignoreAir, usingOrigin, pasteEntities, pasteBiomes, sourceMask),
+            new ClipboardBrush(newHolder, ignoreAir, !pasteStructureVoid, usingOrigin, pasteEntities, pasteBiomes, sourceMask),
             "worldedit.brush.clipboard"
         );
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ClipboardCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ClipboardCommands.java
@@ -151,6 +151,8 @@ public class ClipboardCommands {
     public void paste(Actor actor, World world, LocalSession session, EditSession editSession,
                       @Switch(name = 'a', desc = "Skip air blocks")
                           boolean ignoreAirBlocks,
+                      @Switch(name = 'v', desc = "Include structure void blocks")
+                          boolean pasteStructureVoid,
                       @Switch(name = 'o', desc = "Paste at the original position")
                           boolean atOrigin,
                       @Switch(name = 's', desc = "Select the region after pasting")
@@ -176,6 +178,7 @@ public class ClipboardCommands {
                     .createPaste(editSession)
                     .to(to)
                     .ignoreAirBlocks(ignoreAirBlocks)
+                    .ignoreStructureVoidBlocks(!pasteStructureVoid)
                     .copyBiomes(pasteBiomes)
                     .copyEntities(pasteEntities)
                     .maskSource(sourceMask)

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/ClipboardBrush.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/ClipboardBrush.java
@@ -41,25 +41,13 @@ public class ClipboardBrush implements Brush {
     private final Mask sourceMask;
 
     public ClipboardBrush(ClipboardHolder holder, boolean ignoreAirBlocks, boolean usingOrigin) {
-        this.holder = holder;
-        this.ignoreAirBlocks = ignoreAirBlocks;
-        this.ignoreStructureVoidBlocks = true;
-        this.usingOrigin = usingOrigin;
-        this.pasteBiomes = false;
-        this.pasteEntities = false;
-        this.sourceMask = null;
+        this(holder, ignoreAirBlocks, usingOrigin, false, false, null);
     }
 
     @Deprecated
     public ClipboardBrush(ClipboardHolder holder, boolean ignoreAirBlocks, boolean usingOrigin, boolean pasteEntities,
                           boolean pasteBiomes, Mask sourceMask) {
-        this.holder = holder;
-        this.ignoreAirBlocks = ignoreAirBlocks;
-        this.ignoreStructureVoidBlocks = true;
-        this.usingOrigin = usingOrigin;
-        this.pasteEntities = pasteEntities;
-        this.pasteBiomes = pasteBiomes;
-        this.sourceMask = sourceMask;
+        this(holder, ignoreAirBlocks, false, usingOrigin, pasteEntities, pasteBiomes, sourceMask);
     }
 
     public ClipboardBrush(ClipboardHolder holder, boolean ignoreAirBlocks, boolean ignoreStructureVoidBlocks,

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/ClipboardBrush.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/ClipboardBrush.java
@@ -34,6 +34,7 @@ public class ClipboardBrush implements Brush {
 
     private final ClipboardHolder holder;
     private final boolean ignoreAirBlocks;
+    private final boolean ignoreStructureVoidBlocks;
     private final boolean usingOrigin;
     private final boolean pasteEntities;
     private final boolean pasteBiomes;
@@ -42,16 +43,30 @@ public class ClipboardBrush implements Brush {
     public ClipboardBrush(ClipboardHolder holder, boolean ignoreAirBlocks, boolean usingOrigin) {
         this.holder = holder;
         this.ignoreAirBlocks = ignoreAirBlocks;
+        this.ignoreStructureVoidBlocks = true;
         this.usingOrigin = usingOrigin;
         this.pasteBiomes = false;
         this.pasteEntities = false;
         this.sourceMask = null;
     }
 
+    @Deprecated
     public ClipboardBrush(ClipboardHolder holder, boolean ignoreAirBlocks, boolean usingOrigin, boolean pasteEntities,
                           boolean pasteBiomes, Mask sourceMask) {
         this.holder = holder;
         this.ignoreAirBlocks = ignoreAirBlocks;
+        this.ignoreStructureVoidBlocks = true;
+        this.usingOrigin = usingOrigin;
+        this.pasteEntities = pasteEntities;
+        this.pasteBiomes = pasteBiomes;
+        this.sourceMask = sourceMask;
+    }
+
+    public ClipboardBrush(ClipboardHolder holder, boolean ignoreAirBlocks, boolean ignoreStructureVoidBlocks,
+                          boolean usingOrigin, boolean pasteEntities, boolean pasteBiomes, Mask sourceMask) {
+        this.holder = holder;
+        this.ignoreAirBlocks = ignoreAirBlocks;
+        this.ignoreStructureVoidBlocks = ignoreStructureVoidBlocks;
         this.usingOrigin = usingOrigin;
         this.pasteEntities = pasteEntities;
         this.pasteBiomes = pasteBiomes;
@@ -68,6 +83,7 @@ public class ClipboardBrush implements Brush {
                 .createPaste(editSession)
                 .to(usingOrigin ? position : position.subtract(centerOffset))
                 .ignoreAirBlocks(ignoreAirBlocks)
+                .ignoreStructureVoidBlocks(ignoreStructureVoidBlocks)
                 .copyEntities(pasteEntities)
                 .copyBiomes(pasteBiomes)
                 .maskSource(sourceMask)

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/PasteBuilder.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/PasteBuilder.java
@@ -108,7 +108,9 @@ public class PasteBuilder {
      * Set whether structure void blocks in the source are skipped over when pasting.
      *
      * <p>
-     * This defaults to true, to better align to how Minecraft intends these blocks to function.
+     * This currently defaults to false. In the next major version this will default to true, to better align to how
+     * Minecraft intends these blocks to function. It's recommended to set this if the value of this matters for you,
+     * even if it currently matches the default.
      * </p>
      *
      * @param ignoreStructureVoidBlocks value to set it to

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/PasteBuilder.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/PasteBuilder.java
@@ -48,7 +48,7 @@ public class PasteBuilder {
 
     private BlockVector3 to = BlockVector3.ZERO;
     private boolean ignoreAirBlocks;
-    private boolean ignoreStructureVoidBlocks = true; // default to true as it's their intended purpose
+    private boolean ignoreStructureVoidBlocks; // TODO Make true in WE8
     private boolean copyEntities = true; // default because it used to be this way
     private boolean copyBiomes;
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/PasteBuilder.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/PasteBuilder.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit.session;
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
 import com.sk89q.worldedit.extent.transform.BlockTransformExtent;
+import com.sk89q.worldedit.function.mask.BlockTypeMask;
 import com.sk89q.worldedit.function.mask.ExistingBlockMask;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.mask.MaskIntersection;
@@ -30,6 +31,7 @@ import com.sk89q.worldedit.function.operation.ForwardExtentCopy;
 import com.sk89q.worldedit.function.operation.Operation;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.transform.Transform;
+import com.sk89q.worldedit.world.block.BlockTypes;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -46,6 +48,7 @@ public class PasteBuilder {
 
     private BlockVector3 to = BlockVector3.ZERO;
     private boolean ignoreAirBlocks;
+    private boolean ignoreStructureVoidBlocks = true; // default to true as it's their intended purpose
     private boolean copyEntities = true; // default because it used to be this way
     private boolean copyBiomes;
 
@@ -102,6 +105,21 @@ public class PasteBuilder {
     }
 
     /**
+     * Set whether structure void blocks in the source are skipped over when pasting.
+     *
+     * <p>
+     * This defaults to true, to better align to how Minecraft intends these blocks to function.
+     * </p>
+     *
+     * @param ignoreStructureVoidBlocks value to set it to
+     * @return This builder instance
+     */
+    public PasteBuilder ignoreStructureVoidBlocks(boolean ignoreStructureVoidBlocks) {
+        this.ignoreStructureVoidBlocks = ignoreStructureVoidBlocks;
+        return this;
+    }
+
+    /**
      * Set whether the copy should include source entities.
      * Note that this is true by default for legacy reasons.
      *
@@ -133,12 +151,19 @@ public class PasteBuilder {
         BlockTransformExtent extent = new BlockTransformExtent(clipboard, transform);
         ForwardExtentCopy copy = new ForwardExtentCopy(extent, clipboard.getRegion(), clipboard.getOrigin(), targetExtent, to);
         copy.setTransform(transform);
+
+        Mask combinedMask = sourceMask;
         if (ignoreAirBlocks) {
-            copy.setSourceMask(sourceMask == Masks.alwaysTrue() ? new ExistingBlockMask(clipboard)
-                    : new MaskIntersection(sourceMask, new ExistingBlockMask(clipboard)));
-        } else {
-            copy.setSourceMask(sourceMask);
+            combinedMask = combinedMask == Masks.alwaysTrue() ? new ExistingBlockMask(clipboard)
+                : new MaskIntersection(combinedMask, new ExistingBlockMask(clipboard));
         }
+        if (ignoreStructureVoidBlocks) {
+            Mask structureVoidMask = Masks.negate(new BlockTypeMask(clipboard, BlockTypes.STRUCTURE_VOID));
+            combinedMask = combinedMask == Masks.alwaysTrue() ? structureVoidMask
+                : new MaskIntersection(combinedMask, structureVoidMask);
+        }
+
+        copy.setSourceMask(combinedMask);
         copy.setCopyingEntities(copyEntities);
         copy.setCopyingBiomes(copyBiomes && clipboard.hasBiomes());
         return copy;


### PR DESCRIPTION
Given Minecraft intends these to be a "blank" space for structure pasting, it makes sense for us to ignore these by default. I've added a flag to re-enable pasting these