### PR TITLE
Attempt to fix #2125

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/command/CommandUtil.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/command/CommandUtil.java
@@ -227,7 +227,9 @@ public class CommandUtil {
             return suggestion;
         }
         String substr = suggestion.getSubstring();
-        int sp = substr.lastIndexOf(' ');
+        // Ignore if suggestion ends with a " ", since that signals the end of
+        // the completed command.
+        int sp = substr.trim().lastIndexOf(' ');
         if (sp < 0) {
             return suggestion;
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/command/CommandUtil.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/command/CommandUtil.java
@@ -227,8 +227,7 @@ public class CommandUtil {
             return suggestion;
         }
         String substr = suggestion.getSubstring();
-        // Ignore if suggestion ends with a " ", since that signals the end of
-        // the completed command.
+        // Check if there is a space inside the substring, and suggest starting from there instead.
         int sp = substr.trim().lastIndexOf(' ');
         if (sp < 0) {
             return suggestion;


### PR DESCRIPTION
I think the issue is that the block property completer adds two suggestions:

- One ending with `,`, to start a new property `name=value` pair.
- One ending with `]` and a **trailing space**, to signal that thats the end of the command

`onlyOnLastQuotedWord()` picks up on the trailing space, and attempts to limit the suggestion to the part behind the trailing space it. There is no part behind it, though - it's trailing after all. My fix was to simply ignore the trailing spaces.
That should be looked over by someone who knows the internals and possible sideeffects from this change better than I do, though!

Fixes #2125 