### PR TITLE
EditSession.drawSpline: use vectors at block center for spline nodes

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -2588,7 +2588,7 @@ public class EditSession implements Extent, AutoCloseable {
         Interpolation interpol = new KochanekBartelsInterpolation();
 
         for (BlockVector3 nodevector : nodevectors) {
-            Node n = new Node(nodevector.toVector3());
+            Node n = new Node(nodevector.toVector3().add(Vector3.at(0.5D, 0.5D, 0.5D)));
             n.setTension(tension);
             n.setBias(bias);
             n.setContinuity(continuity);


### PR DESCRIPTION
The spline generator was fed integral block node vectors, where center of a block at coordinate (X,Y,Z) is actually in (X+0.5,Y+0.5,Z+0.5). When generating a spline with (X,Y,Z)s, the curve sometimes doesn't go through the intended block and may make weird turns at end of the curve.

Placing spline nodes at the center causes the curve to actually hit the center of every block selected.

Here is a problematic curve. Nodes are marked in circles. Note that the entire curve is at the very least supposed to look symmetric along the secondary diagonal direction, but upper-left corner looks significantly messed up compared to the lower-right corner.
![截图 2023-01-09 01-05-13](https://user-images.githubusercontent.com/3353318/211249469-00238006-80f8-4882-a66b-e6e3c8dab7ce.png)

The curve generated along the same rig with same nodes after the fix:
![截图 2023-01-09 01-24-38](https://user-images.githubusercontent.com/3353318/211251119-bf072c1d-7f25-4d78-b1e3-ff10f3f2497a.png)

