### PR TITLE
Update McRegionChunkStore.java

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/McRegionChunkStore.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/McRegionChunkStore.java
@@ -70,7 +70,7 @@ public abstract class McRegionChunkStore extends ChunkStore {
     public LinCompoundTag getChunkData(BlockVector2 position, World world) throws DataException, IOException {
         McRegionReader reader = getReader(position, world.getName());
         try (var chunkStream = new DataInputStream(reader.getChunkInputStream(position))) {
-            return LinBinaryIO.readUsing(chunkStream, LinRootEntry::readFrom).toLinTag();
+            return LinBinaryIO.readUsing(chunkStream, LinRootEntry::readFrom).value();
         }
     }
 


### PR DESCRIPTION
- Fixes an issue where the LinCompoundTag passed to ChunkStoreHelper::getChunk is not the expected root compound tag, but one that wraps it. See comment of LinRootEntry::toLinTag