### PR TITLE
Allow factory suggestions to have parser context

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/FactoryConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/FactoryConverter.java
@@ -96,8 +96,7 @@ public class FactoryConverter<T> implements ArgumentConverter<T> {
         this.contextTweaker = contextTweaker;
     }
 
-    @Override
-    public ConversionResult<T> convert(String argument, InjectedValueAccess context) {
+    private ParserContext createContext(InjectedValueAccess context) {
         Actor actor = context.injectedValue(Key.of(Actor.class))
             .orElseThrow(() -> new IllegalStateException("No actor"));
         LocalSession session = WorldEdit.getInstance().getSessionManager().get(actor);
@@ -121,6 +120,13 @@ public class FactoryConverter<T> implements ArgumentConverter<T> {
             contextTweaker.accept(parserContext);
         }
 
+        return parserContext;
+    }
+
+    @Override
+    public ConversionResult<T> convert(String argument, InjectedValueAccess context) {
+        ParserContext parserContext = createContext(context);
+
         try {
             return SuccessfulConversion.fromSingle(
                 factoryExtractor.apply(worldEdit).parseFromInput(argument, parserContext)
@@ -132,7 +138,9 @@ public class FactoryConverter<T> implements ArgumentConverter<T> {
 
     @Override
     public List<String> getSuggestions(String input, InjectedValueAccess context) {
-        return factoryExtractor.apply(worldEdit).getSuggestions(input);
+        ParserContext parserContext = createContext(context);
+
+        return factoryExtractor.apply(worldEdit).getSuggestions(input, parserContext);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/MaskFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/MaskFactory.java
@@ -82,15 +82,15 @@ public final class MaskFactory extends AbstractFactory<Mask> {
     }
 
     @Override
-    public List<String> getSuggestions(String input) {
+    public List<String> getSuggestions(String input, ParserContext context) {
         final String[] split = input.split(" ");
         if (split.length > 1) {
             String prev = input.substring(0, input.lastIndexOf(" ")) + " ";
-            return super.getSuggestions(split[split.length - 1]).stream()
+            return super.getSuggestions(split[split.length - 1], context).stream()
                 .map(s -> prev + s)
                 .collect(Collectors.toList());
         }
-        return super.getSuggestions(input);
+        return super.getSuggestions(input, context);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlocksMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlocksMaskParser.java
@@ -41,8 +41,8 @@ public class BlocksMaskParser extends InputParser<Mask> {
     }
 
     @Override
-    public Stream<String> getSuggestions(String input) {
-        return worldEdit.getBlockFactory().getSuggestions(input).stream();
+    public Stream<String> getSuggestions(String input, ParserContext context) {
+        return worldEdit.getBlockFactory().getSuggestions(input, context).stream();
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/NegateMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/NegateMaskParser.java
@@ -36,14 +36,14 @@ public class NegateMaskParser extends InputParser<Mask> {
     }
 
     @Override
-    public Stream<String> getSuggestions(String input) {
+    public Stream<String> getSuggestions(String input, ParserContext context) {
         if (input.isEmpty()) {
             return Stream.of("!");
         }
         if (input.charAt(0) != '!') {
             return Stream.empty();
         }
-        return worldEdit.getMaskFactory().getSuggestions(input.substring(1)).stream().map(s -> "!" + s);
+        return worldEdit.getMaskFactory().getSuggestions(input.substring(1), context).stream().map(s -> "!" + s);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/OffsetMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/OffsetMaskParser.java
@@ -37,7 +37,7 @@ public class OffsetMaskParser extends InputParser<Mask> {
     }
 
     @Override
-    public Stream<String> getSuggestions(String input) {
+    public Stream<String> getSuggestions(String input, ParserContext context) {
         if (input.isEmpty()) {
             return Stream.of(">", "<");
         }
@@ -45,7 +45,7 @@ public class OffsetMaskParser extends InputParser<Mask> {
         if (firstChar != '>' && firstChar != '<') {
             return Stream.empty();
         }
-        return worldEdit.getMaskFactory().getSuggestions(input.substring(1)).stream().map(s -> firstChar + s);
+        return worldEdit.getMaskFactory().getSuggestions(input.substring(1), context).stream().map(s -> firstChar + s);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/RandomPatternParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/RandomPatternParser.java
@@ -41,7 +41,7 @@ public class RandomPatternParser extends InputParser<Pattern> {
     }
 
     @Override
-    public Stream<String> getSuggestions(String input) {
+    public Stream<String> getSuggestions(String input, ParserContext context) {
         String[] splits = input.split(",", -1);
         List<String> patterns = StringUtil.parseListInQuotes(splits, ',', '[', ']', true);
         // get suggestions for the last token only
@@ -56,7 +56,7 @@ public class RandomPatternParser extends InputParser<Pattern> {
         }
         String previous = patterns.size() == 1 ? "" : String.join(",", patterns.subList(0, patterns.size() - 1)) + ",";
         String prefix = previous + (percent == null ? "" : percent + "%");
-        final List<String> innerSuggestions = worldEdit.getPatternFactory().getSuggestions(token);
+        final List<String> innerSuggestions = worldEdit.getPatternFactory().getSuggestions(token, context);
         return innerSuggestions.stream().map(s -> prefix + s);
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/RandomStatePatternParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/RandomStatePatternParser.java
@@ -36,7 +36,7 @@ public class RandomStatePatternParser extends InputParser<Pattern> {
     }
 
     @Override
-    public Stream<String> getSuggestions(String input) {
+    public Stream<String> getSuggestions(String input, ParserContext context) {
         if (input.isEmpty()) {
             return Stream.of("*");
         }
@@ -44,7 +44,7 @@ public class RandomStatePatternParser extends InputParser<Pattern> {
             return Stream.empty();
         }
 
-        return worldEdit.getBlockFactory().getSuggestions(input.substring(1)).stream().map(s -> "*" + s);
+        return worldEdit.getBlockFactory().getSuggestions(input.substring(1), context).stream().map(s -> "*" + s);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/SingleBlockPatternParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/SingleBlockPatternParser.java
@@ -34,8 +34,8 @@ public class SingleBlockPatternParser extends InputParser<Pattern> {
     }
 
     @Override
-    public Stream<String> getSuggestions(String input) {
-        return worldEdit.getBlockFactory().getSuggestions(input).stream();
+    public Stream<String> getSuggestions(String input, ParserContext context) {
+        return worldEdit.getBlockFactory().getSuggestions(input, context).stream();
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/TypeOrStateApplyingPatternParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/TypeOrStateApplyingPatternParser.java
@@ -45,7 +45,7 @@ public class TypeOrStateApplyingPatternParser extends InputParser<Pattern> {
     }
 
     @Override
-    public Stream<String> getSuggestions(String input) {
+    public Stream<String> getSuggestions(String input, ParserContext context) {
         if (input.isEmpty()) {
             return Stream.of("^");
         }
@@ -58,7 +58,7 @@ public class TypeOrStateApplyingPatternParser extends InputParser<Pattern> {
         String type = parts[0];
 
         if (parts.length == 1) {
-            return worldEdit.getBlockFactory().getSuggestions(input).stream().map(s -> "^" + s);
+            return worldEdit.getBlockFactory().getSuggestions(input, context).stream().map(s -> "^" + s);
         } else {
             if (type.isEmpty()) {
                 return Stream.empty(); // without knowing a type, we can't really suggest states

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/registry/AbstractFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/registry/AbstractFactory.java
@@ -84,10 +84,15 @@ public abstract class AbstractFactory<E> {
         throw new NoMatchException(TranslatableComponent.of("worldedit.error.no-match", TextComponent.of(input)));
     }
 
+    @Deprecated
     public List<String> getSuggestions(String input) {
         return parsers.stream().flatMap(
             p -> p.getSuggestions(input)
         ).collect(Collectors.toList());
+    }
+
+    public List<String> getSuggestions(String input, ParserContext context) {
+        return getSuggestions(input);
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/registry/InputParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/registry/InputParser.java
@@ -45,8 +45,22 @@ public abstract class InputParser<E> {
      * Gets a stream of suggestions of input to this parser.
      *
      * @return a stream of suggestions
+     * @deprecated Use the version that takes a {@link ParserContext}, {@link #getSuggestions(String, ParserContext)}
      */
+    @Deprecated
     public Stream<String> getSuggestions(String input) {
         return Stream.empty();
+    }
+
+    /**
+     * Gets a stream of suggestions of input to this parser.
+     *
+     * @param input The string input
+     * @param context The parser context
+     *
+     * @return a stream of suggestions
+     */
+    public Stream<String> getSuggestions(String input, ParserContext context) {
+        return getSuggestions(input);
     }
 }


### PR DESCRIPTION
This is a refactor to allow access to a ParserContext within the suggestion methods. This is required for any suggestions within the factory parser that are player-specific, such as suggesting properties for the currently held block in `//set hand[layers=6]` or whatever