### PR TITLE
Keep extending cuboid selector after //paste -s/n

### DIFF
--- a/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIExtraCommands.java
+++ b/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIExtraCommands.java
@@ -23,6 +23,7 @@ import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.regions.selector.CuboidRegionSelector;
+import com.sk89q.worldedit.regions.selector.ExtendingCuboidRegionSelector;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.util.task.Task;
 import com.sk89q.worldedit.world.World;
@@ -38,9 +39,13 @@ public class CLIExtraCommands {
         desc = "Select the entire world"
     )
     public void selectWorld(Actor actor, World world, LocalSession session) {
-        session.setRegionSelector(world, new CuboidRegionSelector(
-            world, world.getMinimumPoint(), world.getMaximumPoint()
-        ));
+        final CuboidRegionSelector selector;
+        if (session.getRegionSelector(world) instanceof ExtendingCuboidRegionSelector) {
+            selector = new ExtendingCuboidRegionSelector(world, world.getMinimumPoint(), world.getMaximumPoint());
+        } else {
+            selector = new CuboidRegionSelector(world, world.getMinimumPoint(), world.getMaximumPoint());
+        }
+        session.setRegionSelector(world, selector);
         actor.printInfo(TextComponent.of("Selected the entire world."));
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ClipboardCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ClipboardCommands.java
@@ -45,6 +45,7 @@ import com.sk89q.worldedit.math.transform.AffineTransform;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionSelector;
 import com.sk89q.worldedit.regions.selector.CuboidRegionSelector;
+import com.sk89q.worldedit.regions.selector.ExtendingCuboidRegionSelector;
 import com.sk89q.worldedit.session.ClipboardHolder;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
@@ -188,7 +189,12 @@ public class ClipboardCommands {
             BlockVector3 clipboardOffset = clipboard.getRegion().getMinimumPoint().subtract(clipboard.getOrigin());
             Vector3 realTo = to.toVector3().add(holder.getTransform().apply(clipboardOffset.toVector3()));
             Vector3 max = realTo.add(holder.getTransform().apply(region.getMaximumPoint().subtract(region.getMinimumPoint()).toVector3()));
-            RegionSelector selector = new CuboidRegionSelector(world, realTo.toBlockPoint(), max.toBlockPoint());
+            final CuboidRegionSelector selector;
+            if (session.getRegionSelector(world) instanceof ExtendingCuboidRegionSelector) {
+                selector = new ExtendingCuboidRegionSelector(world, realTo.toBlockPoint(), max.toBlockPoint());
+            } else {
+                selector = new CuboidRegionSelector(world, realTo.toBlockPoint(), max.toBlockPoint());
+            }
             session.setRegionSelector(world, selector);
             selector.learnChanges();
             selector.explainRegionAdjust(actor, session);


### PR DESCRIPTION
When using `//paste -s` or `//paste -n`, the selector type would revert back to `//sel cuboid`.
This fixes uses the extending cuboid selector if it's the currently selected on and the regular cuboid selector otherwise.
Fixes an issue that might be the one reported in #2188.

There is one more relevant place in worldedit-cli that *looked* like it needed to be changed as well, so I also changed that.
I have no experience with worldedit-cli, so I hope that's ok.

Built locally and tested successfully.
Merges with both 7.2.x and master without conflicts.
worldedit-cli parts untested.