### PR TITLE
Use registry lookups for Bukkit adapters

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitServerInterface.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitServerInterface.java
@@ -38,9 +38,10 @@ import com.sk89q.worldedit.util.lifecycle.Lifecycled;
 import com.sk89q.worldedit.world.DataFixer;
 import com.sk89q.worldedit.world.registry.Registries;
 import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
 import org.bukkit.Server;
 import org.bukkit.World;
-import org.bukkit.entity.EntityType;
 import org.enginehub.piston.CommandManager;
 
 import java.util.ArrayList;
@@ -104,12 +105,11 @@ public class BukkitServerInterface extends AbstractPlatform implements MultiUser
 
     @Override
     public boolean isValidMobType(String type) {
-        if (!type.startsWith("minecraft:")) {
+        NamespacedKey entityKey = NamespacedKey.fromString(type);
+        if (entityKey == null) {
             return false;
         }
-        @SuppressWarnings("deprecation")
-        final EntityType entityType = EntityType.fromName(type.substring(10));
-        return entityType != null && entityType.isAlive();
+        return Registry.ENTITY_TYPE.get(entityKey) != null;
     }
 
     @Override

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -264,16 +264,11 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
 
     private void setupTags() {
         // Tags
-        try {
-            for (Tag<Material> blockTag : Bukkit.getTags(Tag.REGISTRY_BLOCKS, Material.class)) {
-                BlockCategory.REGISTRY.register(blockTag.getKey().toString(), new BlockCategory(blockTag.getKey().toString()));
-            }
-            for (Tag<Material> itemTag : Bukkit.getTags(Tag.REGISTRY_ITEMS, Material.class)) {
-                ItemCategory.REGISTRY.register(itemTag.getKey().toString(), new ItemCategory(itemTag.getKey().toString()));
-            }
-        } catch (NoSuchMethodError ignored) {
-            // TODO Remove this catch once we drop older version support
-            getLogger().warning("The version of Spigot/Paper you are using doesn't support Tags. The usage of tags with WorldEdit will not work until you update.");
+        for (Tag<Material> blockTag : Bukkit.getTags(Tag.REGISTRY_BLOCKS, Material.class)) {
+            BlockCategory.REGISTRY.register(blockTag.getKey().toString(), new BlockCategory(blockTag.getKey().toString()));
+        }
+        for (Tag<Material> itemTag : Bukkit.getTags(Tag.REGISTRY_ITEMS, Material.class)) {
+            ItemCategory.REGISTRY.register(itemTag.getKey().toString(), new ItemCategory(itemTag.getKey().toString()));
         }
     }
 


### PR DESCRIPTION
When a lot of this code was written, Bukkit did not support Registry lookups. As these are now supported and various bugs have been fixed, we can greatly clean this up.

I also standardised the isValidMob check to be like other platforms

Targets master as this breaks support <1.17

Supersedes https://github.com/EngineHub/WorldEdit/pull/2294 - resolves all GitHub comments and makes better use of Bukkit API (no iterations of enums etc)