### PR TITLE
Fixed worldedit-bukkit loading on Windows

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitConfiguration.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitConfiguration.java
@@ -67,7 +67,7 @@ public class BukkitConfiguration extends YAMLConfiguration {
 
     private void migrate(String file, String name) {
         Path fromDir = Path.of(file);
-        if (!fromDir.toAbsolutePath().startsWith(Path.of(".").toAbsolutePath())) {
+        if (!fromDir.toAbsolutePath().startsWith(Path.of("").toAbsolutePath())) {
             throw new IllegalArgumentException("Legacy folder must be below the current working directory");
         }
         Path toDir = getWorkingDirectoryPath().resolve(file);


### PR DESCRIPTION
On windows, this path is the literal `.` path, making this check fail.