### PR TITLE
Add method to check initialize state in PlatformManager, deny access to registries when uninitialized

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformManager.java
@@ -298,8 +298,22 @@ public class PlatformManager {
         return queryCapability(Capability.CONFIGURATION).getConfiguration();
     }
 
+    /**
+     * Get the current supported {@link SideEffect}s.
+     *
+     * @return the supported side effects
+     * @throws NoCapablePlatformException thrown if no platform is capable
+     */
     public Collection<SideEffect> getSupportedSideEffects() {
         return queryCapability(Capability.WORLD_EDITING).getSupportedSideEffects();
+    }
+
+    /**
+     * Get the initialized state of the Platform.
+     * {@return if the platform manager is initialized}
+     */
+    public boolean isInitialized() {
+        return initialized.get();
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/registry/NamespacedRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/registry/NamespacedRegistry.java
@@ -19,6 +19,8 @@
 
 package com.sk89q.worldedit.registry;
 
+import com.sk89q.worldedit.WorldEdit;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -36,8 +38,16 @@ public final class NamespacedRegistry<V extends Keyed> extends Registry<V> {
         this(name, MINECRAFT_NAMESPACE);
     }
 
+    public NamespacedRegistry(final String name, final boolean checkInitialized) {
+        this(name, MINECRAFT_NAMESPACE, checkInitialized);
+    }
+
     public NamespacedRegistry(final String name, final String defaultNamespace) {
-        super(name);
+        this(name, defaultNamespace, false);
+    }
+
+    public NamespacedRegistry(final String name, final String defaultNamespace, final boolean checkInitialized) {
+        super(name, checkInitialized);
         this.defaultNamespace = defaultNamespace;
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/registry/Registry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/registry/Registry.java
@@ -19,6 +19,8 @@
 
 package com.sk89q.worldedit.registry;
 
+import com.sk89q.worldedit.WorldEdit;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,9 +36,15 @@ import static java.util.Objects.requireNonNull;
 public class Registry<V extends Keyed> implements Iterable<V> {
     private final Map<String, V> map = new HashMap<>();
     private final String name;
+    private final boolean checkInitialized;
 
     public Registry(final String name) {
+        this(name, false);
+    }
+
+    public Registry(final String name, final boolean checkInitialized) {
         this.name = name;
+        this.checkInitialized = checkInitialized;
     }
 
     public String getName() {
@@ -46,6 +54,10 @@ public class Registry<V extends Keyed> implements Iterable<V> {
     @Nullable
     public V get(final String key) {
         checkState(key.equals(key.toLowerCase(Locale.ROOT)), "key must be lowercase: %s", key);
+        if (this.checkInitialized) {
+            checkState(WorldEdit.getInstance().getPlatformManager().isInitialized(),
+                    "WorldEdit is not enabled yet.");
+        }
         return this.map.get(key);
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/registry/Registry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/registry/Registry.java
@@ -56,7 +56,7 @@ public class Registry<V extends Keyed> implements Iterable<V> {
         checkState(key.equals(key.toLowerCase(Locale.ROOT)), "key must be lowercase: %s", key);
         if (this.checkInitialized) {
             checkState(WorldEdit.getInstance().getPlatformManager().isInitialized(),
-                    "WorldEdit is not enabled yet.");
+                    "WorldEdit is not initialized yet.");
         }
         return this.map.get(key);
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/biome/BiomeType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/biome/BiomeType.java
@@ -29,7 +29,7 @@ import com.sk89q.worldedit.registry.NamespacedRegistry;
  */
 public class BiomeType implements Keyed, BiomePattern {
 
-    public static final NamespacedRegistry<BiomeType> REGISTRY = new NamespacedRegistry<>("biome type");
+    public static final NamespacedRegistry<BiomeType> REGISTRY = new NamespacedRegistry<>("biome type", true);
 
     private final String id;
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockCategory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockCategory.java
@@ -33,7 +33,7 @@ import java.util.Set;
  */
 public class BlockCategory extends Category<BlockType> implements Keyed {
 
-    public static final NamespacedRegistry<BlockCategory> REGISTRY = new NamespacedRegistry<>("block tag");
+    public static final NamespacedRegistry<BlockCategory> REGISTRY = new NamespacedRegistry<>("block tag", true);
 
     public BlockCategory(final String id) {
         super(id);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockType.java
@@ -43,7 +43,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 public class BlockType implements Keyed {
 
-    public static final NamespacedRegistry<BlockType> REGISTRY = new NamespacedRegistry<>("block type");
+    public static final NamespacedRegistry<BlockType> REGISTRY = new NamespacedRegistry<>("block type", true);
 
     private final String id;
     private final Function<BlockState, BlockState> values;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/entity/EntityType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/entity/EntityType.java
@@ -24,7 +24,7 @@ import com.sk89q.worldedit.registry.NamespacedRegistry;
 
 public class EntityType implements Keyed {
 
-    public static final NamespacedRegistry<EntityType> REGISTRY = new NamespacedRegistry<>("entity type");
+    public static final NamespacedRegistry<EntityType> REGISTRY = new NamespacedRegistry<>("entity type", true);
 
     private final String id;
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/item/ItemType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/item/ItemType.java
@@ -34,7 +34,7 @@ import javax.annotation.Nullable;
 
 public class ItemType implements Keyed {
 
-    public static final NamespacedRegistry<ItemType> REGISTRY = new NamespacedRegistry<>("item type");
+    public static final NamespacedRegistry<ItemType> REGISTRY = new NamespacedRegistry<>("item type", true);
 
     private final String id;
     @SuppressWarnings("deprecation")

--- a/worldedit-core/src/test/java/com/sk89q/worldedit/internal/expression/BaseExpressionTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/worldedit/internal/expression/BaseExpressionTest.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -63,6 +64,7 @@ class BaseExpressionTest {
         });
         WorldEdit.getInstance().getPlatformManager().register(mockPlat);
         WorldEdit.getInstance().getEventBus().post(new PlatformsRegisteredEvent());
+        assertTrue(WorldEdit.getInstance().getPlatformManager().isInitialized(), "Platform is not initialized");
         WorldEdit.getInstance().getConfiguration().calculationTimeout = 1_000;
     }
 

--- a/worldedit-core/src/test/java/com/sk89q/worldedit/util/collection/BlockMapTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/worldedit/util/collection/BlockMapTest.java
@@ -20,6 +20,7 @@
 package com.sk89q.worldedit.util.collection;
 
 import com.google.common.collect.ImmutableMap;
+import com.sk89q.worldedit.LocalConfiguration;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.event.platform.PlatformsRegisteredEvent;
 import com.sk89q.worldedit.extension.platform.Capability;
@@ -86,9 +87,16 @@ class BlockMapTest {
             Stream.of(Capability.values())
                 .collect(Collectors.toMap(Function.identity(), __ -> Preference.NORMAL))
         );
+        when(MOCKED_PLATFORM.getConfiguration()).thenReturn(new LocalConfiguration() {
+            @Override
+            public void load() {
+            }
+        });
         PlatformManager platformManager = WorldEdit.getInstance().getPlatformManager();
         platformManager.register(MOCKED_PLATFORM);
         WorldEdit.getInstance().getEventBus().post(new PlatformsRegisteredEvent());
+
+        assertTrue(WorldEdit.getInstance().getPlatformManager().isInitialized(), "Platform is not initialized");
 
         registerBlock("minecraft:air");
         registerBlock("minecraft:oak_wood");


### PR DESCRIPTION
This should fix a bug, where worldedit types such as BlockTypes.AIR will be null when some plugin (or mod) try to access WorldEdit too early (e.g. access BlockTypes.AIR in onLoad).

I added a method to get the current initialization state in PlatformManager for that. To check that state I added some check to the UnitTests.

The static code block in the Types classes are not the cleanest approach but adding some code in Registry classes might be a breaking change because some other plugins may use them.