### PR TITLE
Add -Penginehub.obf.none=true gradle property to build mojmap worldedit-bukkit.

### DIFF
--- a/worldedit-bukkit/build.gradle.kts
+++ b/worldedit-bukkit/build.gradle.kts
@@ -27,7 +27,13 @@ val adapters = configurations.create("adapters") {
     isCanBeResolved = true
     shouldResolveConsistentlyWith(configurations["runtimeClasspath"])
     attributes {
-        attribute(Obfuscation.OBFUSCATION_ATTRIBUTE, objects.named(Obfuscation.OBFUSCATED))
+        attribute(Obfuscation.OBFUSCATION_ATTRIBUTE,
+            if ((project.findProperty("enginehub.obf.none") as String?).toBoolean()) {
+                objects.named(Obfuscation.NONE)
+            } else {
+                objects.named(Obfuscation.OBFUSCATED)
+            }
+        )
     }
 }
 


### PR DESCRIPTION
This simply takes the -dev adapter jars instead of the obfuscated ones, creating otherwise the exact same worldedit-bukkit jar. This jar can be used on mojmap paper servers.

Closes #1929.