### PR TITLE
Add API to disable history tracking in EditSessions

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/ChangeSetExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/ChangeSetExtent.java
@@ -63,6 +63,7 @@ public class ChangeSetExtent extends AbstractDelegateExtent {
      *
      * @param extent the extent
      * @param changeSet the change set
+     * @param enabled if the extent is enabled
      */
     public ChangeSetExtent(Extent extent, ChangeSet changeSet, boolean enabled) {
         super(extent);


### PR DESCRIPTION
Adds API to get whether history is tracked, or enable/disable it. A command could be added to handle this in the future too.

Many API usecases never touch history at all, so it's basically time spent that could be avoided