### PR TITLE
Replace enum value access by namespaced keys

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitServerInterface.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitServerInterface.java
@@ -104,11 +104,7 @@ public class BukkitServerInterface extends AbstractPlatform implements MultiUser
 
     @Override
     public boolean isValidMobType(String type) {
-        if (!type.startsWith("minecraft:")) {
-            return false;
-        }
-        @SuppressWarnings("deprecation")
-        final EntityType entityType = EntityType.fromName(type.substring(10));
+        final EntityType entityType = BukkitAdapter.adapt(com.sk89q.worldedit.world.entity.EntityType.REGISTRY.get(type));
         return entityType != null && entityType.isAlive();
     }
 

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -211,8 +211,7 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
         // Biome
         for (Biome biome : Biome.values()) {
             if (!biome.name().equals("CUSTOM")) {
-                String lowerCaseBiomeName = biome.name().toLowerCase(Locale.ROOT);
-                BiomeType.REGISTRY.register("minecraft:" + lowerCaseBiomeName, new BiomeType("minecraft:" + lowerCaseBiomeName));
+                BiomeType.REGISTRY.register(biome.getKey().toString(), new BiomeType(biome.getKey().toString()));
             }
         }
         // Block & Item
@@ -246,10 +245,11 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
         }
         // Entity
         for (org.bukkit.entity.EntityType entityType : org.bukkit.entity.EntityType.values()) {
-            String mcid = entityType.getName();
-            if (mcid != null) {
-                String lowerCaseMcId = mcid.toLowerCase(Locale.ROOT);
-                EntityType.REGISTRY.register("minecraft:" + lowerCaseMcId, new EntityType("minecraft:" + lowerCaseMcId));
+            try {
+                String entityTypeKey = entityType.getKey().toString();
+                EntityType.REGISTRY.register(entityTypeKey, new EntityType(entityTypeKey));
+            } catch (IllegalArgumentException e) {
+                // EntityType.UNKNOWN has no key
             }
         }
         // ... :|


### PR DESCRIPTION
Match with namespaced keys for `Material`, `EntityType` and `Biome`, instead of their Bukkit enum names.