### PR TITLE
Allow finding schematic format by InputStream

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,3 +1,4 @@
+
 import org.gradle.api.Project
 
 object Versions {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,4 +1,3 @@
-
 import org.gradle.api.Project
 
 object Versions {

--- a/verification/src/changes/accepted-core-public-api-changes.json
+++ b/verification/src/changes/accepted-core-public-api-changes.json
@@ -192,5 +192,23 @@
                 "FIELD_NOW_FINAL"
             ]
         }
+    ],
+    "This now delegates to the InputStream method if not implemented": [
+        {
+            "type": "com.sk89q.worldedit.extent.clipboard.io.ClipboardFormat",
+            "member": "Method com.sk89q.worldedit.extent.clipboard.io.ClipboardFormat.isFormat(java.io.File)",
+            "changes": [
+                "METHOD_ABSTRACT_NOW_DEFAULT"
+            ]
+        }
+    ],
+    "New method added with default implementation": [
+        {
+            "type": "com.sk89q.worldedit.extent.clipboard.io.ClipboardFormat",
+            "member": "Method com.sk89q.worldedit.extent.clipboard.io.ClipboardFormat.isFormat(java.io.InputStream)",
+            "changes": [
+                "METHOD_NEW_DEFAULT"
+            ]
+        }
     ]
 }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
@@ -256,7 +256,6 @@ public interface BukkitImplAdapter {
     }
 
     /**
-<<<<<<< HEAD
      * Checks if this adapter supports custom biomes.
      * @return if custom biomes are supported
      */

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/BuiltInClipboardFormat.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/BuiltInClipboardFormat.java
@@ -20,8 +20,6 @@
 package com.sk89q.worldedit.extent.clipboard.io;
 
 import com.google.common.collect.ImmutableSet;
-import com.sk89q.jnbt.NBTInputStream;
-import com.sk89q.jnbt.NBTOutputStream;
 import com.sk89q.worldedit.extent.clipboard.io.sponge.SpongeSchematicV1Reader;
 import com.sk89q.worldedit.extent.clipboard.io.sponge.SpongeSchematicV2Reader;
 import com.sk89q.worldedit.extent.clipboard.io.sponge.SpongeSchematicV2Writer;
@@ -35,8 +33,6 @@ import org.enginehub.linbus.tree.LinTagType;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -72,9 +68,9 @@ public enum BuiltInClipboardFormat implements ClipboardFormat {
         }
 
         @Override
-        public boolean isFormat(File file) {
+        public boolean isFormat(InputStream inputStream) {
             LinRootEntry rootEntry;
-            try (var stream = new DataInputStream(new GZIPInputStream(new FileInputStream(file)))) {
+            try (var stream = new DataInputStream(new GZIPInputStream(inputStream))) {
                 rootEntry = LinBinaryIO.readUsing(stream, LinRootEntry::readFrom);
             } catch (Exception e) {
                 return false;
@@ -105,8 +101,8 @@ public enum BuiltInClipboardFormat implements ClipboardFormat {
         }
 
         @Override
-        public boolean isFormat(File file) {
-            return detectOldSpongeSchematic(file, 1);
+        public boolean isFormat(InputStream inputStream) {
+            return detectOldSpongeSchematic(inputStream, 1);
         }
     },
     SPONGE_V2_SCHEMATIC("sponge.2") {
@@ -129,8 +125,8 @@ public enum BuiltInClipboardFormat implements ClipboardFormat {
         }
 
         @Override
-        public boolean isFormat(File file) {
-            return detectOldSpongeSchematic(file, 2);
+        public boolean isFormat(InputStream inputStream) {
+            return detectOldSpongeSchematic(inputStream, 2);
         }
     },
     SPONGE_V3_SCHEMATIC("sponge.3", "sponge", "schem") {
@@ -153,9 +149,9 @@ public enum BuiltInClipboardFormat implements ClipboardFormat {
         }
 
         @Override
-        public boolean isFormat(File file) {
+        public boolean isFormat(InputStream inputStream) {
             LinCompoundTag root;
-            try (var stream = new DataInputStream(new GZIPInputStream(new FileInputStream(file)))) {
+            try (var stream = new DataInputStream(new GZIPInputStream(inputStream))) {
                 root = LinBinaryIO.readUsing(stream, LinRootEntry::readFrom).value();
             } catch (Exception e) {
                 return false;
@@ -173,9 +169,9 @@ public enum BuiltInClipboardFormat implements ClipboardFormat {
     },
     ;
 
-    private static boolean detectOldSpongeSchematic(File file, int version) {
+    private static boolean detectOldSpongeSchematic(InputStream inputStream, int version) {
         LinRootEntry rootEntry;
-        try (var stream = new DataInputStream(new GZIPInputStream(new FileInputStream(file)))) {
+        try (var stream = new DataInputStream(new GZIPInputStream(inputStream))) {
             rootEntry = LinBinaryIO.readUsing(stream, LinRootEntry::readFrom);
         } catch (Exception e) {
             return false;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/BuiltInClipboardFormat.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/BuiltInClipboardFormat.java
@@ -70,7 +70,8 @@ public enum BuiltInClipboardFormat implements ClipboardFormat {
         @Override
         public boolean isFormat(InputStream inputStream) {
             LinRootEntry rootEntry;
-            try (var stream = new DataInputStream(new GZIPInputStream(inputStream))) {
+            try {
+                var stream = new DataInputStream(new GZIPInputStream(inputStream));
                 rootEntry = LinBinaryIO.readUsing(stream, LinRootEntry::readFrom);
             } catch (Exception e) {
                 return false;
@@ -151,7 +152,8 @@ public enum BuiltInClipboardFormat implements ClipboardFormat {
         @Override
         public boolean isFormat(InputStream inputStream) {
             LinCompoundTag root;
-            try (var stream = new DataInputStream(new GZIPInputStream(inputStream))) {
+            try {
+                var stream = new DataInputStream(new GZIPInputStream(inputStream));
                 root = LinBinaryIO.readUsing(stream, LinRootEntry::readFrom).value();
             } catch (Exception e) {
                 return false;
@@ -171,7 +173,8 @@ public enum BuiltInClipboardFormat implements ClipboardFormat {
 
     private static boolean detectOldSpongeSchematic(InputStream inputStream, int version) {
         LinRootEntry rootEntry;
-        try (var stream = new DataInputStream(new GZIPInputStream(inputStream))) {
+        try {
+            var stream = new DataInputStream(new GZIPInputStream(inputStream));
             rootEntry = LinBinaryIO.readUsing(stream, LinRootEntry::readFrom);
         } catch (Exception e) {
             return false;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/BuiltInClipboardFormat.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/BuiltInClipboardFormat.java
@@ -71,7 +71,9 @@ public enum BuiltInClipboardFormat implements ClipboardFormat {
         public boolean isFormat(InputStream inputStream) {
             LinRootEntry rootEntry;
             try {
-                var stream = new DataInputStream(new GZIPInputStream(inputStream));
+                DataInputStream stream = inputStream instanceof DataInputStream dataInputStream
+                    ? dataInputStream
+                    : new DataInputStream(inputStream);
                 rootEntry = LinBinaryIO.readUsing(stream, LinRootEntry::readFrom);
             } catch (Exception e) {
                 return false;
@@ -153,7 +155,9 @@ public enum BuiltInClipboardFormat implements ClipboardFormat {
         public boolean isFormat(InputStream inputStream) {
             LinCompoundTag root;
             try {
-                var stream = new DataInputStream(new GZIPInputStream(inputStream));
+                DataInputStream stream = inputStream instanceof DataInputStream dataInputStream
+                    ? dataInputStream
+                    : new DataInputStream(inputStream);
                 root = LinBinaryIO.readUsing(stream, LinRootEntry::readFrom).value();
             } catch (Exception e) {
                 return false;
@@ -174,7 +178,9 @@ public enum BuiltInClipboardFormat implements ClipboardFormat {
     private static boolean detectOldSpongeSchematic(InputStream inputStream, int version) {
         LinRootEntry rootEntry;
         try {
-            var stream = new DataInputStream(new GZIPInputStream(inputStream));
+            DataInputStream stream = inputStream instanceof DataInputStream dataInputStream
+                ? dataInputStream
+                : new DataInputStream(inputStream);
             rootEntry = LinBinaryIO.readUsing(stream, LinRootEntry::readFrom);
         } catch (Exception e) {
             return false;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormat.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormat.java
@@ -20,12 +20,12 @@
 package com.sk89q.worldedit.extent.clipboard.io;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.Set;
+import java.util.zip.GZIPInputStream;
 
 /**
  * A collection of supported clipboard formats.
@@ -71,9 +71,9 @@ public interface ClipboardFormat {
      * @return true if the given file is of this format
      */
     default boolean isFormat(File file) {
-        try {
-            return isFormat(new FileInputStream(file));
-        } catch (FileNotFoundException e) {
+        try (InputStream stream = new GZIPInputStream(Files.newInputStream(file.toPath()))) {
+            return isFormat(stream);
+        } catch (IOException e) {
             return false;
         }
     }
@@ -81,7 +81,11 @@ public interface ClipboardFormat {
     /**
      * Return whether the given stream is of this format.
      *
-     * @apiNote The caller is responsible for closing the given InputStream.
+     * @apiNote The caller is responsible for the following:
+     * <ul>
+     *   <li>Closing the input stream</li>
+     *   <li>Ensuring the data is directly readable, such as not being in GZip format</li>
+     * </ul>
      *
      * @param inputStream The stream
      * @return true if the given stream is of this format

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormat.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormat.java
@@ -20,6 +20,8 @@
 package com.sk89q.worldedit.extent.clipboard.io;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -68,7 +70,23 @@ public interface ClipboardFormat {
      * @param file the file
      * @return true if the given file is of this format
      */
-    boolean isFormat(File file);
+    default boolean isFormat(File file) {
+        try {
+            return isFormat(new FileInputStream(file));
+        } catch (FileNotFoundException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Return whether the given stream is of this format.
+     *
+     * @param inputStream The stream
+     * @return true if the given stream is of this format
+     */
+    default boolean isFormat(InputStream inputStream) {
+        return false;
+    }
 
     /**
      * Get the file extension this format primarily uses.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormat.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormat.java
@@ -81,6 +81,8 @@ public interface ClipboardFormat {
     /**
      * Return whether the given stream is of this format.
      *
+     * @apiNote The caller is responsible for closing the given InputStream.
+     *
      * @param inputStream The stream
      * @return true if the given stream is of this format
      */

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormat.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormat.java
@@ -82,10 +82,10 @@ public interface ClipboardFormat {
      * Return whether the given stream is of this format.
      *
      * @apiNote The caller is responsible for the following:
-     * <ul>
-     *   <li>Closing the input stream</li>
-     *   <li>Ensuring the data is directly readable, such as not being in GZip format</li>
-     * </ul>
+     *     <ul>
+     *         <li>Closing the input stream</li>
+     *         <li>Ensuring the data is directly readable, such as not being in GZip format</li>
+     *     </ul>
      *
      * @param inputStream The stream
      * @return true if the given stream is of this format

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormats.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormats.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Multimaps;
 import com.sk89q.worldedit.WorldEdit;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -112,9 +113,11 @@ public class ClipboardFormats {
         checkNotNull(inputStreamSupplier);
 
         for (ClipboardFormat format : registeredFormats) {
-            if (format.isFormat(inputStreamSupplier.get())) {
-                return format;
-            }
+            try (var stream = inputStreamSupplier.get()) {
+                if (format.isFormat(stream)) {
+                    return format;
+                }
+            } catch (IOException ignored) {}
         }
 
         return null;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormats.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormats.java
@@ -105,6 +105,8 @@ public class ClipboardFormats {
     /**
      * Detect the format of a given input stream.
      *
+     * @apiNote The caller is responsible for ensuring the stream is in a readable format, such as removing GZip compression.
+     *
      * @param inputStreamSupplier The input stream supplier
      * @return the format, otherwise null if one cannot be detected
      */

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormats.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormats.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Multimaps;
 import com.sk89q.worldedit.WorldEdit;
 
 import java.io.File;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -32,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -80,7 +82,7 @@ public class ClipboardFormats {
     }
 
     /**
-     * Detect the format of given a file.
+     * Detect the format of a given file.
      *
      * @param file
      *            the file
@@ -92,6 +94,25 @@ public class ClipboardFormats {
 
         for (ClipboardFormat format : registeredFormats) {
             if (format.isFormat(file)) {
+                return format;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Detect the format of a given input stream.
+     *
+     * @param inputStreamSupplier The input stream supplier
+     * @return the format, otherwise null if one cannot be detected
+     */
+    @Nullable
+    public static ClipboardFormat findByInputStream(Supplier<InputStream> inputStreamSupplier) {
+        checkNotNull(inputStreamSupplier);
+
+        for (ClipboardFormat format : registeredFormats) {
+            if (format.isFormat(inputStreamSupplier.get())) {
                 return format;
             }
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormats.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormats.java
@@ -119,7 +119,7 @@ public class ClipboardFormats {
                 if (format.isFormat(stream)) {
                     return format;
                 }
-            } catch (IOException ignored) {}
+            } catch (IOException ignored) { }
         }
 
         return null;


### PR DESCRIPTION
Adds methods to find the format of a schematic by an InputStream, rather than a file. Given all the loading etc functions use InputStream, this makes sense to include.

This allows situations that don't have a proper file to still determine the format, such as situations where a schematic is downloaded from the internet or loaded from a zip file. 