### PR TITLE
Preserve player-set side effects

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -107,7 +107,6 @@ public class LocalSession {
     private transient boolean useInventory;
     private transient com.sk89q.worldedit.world.snapshot.Snapshot snapshot;
     private transient Snapshot snapshotExperimental;
-    private transient SideEffectSet sideEffectSet = SideEffectSet.defaults();
     private transient Mask mask;
     private transient ZoneId timezone = ZoneId.systemDefault();
     private transient BlockVector3 cuiTemporaryBlock;
@@ -127,6 +126,7 @@ public class LocalSession {
     private Boolean wandItemDefault;
     private String navWandItem;
     private Boolean navWandItemDefault;
+    private SideEffectSet sideEffectSet = SideEffectSet.defaults();
 
     /**
      * Construct the object.
@@ -1159,6 +1159,7 @@ public class LocalSession {
      */
     public void setSideEffectSet(SideEffectSet sideEffectSet) {
         this.sideEffectSet = sideEffectSet;
+        setDirty();
     }
 
     /**
@@ -1178,7 +1179,7 @@ public class LocalSession {
      */
     @Deprecated
     public void setFastMode(boolean fastMode) {
-        this.sideEffectSet = fastMode ? SideEffectSet.none() : SideEffectSet.defaults();
+        setSideEffectSet(fastMode ? SideEffectSet.none() : SideEffectSet.defaults());
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/storage/JsonFileSessionStore.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/storage/JsonFileSessionStore.java
@@ -25,6 +25,7 @@ import com.google.gson.JsonIOException;
 import com.google.gson.JsonParseException;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
+import com.sk89q.worldedit.util.SideEffectSet;
 import com.sk89q.worldedit.util.gson.GsonUtil;
 import org.apache.logging.log4j.Logger;
 
@@ -77,7 +78,9 @@ public class JsonFileSessionStore implements SessionStore {
         this.dir = dir;
 
         GsonBuilder builder = GsonUtil.createBuilder();
-        gson = builder.create();
+        gson = builder
+            .registerTypeAdapter(SideEffectSet.class, new SideEffectSet.GsonSerializer())
+            .create();
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/SideEffectSet.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/SideEffectSet.java
@@ -21,7 +21,16 @@ package com.sk89q.worldedit.util;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
 
+import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.Map;
@@ -90,5 +99,29 @@ public class SideEffectSet {
 
     public static SideEffectSet none() {
         return NONE;
+    }
+
+    public static class GsonSerializer implements JsonSerializer<SideEffectSet>, JsonDeserializer<SideEffectSet> {
+
+        @Override
+        public SideEffectSet deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            Map<SideEffect, SideEffect.State> sideEffects = Maps.newEnumMap(SideEffect.class);
+            JsonObject obj = json.getAsJsonObject();
+            for (Map.Entry<String, JsonElement> stringJsonElementEntry : obj.entrySet()) {
+                SideEffect sideEffect = SideEffect.valueOf(stringJsonElementEntry.getKey());
+                SideEffect.State state = SideEffect.State.valueOf(stringJsonElementEntry.getValue().getAsString());
+                sideEffects.put(sideEffect, state);
+            }
+            return new SideEffectSet(sideEffects);
+        }
+
+        @Override
+        public JsonElement serialize(SideEffectSet src, Type typeOfSrc, JsonSerializationContext context) {
+            JsonObject obj = new JsonObject();
+            for (Map.Entry<SideEffect, SideEffect.State> entry : src.sideEffects.entrySet()) {
+                obj.add(entry.getKey().name(), new JsonPrimitive(entry.getValue().name()));
+            }
+            return obj;
+        }
     }
 }


### PR DESCRIPTION
More a test PR to see how it behaves to see if we really want to do it, but it fixes https://github.com/EngineHub/WorldEdit/issues/2293.

As it's a class it requires a custom serializer/deserializer, which means if we were to ever add another session store type it'd need to be included there too.

Biggest caveat from testing is that once something is set in there, there's no way to set it back to "default". We're storing the list of side effects that differ from default in the SideEffectSet