### PR TITLE
Fix data values returned by the query functions in the expression language

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/WorldEditExpressionEnvironment.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/WorldEditExpressionEnvironment.java
@@ -23,6 +23,7 @@ import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.internal.expression.ExpressionEnvironment;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
+import com.sk89q.worldedit.world.registry.LegacyMapper;
 
 public class WorldEditExpressionEnvironment implements ExpressionEnvironment {
 
@@ -46,40 +47,39 @@ public class WorldEditExpressionEnvironment implements ExpressionEnvironment {
         return current.add(x, y, z);
     }
 
-    @SuppressWarnings("deprecation")
+    private int getLegacy(BlockVector3 position, int index) {
+        final int[] legacy = LegacyMapper.getInstance().getLegacyFromBlock(extent.getBlock(position).toImmutableState());
+        return legacy == null ? 0 : legacy[index];
+    }
+
     @Override
     public int getBlockType(double x, double y, double z) {
-        return extent.getBlock(toWorld(x, y, z)).getBlockType().getLegacyId();
+        return getLegacy(toWorld(x, y, z), 0);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public int getBlockData(double x, double y, double z) {
-        return extent.getBlock(toWorld(x, y, z)).getBlockType().getLegacyData();
+        return getLegacy(toWorld(x, y, z), 1);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public int getBlockTypeAbs(double x, double y, double z) {
-        return extent.getBlock(BlockVector3.at(x, y, z)).getBlockType().getLegacyId();
+        return getLegacy(BlockVector3.at(x, y, z), 0);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public int getBlockDataAbs(double x, double y, double z) {
-        return extent.getBlock(BlockVector3.at(x, y, z)).getBlockType().getLegacyData();
+        return getLegacy(BlockVector3.at(x, y, z), 1);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public int getBlockTypeRel(double x, double y, double z) {
-        return extent.getBlock(toWorldRel(x, y, z).toBlockPoint()).getBlockType().getLegacyId();
+        return getLegacy(toWorldRel(x, y, z).toBlockPoint(), 0);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public int getBlockDataRel(double x, double y, double z) {
-        return extent.getBlock(toWorldRel(x, y, z).toBlockPoint()).getBlockType().getLegacyData();
+        return getLegacy(toWorldRel(x, y, z).toBlockPoint(), 1);
     }
 
     public void setCurrentBlock(Vector3 current) {


### PR DESCRIPTION
repro steps:
```python
# Make sure we have a selection where pos2=pos1+(3,0,0)
//sel
//pos1
//pos2
//expand 3 west

# Place all 4 types of magenta_glazed_terracotta
//toggleplace pos1
//g -o magenta_glazed_terracotta data=x;1

# Replace everything with data value 2 by stone
//g magenta_glazed_terracotta t=d=0;queryRel(0,0,0,t,d);type=1;data=0;d==2
```
Expected: 1 stone block and 3 magenta_glazed_terracotta blocks
Actual: 4 stone blocks

So apparently, all 4 directions match data==2.
I did some snooping around and apparently, `WorldEditExpressionEnvironment` is using `BlockState.getBlockType().getLegacyId/Data()` and `getBlockType` throws away everything but the basic block type.