### PR TITLE
Use SnakeYaml 1.32+, set loader code point limit.

### DIFF
--- a/worldedit-core/build.gradle.kts
+++ b/worldedit-core/build.gradle.kts
@@ -29,7 +29,7 @@ configurations {
 dependencies {
     constraints {
         "implementation"( "org.yaml:snakeyaml") {
-            version { require("1.26") }
+            version { require("1.33") }
             because("Bukkit provides SnakeYaml")
         }
     }
@@ -37,7 +37,7 @@ dependencies {
     "api"(project(":worldedit-libs:core"))
     "compileOnly"("de.schlichtherle:truezip:6.8.4")
     "implementation"("org.mozilla:rhino-runtime:1.7.13")
-    "implementation"("org.yaml:snakeyaml:1.26")
+    "implementation"("org.yaml:snakeyaml:1.33")
     "implementation"("com.google.guava:guava")
     "compileOnlyApi"("com.google.code.findbugs:jsr305:1.3.9")
     "implementation"("com.google.code.gson:gson")

--- a/worldedit-core/src/main/java/com/sk89q/util/yaml/YAMLProcessor.java
+++ b/worldedit-core/src/main/java/com/sk89q/util/yaml/YAMLProcessor.java
@@ -21,6 +21,7 @@ package com.sk89q.util.yaml;
 
 import com.sk89q.util.StringUtil;
 import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.nodes.Tag;
@@ -89,13 +90,21 @@ public class YAMLProcessor extends YAMLNode {
         super(new LinkedHashMap<>(), writeDefaults);
         this.format = format;
 
-        DumperOptions options = new DumperOptions();
-        options.setIndent(4);
-        options.setDefaultFlowStyle(format.getStyle());
+        DumperOptions dumperOptions = new DumperOptions();
+        dumperOptions.setIndent(4);
+        dumperOptions.setDefaultFlowStyle(format.getStyle());
         Representer representer = new FancyRepresenter();
         representer.setDefaultFlowStyle(format.getStyle());
+        LoaderOptions loaderOptions = new LoaderOptions();
+        try {
+            // 64 MB default
+            int yamlCodePointLimit = Integer.getInteger("worldedit.yaml.codePointLimit", 64 * 1024 * 1024);
+            loaderOptions.setCodePointLimit(yamlCodePointLimit);
+        } catch (NoSuchMethodError ignored) {
+            // pre-1.32 snakeyaml
+        }
 
-        yaml = new Yaml(new SafeConstructor(), representer, options);
+        yaml = new Yaml(new SafeConstructor(), representer, dumperOptions, loaderOptions);
 
         this.file = file;
     }


### PR DESCRIPTION
Defaults to 64MB, can be set via -Dworldedit.yaml.codePointLimit sysprop.

Fixes #2193, EngineHub/WorldGuard#1953.