### PR TITLE
Add a BiomeCategories API

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1.20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R1/PaperweightAdapter.java
@@ -56,6 +56,7 @@ import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.io.file.SafeFiles;
 import com.sk89q.worldedit.world.DataFixer;
 import com.sk89q.worldedit.world.RegenOptions;
+import com.sk89q.worldedit.world.biome.BiomeCategory;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.biome.BiomeTypes;
 import com.sk89q.worldedit.world.block.BaseBlock;
@@ -70,6 +71,8 @@ import com.sk89q.worldedit.world.item.ItemType;
 import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
+import net.minecraft.core.HolderSet;
+import net.minecraft.core.Registry;
 import net.minecraft.core.SectionPos;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.ByteArrayTag;
@@ -184,6 +187,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -340,6 +344,14 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         }
 
         return state;
+    }
+
+    public BiomeType adapt(Biome biome) {
+        var mcBiome = ((CraftServer) Bukkit.getServer()).getServer().registryAccess().registryOrThrow(Registries.BIOME).getKey(biome);
+        if (mcBiome == null) {
+            return null;
+        }
+        return BiomeType.REGISTRY.get(mcBiome.toString());
     }
 
     public net.minecraft.world.level.block.state.BlockState adapt(BlockState blockState) {
@@ -908,6 +920,23 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
                 StructureType.REGISTRY.register(name.toString(), new StructureType(name.toString()));
             }
         }
+
+        // BiomeCategories
+        Registry<Biome> biomeRegistry = server.registryAccess().registryOrThrow(Registries.BIOME);
+        biomeRegistry.getTagNames().forEach(tagKey -> {
+            String key = tagKey.location().toString();
+            if (BiomeCategory.REGISTRY.get(key) == null) {
+                BiomeCategory.REGISTRY.register(key, new BiomeCategory(
+                    key,
+                    biomeRegistry.getTag(tagKey)
+                        .stream()
+                        .flatMap(HolderSet.Named::stream)
+                        .map(Holder::value)
+                        .map(this::adapt)
+                        .collect(Collectors.toSet()))
+                );
+            }
+        });
     }
 
     public boolean generateFeature(ConfiguredFeatureType type, World world, EditSession session, BlockVector3 pt) {

--- a/worldedit-bukkit/adapters/adapter-1.20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R1/PaperweightAdapter.java
@@ -928,7 +928,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             if (BiomeCategory.REGISTRY.get(key) == null) {
                 BiomeCategory.REGISTRY.register(key, new BiomeCategory(
                     key,
-                    biomeRegistry.getTag(tagKey)
+                    () -> biomeRegistry.getTag(tagKey)
                         .stream()
                         .flatMap(HolderSet.Named::stream)
                         .map(Holder::value)

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/registry/Category.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/registry/Category.java
@@ -23,12 +23,20 @@ import java.util.HashSet;
 import java.util.Set;
 
 public abstract class Category<T extends Keyed> {
-    private final Set<T> set = new HashSet<>();
+    private final Set<T> set;
     protected final String id;
     private boolean empty = true;
 
-    protected Category(final String id) {
+    public Category(final String id) {
         this.id = id;
+        // TODO Make this immutable in WE8
+        this.set = new HashSet<>();
+    }
+
+    public Category(final String id, final Set<T> contents) {
+        this.id = id;
+        this.set = Set.copyOf(contents);
+        this.empty = false;
     }
 
     public final String getId() {
@@ -43,6 +51,14 @@ public abstract class Category<T extends Keyed> {
         return this.set;
     }
 
+    /**
+     * Loads the contents of this category from the platform.
+     *
+     * @deprecated The load system will be removed in a future WorldEdit release. The registries should be populated by
+     * the platforms.
+     * @return The loaded contents of the category
+     */
+    @Deprecated
     protected abstract Set<T> load();
 
     /**
@@ -55,6 +71,11 @@ public abstract class Category<T extends Keyed> {
         return this.getAll().contains(object);
     }
 
+    /**
+     * @deprecated The load system will be removed in a future WorldEdit release. The registries should be populated by
+     * the platforms.
+     */
+    @Deprecated
     public void invalidateCache() {
         this.set.clear();
         this.empty = true;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/registry/NamespacedRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/registry/NamespacedRegistry.java
@@ -19,8 +19,6 @@
 
 package com.sk89q.worldedit.registry;
 
-import com.sk89q.worldedit.WorldEdit;
-
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/biome/BiomeCategories.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/biome/BiomeCategories.java
@@ -1,0 +1,93 @@
+package com.sk89q.worldedit.world.biome;
+
+/**
+ * Stores a list of common {@link BiomeCategory BiomeCategories}.
+ *
+ * @see BiomeCategory
+ */
+@SuppressWarnings("unused")
+public final class BiomeCategories {
+    public static final BiomeCategory ALLOWS_SURFACE_SLIME_SPAWNS = get("minecraft:allows_surface_slime_spawns");
+    public static final BiomeCategory ALLOWS_TROPICAL_FISH_SPAWNS_AT_ANY_HEIGHT = get("minecraft:allows_tropical_fish_spawns_at_any_height");
+    public static final BiomeCategory HAS_CLOSER_WATER_FOG = get("minecraft:has_closer_water_fog");
+    public static final BiomeCategory HAS_STRUCTURE_ANCIENT_CITY = get("minecraft:has_structure/ancient_city");
+    public static final BiomeCategory HAS_STRUCTURE_BASTION_REMNANT = get("minecraft:has_structure/bastion_remnant");
+    public static final BiomeCategory HAS_STRUCTURE_BURIED_TREASURE = get("minecraft:has_structure/buried_treasure");
+    public static final BiomeCategory HAS_STRUCTURE_DESERT_PYRAMID = get("minecraft:has_structure/desert_pyramid");
+    public static final BiomeCategory HAS_STRUCTURE_END_CITY = get("minecraft:has_structure/end_city");
+    public static final BiomeCategory HAS_STRUCTURE_IGLOO = get("minecraft:has_structure/igloo");
+    public static final BiomeCategory HAS_STRUCTURE_JUNGLE_TEMPLE = get("minecraft:has_structure/jungle_temple");
+    public static final BiomeCategory HAS_STRUCTURE_MINESHAFT = get("minecraft:has_structure/mineshaft");
+    public static final BiomeCategory HAS_STRUCTURE_MINESHAFT_MESA = get("minecraft:has_structure/mineshaft_mesa");
+    public static final BiomeCategory HAS_STRUCTURE_NETHER_FORTRESS = get("minecraft:has_structure/nether_fortress");
+    public static final BiomeCategory HAS_STRUCTURE_NETHER_FOSSIL = get("minecraft:has_structure/nether_fossil");
+    public static final BiomeCategory HAS_STRUCTURE_OCEAN_MONUMENT = get("minecraft:has_structure/ocean_monument");
+    public static final BiomeCategory HAS_STRUCTURE_OCEAN_RUIN_COLD = get("minecraft:has_structure/ocean_ruin_cold");
+    public static final BiomeCategory HAS_STRUCTURE_OCEAN_RUIN_WARM = get("minecraft:has_structure/ocean_ruin_warm");
+    public static final BiomeCategory HAS_STRUCTURE_PILLAGER_OUTPOST = get("minecraft:has_structure/pillager_outpost");
+    public static final BiomeCategory HAS_STRUCTURE_RUINED_PORTAL_DESERT = get("minecraft:has_structure/ruined_portal_desert");
+    public static final BiomeCategory HAS_STRUCTURE_RUINED_PORTAL_JUNGLE = get("minecraft:has_structure/ruined_portal_jungle");
+    public static final BiomeCategory HAS_STRUCTURE_RUINED_PORTAL_MOUNTAIN = get("minecraft:has_structure/ruined_portal_mountain");
+    public static final BiomeCategory HAS_STRUCTURE_RUINED_PORTAL_NETHER = get("minecraft:has_structure/ruined_portal_nether");
+    public static final BiomeCategory HAS_STRUCTURE_RUINED_PORTAL_OCEAN = get("minecraft:has_structure/ruined_portal_ocean");
+    public static final BiomeCategory HAS_STRUCTURE_RUINED_PORTAL_STANDARD = get("minecraft:has_structure/ruined_portal_standard");
+    public static final BiomeCategory HAS_STRUCTURE_RUINED_PORTAL_SWAMP = get("minecraft:has_structure/ruined_portal_swamp");
+    public static final BiomeCategory HAS_STRUCTURE_SHIPWRECK = get("minecraft:has_structure/shipwreck");
+    public static final BiomeCategory HAS_STRUCTURE_SHIPWRECK_BEACHED = get("minecraft:has_structure/shipwreck_beached");
+    public static final BiomeCategory HAS_STRUCTURE_STRONGHOLD = get("minecraft:has_structure/stronghold");
+    public static final BiomeCategory HAS_STRUCTURE_SWAMP_HUT = get("minecraft:has_structure/swamp_hut");
+    public static final BiomeCategory HAS_STRUCTURE_TRAIL_RUINS = get("minecraft:has_structure/trail_ruins");
+    public static final BiomeCategory HAS_STRUCTURE_VILLAGE_DESERT = get("minecraft:has_structure/village_desert");
+    public static final BiomeCategory HAS_STRUCTURE_VILLAGE_PLAINS = get("minecraft:has_structure/village_plains");
+    public static final BiomeCategory HAS_STRUCTURE_VILLAGE_SAVANNA = get("minecraft:has_structure/village_savanna");
+    public static final BiomeCategory HAS_STRUCTURE_VILLAGE_SNOWY = get("minecraft:has_structure/village_snowy");
+    public static final BiomeCategory HAS_STRUCTURE_VILLAGE_TAIGA = get("minecraft:has_structure/village_taiga");
+    public static final BiomeCategory HAS_STRUCTURE_WOODLAND_MANSION = get("minecraft:has_structure/woodland_mansion");
+    public static final BiomeCategory INCREASED_FIRE_BURNOUT = get("minecraft:increased_fire_burnout");
+    public static final BiomeCategory IS_BADLANDS = get("minecraft:is_badlands");
+    public static final BiomeCategory IS_BEACH = get("minecraft:is_beach");
+    public static final BiomeCategory IS_DEEP_OCEAN = get("minecraft:is_deep_ocean");
+    public static final BiomeCategory IS_END = get("minecraft:is_end");
+    public static final BiomeCategory IS_FOREST = get("minecraft:is_forest");
+    public static final BiomeCategory IS_HILL = get("minecraft:is_hill");
+    public static final BiomeCategory IS_JUNGLE = get("minecraft:is_jungle");
+    public static final BiomeCategory IS_MOUNTAIN = get("minecraft:is_mountain");
+    public static final BiomeCategory IS_NETHER = get("minecraft:is_nether");
+    public static final BiomeCategory IS_OCEAN = get("minecraft:is_ocean");
+    public static final BiomeCategory IS_OVERWORLD = get("minecraft:is_overworld");
+    public static final BiomeCategory IS_RIVER = get("minecraft:is_river");
+    public static final BiomeCategory IS_SAVANNA = get("minecraft:is_savanna");
+    public static final BiomeCategory IS_TAIGA = get("minecraft:is_taiga");
+    public static final BiomeCategory MINESHAFT_BLOCKING = get("minecraft:mineshaft_blocking");
+    public static final BiomeCategory MORE_FREQUENT_DROWNED_SPAWNS = get("minecraft:more_frequent_drowned_spawns");
+    public static final BiomeCategory PLAYS_UNDERWATER_MUSIC = get("minecraft:plays_underwater_music");
+    public static final BiomeCategory POLAR_BEARS_SPAWN_ON_ALTERNATE_BLOCKS = get("minecraft:polar_bears_spawn_on_alternate_blocks");
+    public static final BiomeCategory PRODUCES_CORALS_FROM_BONEMEAL = get("minecraft:produces_corals_from_bonemeal");
+    public static final BiomeCategory REDUCE_WATER_AMBIENT_SPAWNS = get("minecraft:reduce_water_ambient_spawns");
+    public static final BiomeCategory REQUIRED_OCEAN_MONUMENT_SURROUNDING = get("minecraft:required_ocean_monument_surrounding");
+    public static final BiomeCategory SNOW_GOLEM_MELTS = get("minecraft:snow_golem_melts");
+    public static final BiomeCategory SPAWNS_COLD_VARIANT_FROGS = get("minecraft:spawns_cold_variant_frogs");
+    public static final BiomeCategory SPAWNS_GOLD_RABBITS = get("minecraft:spawns_gold_rabbits");
+    public static final BiomeCategory SPAWNS_SNOW_FOXES = get("minecraft:spawns_snow_foxes");
+    public static final BiomeCategory SPAWNS_WARM_VARIANT_FROGS = get("minecraft:spawns_warm_variant_frogs");
+    public static final BiomeCategory SPAWNS_WHITE_RABBITS = get("minecraft:spawns_white_rabbits");
+    public static final BiomeCategory STRONGHOLD_BIASED_TO = get("minecraft:stronghold_biased_to");
+    public static final BiomeCategory WATER_ON_MAP_OUTLINES = get("minecraft:water_on_map_outlines");
+    public static final BiomeCategory WITHOUT_PATROL_SPAWNS = get("minecraft:without_patrol_spawns");
+    public static final BiomeCategory WITHOUT_WANDERING_TRADER_SPAWNS = get("minecraft:without_wandering_trader_spawns");
+    public static final BiomeCategory WITHOUT_ZOMBIE_SIEGES = get("minecraft:without_zombie_sieges");
+
+    private BiomeCategories() {
+    }
+
+    /**
+     * Gets the {@link BiomeCategory} associated with the given id.
+     */
+    public static BiomeCategory get(String id) {
+        BiomeCategory entry = BiomeCategory.REGISTRY.get(id);
+        if (entry == null) {
+            return new BiomeCategory(id);
+        }
+        return entry;
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/biome/BiomeCategories.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/biome/BiomeCategories.java
@@ -1,3 +1,22 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.sk89q.worldedit.world.biome;
 
 /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/biome/BiomeCategory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/biome/BiomeCategory.java
@@ -24,6 +24,7 @@ import com.sk89q.worldedit.registry.Keyed;
 import com.sk89q.worldedit.registry.NamespacedRegistry;
 
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * A category of biomes.
@@ -36,8 +37,8 @@ public class BiomeCategory extends Category<BiomeType> implements Keyed {
         super(id);
     }
 
-    public BiomeCategory(final String id, final Set<BiomeType> contents) {
-        super(id, contents);
+    public BiomeCategory(final String id, final Supplier<Set<BiomeType>> contentSupplier) {
+        super(id, contentSupplier);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/biome/BiomeCategory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/biome/BiomeCategory.java
@@ -1,0 +1,48 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.world.biome;
+
+import com.sk89q.worldedit.registry.Category;
+import com.sk89q.worldedit.registry.Keyed;
+import com.sk89q.worldedit.registry.NamespacedRegistry;
+
+import java.util.Set;
+
+/**
+ * A category of biomes.
+ */
+public class BiomeCategory extends Category<BiomeType> implements Keyed {
+
+    public static final NamespacedRegistry<BiomeCategory> REGISTRY = new NamespacedRegistry<>("biome tag", true);
+
+    public BiomeCategory(final String id) {
+        super(id);
+    }
+
+    public BiomeCategory(final String id, final Set<BiomeType> contents) {
+        super(id, contents);
+    }
+
+    @Override
+    protected Set<BiomeType> load() {
+        return Set.of();
+    }
+
+}

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorldEdit.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorldEdit.java
@@ -241,7 +241,7 @@ public class FabricWorldEdit implements ModInitializer {
             if (BiomeCategory.REGISTRY.get(key) == null) {
                 BiomeCategory.REGISTRY.register(key, new BiomeCategory(
                     key,
-                    biomeRegistry.getTag(tagKey)
+                    () -> biomeRegistry.getTag(tagKey)
                         .stream()
                         .flatMap(HolderSet.Named::stream)
                         .map(Holder::value)

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorldEdit.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorldEdit.java
@@ -36,6 +36,7 @@ import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.lifecycle.Lifecycled;
 import com.sk89q.worldedit.util.lifecycle.SimpleLifecycled;
+import com.sk89q.worldedit.world.biome.BiomeCategory;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockCategory;
 import com.sk89q.worldedit.world.block.BlockType;
@@ -59,6 +60,8 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderSet;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
@@ -73,6 +76,7 @@ import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.phys.BlockHitResult;
 import org.apache.logging.log4j.Logger;
 import org.enginehub.piston.Command;
@@ -84,6 +88,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.sk89q.worldedit.fabric.FabricAdapter.adaptPlayer;
@@ -228,6 +233,21 @@ public class FabricWorldEdit implements ModInitializer {
         server.registryAccess().registryOrThrow(Registries.ITEM).getTagNames().map(TagKey::location).forEach(name -> {
             if (ItemCategory.REGISTRY.get(name.toString()) == null) {
                 ItemCategory.REGISTRY.register(name.toString(), new ItemCategory(name.toString()));
+            }
+        });
+        Registry<Biome> biomeRegistry = server.registryAccess().registryOrThrow(Registries.BIOME);
+        biomeRegistry.getTagNames().forEach(tagKey -> {
+            String key = tagKey.location().toString();
+            if (BiomeCategory.REGISTRY.get(key) == null) {
+                BiomeCategory.REGISTRY.register(key, new BiomeCategory(
+                    key,
+                    biomeRegistry.getTag(tagKey)
+                        .stream()
+                        .flatMap(HolderSet.Named::stream)
+                        .map(Holder::value)
+                        .map(FabricAdapter::adapt)
+                        .collect(Collectors.toSet()))
+                );
             }
         });
         // Features

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
@@ -223,7 +223,7 @@ public class ForgeWorldEdit {
             if (BiomeCategory.REGISTRY.get(key) == null) {
                 BiomeCategory.REGISTRY.register(key, new BiomeCategory(
                     key,
-                    biomeRegistry.getTag(tagKey)
+                    () -> biomeRegistry.getTag(tagKey)
                         .stream()
                         .flatMap(HolderSet.Named::stream)
                         .map(Holder::value)

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
@@ -38,6 +38,7 @@ import com.sk89q.worldedit.internal.anvil.ChunkDeleter;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldedit.world.biome.BiomeCategory;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockCategory;
 import com.sk89q.worldedit.world.block.BlockType;
@@ -47,6 +48,9 @@ import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.item.ItemCategory;
 import com.sk89q.worldedit.world.item.ItemType;
 import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderSet;
+import net.minecraft.core.Registry;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
@@ -54,6 +58,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.level.biome.Biome;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.CommandEvent;
 import net.minecraftforge.event.RegisterCommandsEvent;
@@ -87,6 +92,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.sk89q.worldedit.forge.ForgeAdapter.adaptCommandSource;
@@ -209,6 +215,21 @@ public class ForgeWorldEdit {
         server.registryAccess().registryOrThrow(Registries.ITEM).getTagNames().map(TagKey::location).forEach(name -> {
             if (ItemCategory.REGISTRY.get(name.toString()) == null) {
                 ItemCategory.REGISTRY.register(name.toString(), new ItemCategory(name.toString()));
+            }
+        });
+        Registry<Biome> biomeRegistry = server.registryAccess().registryOrThrow(Registries.BIOME);
+        biomeRegistry.getTagNames().forEach(tagKey -> {
+            String key = tagKey.location().toString();
+            if (BiomeCategory.REGISTRY.get(key) == null) {
+                BiomeCategory.REGISTRY.register(key, new BiomeCategory(
+                    key,
+                    biomeRegistry.getTag(tagKey)
+                        .stream()
+                        .flatMap(HolderSet.Named::stream)
+                        .map(Holder::value)
+                        .map(ForgeAdapter::adapt)
+                        .collect(Collectors.toSet()))
+                );
             }
         });
         // Features

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeAdapter.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeAdapter.java
@@ -136,6 +136,10 @@ public class SpongeAdapter {
             .asReference();
     }
 
+    public static BiomeType adapt(Biome biomeType) {
+        return BiomeType.REGISTRY.get(biomeType.toString());
+    }
+
     /**
      * Create a WorldEdit location from a Sponge location.
      *

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorldEdit.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorldEdit.java
@@ -36,6 +36,7 @@ import com.sk89q.worldedit.extension.platform.PlatformManager;
 import com.sk89q.worldedit.internal.anvil.ChunkDeleter;
 import com.sk89q.worldedit.internal.command.CommandUtil;
 import com.sk89q.worldedit.sponge.config.SpongeConfiguration;
+import com.sk89q.worldedit.world.biome.BiomeCategory;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockCategory;
 import com.sk89q.worldedit.world.item.ItemCategory;
@@ -83,6 +84,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static com.sk89q.worldedit.internal.anvil.ChunkDeleter.DELCHUNKS_FILE_NAME;
 import static java.util.stream.Collectors.toList;
@@ -203,6 +205,12 @@ public class SpongeWorldEdit {
             String id = itemTypeTag.key().asString();
             if (!ItemCategory.REGISTRY.keySet().contains(id)) {
                 ItemCategory.REGISTRY.register(id, new ItemCategory(id));
+            }
+        });
+        event.game().registry(RegistryTypes.BIOME).tags().forEach(biomeTag -> {
+            String id = biomeTag.key().asString();
+            if (!BiomeCategory.REGISTRY.keySet().contains(id)) {
+                BiomeCategory.REGISTRY.register(id, new BiomeCategory(id, event.game().registry(RegistryTypes.BIOME).taggedValues(biomeTag).stream().map(SpongeAdapter::adapt).collect(Collectors.toSet())));
             }
         });
 

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorldEdit.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorldEdit.java
@@ -210,7 +210,7 @@ public class SpongeWorldEdit {
         event.game().registry(RegistryTypes.BIOME).tags().forEach(biomeTag -> {
             String id = biomeTag.key().asString();
             if (!BiomeCategory.REGISTRY.keySet().contains(id)) {
-                BiomeCategory.REGISTRY.register(id, new BiomeCategory(id, event.game().registry(RegistryTypes.BIOME).taggedValues(biomeTag).stream().map(SpongeAdapter::adapt).collect(Collectors.toSet())));
+                BiomeCategory.REGISTRY.register(id, new BiomeCategory(id, () -> event.game().registry(RegistryTypes.BIOME).taggedValues(biomeTag).stream().map(SpongeAdapter::adapt).collect(Collectors.toSet())));
             }
         });
 


### PR DESCRIPTION
This PR adds BiomeCategories, and reworks the category registry system to make it provided by the platform rather than pulling from the platform. Expanding this would heavily cleanup the code.

There are some open design questions though, the main ones being:

- [x] Rather than passing a set to the category, should it receive a Supplier?

This PR mostly uses the new category type as a demo for the API changes; will follow up with entity categories too after this is all sorted

Fixes https://github.com/EngineHub/WorldEdit/issues/2331