### PR TITLE
Fixed clipboards failing to paste when a block has NBT data

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/block/ExtentBlockCopy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/block/ExtentBlockCopy.java
@@ -92,7 +92,7 @@ public class ExtentBlockCopy implements RegionFunction {
         if (tag != null) {
             // Handle blocks which store their rotation in NBT
             LinTag<?> rotTag = tag.value().get("Rot");
-            if (rotTag.value() instanceof Number number) {
+            if (rotTag != null && rotTag.value() instanceof Number number) {
                 int rot = number.intValue();
 
                 Direction direction = MCDirections.fromRotation(rot);


### PR DESCRIPTION
Someone reported this issue with 7.3.0 the other day, I reproduced it and fixed it.