### PR TITLE
Properly reinit convex CUI selection on primary click

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/ConvexPolyhedralRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/ConvexPolyhedralRegionSelector.java
@@ -25,6 +25,7 @@ import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.internal.cui.CUIRegion;
 import com.sk89q.worldedit.internal.cui.SelectionPointEvent;
 import com.sk89q.worldedit.internal.cui.SelectionPolygonEvent;
+import com.sk89q.worldedit.internal.cui.SelectionShapeEvent;
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.ConvexPolyhedralRegion;
@@ -199,6 +200,7 @@ public class ConvexPolyhedralRegionSelector implements RegionSelector, CUIRegion
         checkNotNull(session);
         checkNotNull(pos);
 
+        session.dispatchCUIEvent(player, new SelectionShapeEvent(getTypeID()));
         session.describeCUI(player);
 
         player.printInfo(TranslatableComponent.of("worldedit.selection.convex.explain.primary", TextComponent.of(pos.toString())));
@@ -219,6 +221,8 @@ public class ConvexPolyhedralRegionSelector implements RegionSelector, CUIRegion
     public void explainRegionAdjust(Actor player, LocalSession session) {
         checkNotNull(player);
         checkNotNull(session);
+
+        session.dispatchCUIEvent(player, new SelectionShapeEvent(getTypeID()));
         session.describeCUI(player);
     }
 


### PR DESCRIPTION
This is similar to the logic that a 2d poly selection does when transmitting a primary selection to the player.

Fixes #2312 