### PR TITLE
Add author to, and cleanup manifest files for various platforms

### DIFF
--- a/worldedit-bukkit/src/main/resources/plugin.yml
+++ b/worldedit-bukkit/src/main/resources/plugin.yml
@@ -4,3 +4,5 @@ version: "${internalVersion}"
 load: STARTUP
 api-version: 1.13
 softdepend: [Vault]
+author: EngineHub
+website: https://enginehub.org/worldedit

--- a/worldedit-fabric/src/main/resources/fabric.mod.json
+++ b/worldedit-fabric/src/main/resources/fabric.mod.json
@@ -6,12 +6,7 @@
     "name": "WorldEdit",
     "description": "WorldEdit is an easy-to-use in-game world editor for Minecraft, supporting both single- and multi-player.",
     "authors": [
-        "EngineHub",
-        "sk89q",
-        "wizjany",
-        "TomyLobo",
-        "octylFractal",
-        "Me4502"
+        "EngineHub"
     ],
     "contact": {
         "homepage": "https://enginehub.org/worldedit/",

--- a/worldedit-fabric/src/main/resources/fabric.mod.json
+++ b/worldedit-fabric/src/main/resources/fabric.mod.json
@@ -6,6 +6,7 @@
     "name": "WorldEdit",
     "description": "WorldEdit is an easy-to-use in-game world editor for Minecraft, supporting both single- and multi-player.",
     "authors": [
+        "EngineHub",
         "sk89q",
         "wizjany",
         "TomyLobo",

--- a/worldedit-forge/src/main/resources/META-INF/mods.toml
+++ b/worldedit-forge/src/main/resources/META-INF/mods.toml
@@ -5,11 +5,11 @@ loaderVersion="[24,)"
 # A URL to refer people to when problems occur with this mod
 issueTrackerURL="https://discord.gg/enginehub"
 # A URL for the "homepage" for this mod, displayed in the mod UI
-displayURL="https://worldedit.enginehub.org/"
+displayURL="https://enginehub.org/worldedit/"
 # A file name (in the root of the mod JAR) containing a logo for display
 logoFile="worldedit-icon.png"
 # A text field displayed in the mod UI
-authors="sk89q, wizjany, TomyLobo, kenzierocks, Me4502"
+authors="EngineHub, sk89q, wizjany, TomyLobo, octylFractal, Me4502"
 license="GPL"
 # A list of mods - how many allowed here is determined by the individual mod loader
 [[mods]]
@@ -35,9 +35,3 @@ WorldEdit is an easy-to-use in-game world editor for Minecraft, supporting both 
     versionRange="[${forgeVersion},)"
     ordering="NONE"
     side="BOTH"
-[[dependencies.worldedit]]
-    modId="sponge"
-    mandatory=false
-    versionRange="[1.13]"
-    ordering="BEFORE"
-    side="SERVER"

--- a/worldedit-forge/src/main/resources/META-INF/mods.toml
+++ b/worldedit-forge/src/main/resources/META-INF/mods.toml
@@ -9,7 +9,7 @@ displayURL="https://enginehub.org/worldedit/"
 # A file name (in the root of the mod JAR) containing a logo for display
 logoFile="worldedit-icon.png"
 # A text field displayed in the mod UI
-authors="EngineHub, sk89q, wizjany, TomyLobo, octylFractal, Me4502"
+authors="EngineHub"
 license="GPL"
 # A list of mods - how many allowed here is determined by the individual mod loader
 [[mods]]


### PR DESCRIPTION
* Adds EngineHub as an author
* Standardises the "website" we provide to the main WorldEdit homepage, as it links to various places such as docs, github & discord
* Removes the Sponge require for -forge, as it was removed in the archive branch

Partially addresses https://github.com/EngineHub/WorldEdit/issues/2196