### PR TITLE
Add a setting for compass navigation past border

### DIFF
--- a/worldedit-bukkit/src/main/resources/defaults/config.yml
+++ b/worldedit-bukkit/src/main/resources/defaults/config.yml
@@ -123,6 +123,7 @@ snapshots:
 navigation-wand:
     item: minecraft:compass
     max-distance: 100
+    teleport-past-world-border: false
 
 scripting:
     timeout: 3000

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalConfiguration.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalConfiguration.java
@@ -77,6 +77,7 @@ public abstract class LocalConfiguration {
     public boolean useInventoryOverride = false;
     public boolean useInventoryCreativeOverride = false;
     public boolean navigationUseGlass = true;
+    public boolean teleportPastWorldBorder = false;
     public String navigationWand = "minecraft:compass";
     public int navigationWandMaxDistance = 50;
     public int scriptTimeout = 3000;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
@@ -482,6 +482,18 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
         }
 
         Location foundBlock = hitBlox.getCurrentBlock();
+        //actual max and min points of the world are 17 blocks away from the visible border
+        final int maxX = getWorld().getMaximumPoint().getX() - 17;
+        final int maxZ = getWorld().getMaximumPoint().getZ() - 17;
+        final int minX = getWorld().getMinimumPoint().getX() + 17;
+        final int minZ = getWorld().getMinimumPoint().getZ() + 17;
+
+        if(!WorldEdit.getInstance().getConfiguration().teleportPastWorldBorder) {
+            if (foundBlock.getX() < minX || foundBlock.getZ() < minZ || foundBlock.getX() > maxX || foundBlock.getZ() > maxZ) {
+                return false;
+            }
+        }
+
         if (foundBlock != null) {
             setOnGround(foundBlock);
             return true;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/PropertiesConfiguration.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/PropertiesConfiguration.java
@@ -121,6 +121,7 @@ public class PropertiesConfiguration extends LocalConfiguration {
         } catch (Throwable ignored) {
         }
         navigationWandMaxDistance = getInt("nav-wand-distance", navigationWandMaxDistance);
+        teleportPastWorldBorder = getBool("teleport-past-world-border", teleportPastWorldBorder);
         navigationUseGlass = getBool("nav-use-glass", navigationUseGlass);
         scriptTimeout = getInt("scripting-timeout", scriptTimeout);
         calculationTimeout = getInt("calculation-timeout", calculationTimeout);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/YAMLConfiguration.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/YAMLConfiguration.java
@@ -102,6 +102,7 @@ public class YAMLConfiguration extends LocalConfiguration {
 
         navigationWand = convertLegacyItem(config.getString("navigation-wand.item", navigationWand)).toLowerCase(Locale.ROOT);
         navigationWandMaxDistance = config.getInt("navigation-wand.max-distance", navigationWandMaxDistance);
+        teleportPastWorldBorder = config.getBoolean("navigation-wand.teleport-past-world-border", teleportPastWorldBorder);
         navigationUseGlass = config.getBoolean("navigation.use-glass", navigationUseGlass);
 
         scriptTimeout = config.getInt("scripting.timeout", scriptTimeout);

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/config/ConfigurateConfiguration.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/config/ConfigurateConfiguration.java
@@ -120,6 +120,7 @@ public class ConfigurateConfiguration extends LocalConfiguration {
         } catch (Throwable ignored) {
         }
         navigationWandMaxDistance = node.node("navigation-wand", "max-distance").getInt(navigationWandMaxDistance);
+        teleportPastWorldBorder = node.node("navigation-wand", "teleport-past-world-border").getBoolean(teleportPastWorldBorder);
         navigationUseGlass = node.node("navigation", "use-glass").getBoolean(navigationUseGlass);
 
         scriptTimeout = node.node("scripting", "timeout").getInt(scriptTimeout);


### PR DESCRIPTION
I added a setting tpPastBorder to disable or enable navigating past the border with the compass navigation wand as requested in issue #2182 