### PR TITLE
Add worldedit runtime environment to increase yaml alias limit

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/util/yaml/YAMLProcessor.java
+++ b/worldedit-core/src/main/java/com/sk89q/util/yaml/YAMLProcessor.java
@@ -97,6 +97,8 @@ public class YAMLProcessor extends YAMLNode {
         representer.setDefaultFlowStyle(format.getStyle());
         LoaderOptions loaderOptions = new LoaderOptions();
         try {
+            int yamlAliasLimit = Integer.getInteger("worldedit.yaml.aliasLimit", 50);
+            loaderOptions.setMaxAliasesForCollections(yamlAliasLimit);
             // 64 MB default
             int yamlCodePointLimit = Integer.getInteger("worldedit.yaml.codePointLimit", 64 * 1024 * 1024);
             loaderOptions.setCodePointLimit(yamlCodePointLimit);
@@ -104,7 +106,7 @@ public class YAMLProcessor extends YAMLNode {
             // pre-1.32 snakeyaml
         }
 
-        yaml = new Yaml(new SafeConstructor(new LoaderOptions()), representer, dumperOptions, loaderOptions);
+        yaml = new Yaml(new SafeConstructor(loaderOptions), representer, dumperOptions, loaderOptions);
 
         this.file = file;
     }


### PR DESCRIPTION
Using snakeyaml can be a PITA sometimes. Depending on the used objects the nodes can be replaced by aliases when stuff is saved snakeyaml. Deserializing aliases only works with 50 aliases by default.

This PR adds a runtime environment option which can increase the alias limit. This can be set by -Dworldedit.yaml.aliasLimit=XXX in the startup parameter.