### PR TITLE
Ensure blockmap uniqueness across TE values. Fixes #2250

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/collection/Int2BaseBlockMap.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/collection/Int2BaseBlockMap.java
@@ -169,7 +169,7 @@ class Int2BaseBlockMap extends AbstractInt2ObjectMap<BaseBlock> {
             return old;
         }
         int oldId = commonMap.put(key, internalId);
-        return assumeAsBlock(oldId);
+        return BlockStateIdAccess.isValidInternalId(oldId) ? assumeAsBlock(oldId) : uncommonMap.remove(key);
     }
 
     @Override

--- a/worldedit-core/src/test/java/com/sk89q/worldedit/util/collection/BlockMapTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/worldedit/util/collection/BlockMapTest.java
@@ -20,6 +20,8 @@
 package com.sk89q.worldedit.util.collection;
 
 import com.google.common.collect.ImmutableMap;
+import com.sk89q.jnbt.CompoundTag;
+import com.sk89q.jnbt.StringTag;
 import com.sk89q.worldedit.LocalConfiguration;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.event.platform.PlatformsRegisteredEvent;
@@ -100,6 +102,7 @@ class BlockMapTest {
 
         registerBlock("minecraft:air");
         registerBlock("minecraft:oak_wood");
+        registerBlock("minecraft:chest");
     }
 
     @AfterAll
@@ -123,6 +126,7 @@ class BlockMapTest {
 
     private final BaseBlock air = checkNotNull(BlockTypes.AIR).getDefaultState().toBaseBlock();
     private final BaseBlock oakWood = checkNotNull(BlockTypes.OAK_WOOD).getDefaultState().toBaseBlock();
+    private final BaseBlock chestWithNbt = checkNotNull(BlockTypes.CHEST).getDefaultState().toBaseBlock(new CompoundTag(ImmutableMap.of("dummy", new StringTag("value"))));
 
     private AutoCloseable mocks;
 
@@ -745,6 +749,22 @@ class BlockMapTest {
                 }));
                 assertEquals(1, map.size());
                 assertEquals(oakWood, map.get(vec));
+            });
+        }
+
+        @SuppressWarnings("OverwrittenKey")
+        @Test
+        @DisplayName("put with valid and invalid keys doesn't duplicate")
+        void putWithInvalidAndValid() {
+            generator.makeVectorsStream().forEach(vec -> {
+                BlockMap<BaseBlock> map = BlockMap.createForBaseBlock();
+                // This tests https://github.com/EngineHub/WorldEdit/issues/2250
+                // Due to two internal maps, a bug existed where both could have the same value
+                map.put(vec, chestWithNbt);
+                map.put(vec, air);
+
+                assertEquals(1, map.size());
+                assertEquals(air, map.get(vec));
             });
         }
 


### PR DESCRIPTION
Fixes https://github.com/EngineHub/WorldEdit/issues/2250. As far as I can tell this didn't affect WE itself, only API usages, as we never are in a position where we set values in this way.

Applies the suggested fix from the issue, and adds a regression test to prevent it occurring again.