### PR TITLE
Improve error behaviour of //generate

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -2240,9 +2240,10 @@ public class EditSession implements Extent, AutoCloseable {
                 } catch (ExpressionTimeoutException e) {
                     timedOut[0] = timedOut[0] + 1;
                     return null;
+                } catch (RuntimeException e) {
+                    throw e;
                 } catch (Exception e) {
-                    LOGGER.warn("Failed to create shape", e);
-                    return null;
+                    throw new RuntimeException(e);
                 }
             }
         };


### PR DESCRIPTION
Now it has the same error behaviour as //deform.