### PR TITLE
Fix legacy block wrappers with new NBT API

### DIFF
--- a/worldedit-core/src/legacy/java/com/sk89q/worldedit/blocks/LegacyBaseBlockWrapper.java
+++ b/worldedit-core/src/legacy/java/com/sk89q/worldedit/blocks/LegacyBaseBlockWrapper.java
@@ -1,0 +1,48 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.blocks;
+
+import com.sk89q.jnbt.CompoundTag;
+import com.sk89q.worldedit.util.concurrency.LazyReference;
+import com.sk89q.worldedit.world.block.BaseBlock;
+import com.sk89q.worldedit.world.block.BlockState;
+import org.enginehub.linbus.tree.LinCompoundTag;
+
+import javax.annotation.Nullable;
+
+@Deprecated
+public class LegacyBaseBlockWrapper extends BaseBlock {
+    protected LegacyBaseBlockWrapper(BlockState blockState) {
+        super(blockState);
+    }
+
+    // These two methods force the legacy blocks to use the old NBT methods.
+    @Nullable
+    @Override
+    public LazyReference<LinCompoundTag> getNbtReference() {
+        CompoundTag nbtData = getNbtData();
+        return nbtData == null ? null : LazyReference.from(nbtData::toLinTag);
+    }
+
+    @Override
+    public void setNbtReference(@Nullable LazyReference<LinCompoundTag> nbtData) {
+        setNbtData(nbtData == null ? null : new CompoundTag(nbtData.getValue()));
+    }
+}

--- a/worldedit-core/src/legacy/java/com/sk89q/worldedit/blocks/MobSpawnerBlock.java
+++ b/worldedit-core/src/legacy/java/com/sk89q/worldedit/blocks/MobSpawnerBlock.java
@@ -28,7 +28,6 @@ import com.sk89q.jnbt.NBTUtils;
 import com.sk89q.jnbt.ShortTag;
 import com.sk89q.jnbt.StringTag;
 import com.sk89q.jnbt.Tag;
-import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.storage.InvalidFormatException;
 
@@ -42,7 +41,7 @@ import java.util.Map;
  *     deprecated for removal without replacement
  */
 @Deprecated
-public class MobSpawnerBlock extends BaseBlock {
+public class MobSpawnerBlock extends LegacyBaseBlockWrapper {
 
     private String mobType;
     private short delay = -1;

--- a/worldedit-core/src/legacy/java/com/sk89q/worldedit/blocks/SignBlock.java
+++ b/worldedit-core/src/legacy/java/com/sk89q/worldedit/blocks/SignBlock.java
@@ -27,7 +27,6 @@ import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.platform.Capability;
 import com.sk89q.worldedit.internal.Constants;
 import com.sk89q.worldedit.util.gson.GsonUtil;
-import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
 
 import java.util.Arrays;
@@ -42,7 +41,7 @@ import java.util.stream.Collectors;
  *     deprecated for removal without replacement
  */
 @Deprecated
-public class SignBlock extends BaseBlock {
+public class SignBlock extends LegacyBaseBlockWrapper {
 
     private String[] text;
 

--- a/worldedit-core/src/legacy/java/com/sk89q/worldedit/blocks/SkullBlock.java
+++ b/worldedit-core/src/legacy/java/com/sk89q/worldedit/blocks/SkullBlock.java
@@ -23,7 +23,6 @@ import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.jnbt.StringTag;
 import com.sk89q.jnbt.Tag;
 import com.sk89q.worldedit.internal.util.DeprecationUtil;
-import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
 
 import java.util.HashMap;
@@ -36,7 +35,7 @@ import java.util.Map;
  *     deprecated for removal without replacement
  */
 @Deprecated
-public class SkullBlock extends BaseBlock {
+public class SkullBlock extends LegacyBaseBlockWrapper {
 
     private String owner = ""; // notchian
 


### PR DESCRIPTION
This adds a class that redirects the legacy block wrapper NBT functions from the new NBT API. I kept it as-is and just added a wrapper due to these being deprecated for removal in WE8. Basically, just a hack to make them work until removed.

Fixes #2358