### PR TITLE
Add optional argument to //toggleplace

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
@@ -28,6 +28,7 @@ import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.command.util.CommandPermissions;
 import com.sk89q.worldedit.command.util.CommandPermissionsConditionGenerator;
 import com.sk89q.worldedit.command.util.HookMode;
+import com.sk89q.worldedit.command.util.Placement;
 import com.sk89q.worldedit.command.util.WorldEditAsyncCommandBuilder;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.platform.Actor;
@@ -425,12 +426,19 @@ public class GeneralCommands {
         aliases = {"/toggleplace"},
         desc = "Switch between your position and pos1 for placement"
     )
-    public void togglePlace(Actor actor, LocalSession session) {
+    public void togglePlace(Actor actor, LocalSession session,
+                            @Arg(desc = "Which placement to use, toggle if absent", def = "")
+                            Placement placement) {
         if (!(actor instanceof Locatable)) {
             actor.printError(TranslatableComponent.of("worldedit.toggleplace.not-locatable"));
             return;
         }
-        if (session.togglePlacementPosition()) {
+        if (placement == null) {
+            session.togglePlacementPosition();
+        } else {
+            session.setPlaceAtPos1(placement == Placement.POS1);
+        }
+        if (session.isPlaceAtPos1()) {
             actor.printInfo(TranslatableComponent.of("worldedit.toggleplace.pos1"));
         } else {
             actor.printInfo(TranslatableComponent.of("worldedit.toggleplace.player"));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/EnumConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/EnumConverter.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit.command.argument;
 import com.google.common.collect.ImmutableSet;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.command.util.HookMode;
+import com.sk89q.worldedit.command.util.Placement;
 import com.sk89q.worldedit.extent.TracingExtent;
 import com.sk89q.worldedit.util.SideEffect;
 import com.sk89q.worldedit.util.TreeGenerator;
@@ -57,6 +58,8 @@ public final class EnumConverter {
             basic(HookMode.class));
         commandManager.registerConverter(Key.of(TracingExtent.Action.class),
             basic(TracingExtent.Action.class));
+        commandManager.registerConverter(Key.of(Placement.class),
+            basic(Placement.class));
     }
 
     private static <E extends Enum<E>> ArgumentConverter<E> basic(Class<E> enumClass) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/util/Placement.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/util/Placement.java
@@ -1,0 +1,24 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.command.util;
+
+public enum Placement {
+    POS1, PLAYER
+}


### PR DESCRIPTION
By invoking either `//toggleplace pos1` or `//toggleplace player`, the player can select either pos1 or player explicitly.
Without the argument, the command behaves as it always has and toggles between the two states