### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/worldedit-core/doctools/src/main/kotlin/com/sk89q/worldedit/internal/util/DocumentationPrinter.kt
+++ b/worldedit-core/doctools/src/main/kotlin/com/sk89q/worldedit/internal/util/DocumentationPrinter.kt
@@ -207,7 +207,7 @@ Other Permissions
     ``worldedit.inventory.unrestricted``,"Override the ``use-inventory`` option if enabled in the :doc:`configuration <config>`."
     ``worldedit.override.bedrock``,"Allows breaking of bedrock with the super-pickaxe tool."
     ``worldedit.override.data-cycler``,"Allows cycling non-whitelisted blocks with the data cycler tool."
-    ``worldedit.setnbt``,"Allows setting `extra data <https://minecraft.gamepedia.com/Block_entity>`_ on blocks (such as signs, chests, etc)."
+    ``worldedit.setnbt``,"Allows setting `extra data <https://minecraft.wiki/w/Block_entity>`_ on blocks (such as signs, chests, etc)."
     ``worldedit.report.pastebin``,"Allows uploading report files to pastebin automatically for the ``/worldedit report`` :doc:`command <commands>`."
     ``worldedit.scripting.execute.<filename>``,"Allows using the CraftScript with the given filename."
 """.trim())

--- a/worldedit-core/src/main/java/com/sk89q/jnbt/NBTInputStream.java
+++ b/worldedit-core/src/main/java/com/sk89q/jnbt/NBTInputStream.java
@@ -34,8 +34,8 @@ import java.io.InputStream;
  *
  * <p>
  * The NBT format was created by Markus Persson, and the specification may be
- * found at <a href="https://minecraft.gamepedia.com/NBT_format">
- * https://minecraft.gamepedia.com/NBT_format</a>.
+ * found at <a href="https://minecraft.wiki/w/NBT_format">
+ * https://minecraft.wiki/w/NBT_format</a>.
  * </p>
  *
  * @deprecated JNBT is being removed for lin-bus in WorldEdit 8, use {@link LinBinaryIO} instead

--- a/worldedit-core/src/main/java/com/sk89q/jnbt/NBTOutputStream.java
+++ b/worldedit-core/src/main/java/com/sk89q/jnbt/NBTOutputStream.java
@@ -34,8 +34,8 @@ import java.io.OutputStream;
  *
  * <p>
  * The NBT format was created by Markus Persson, and the specification may be
- * found at <a href="https://minecraft.gamepedia.com/NBT_format">
- * https://minecraft.gamepedia.com/NBT_format</a>.
+ * found at <a href="https://minecraft.wiki/w/NBT_format">
+ * https://minecraft.wiki/w/NBT_format</a>.
  * </p>
  *
  * @deprecated JNBT is being removed for lin-bus in WorldEdit 8, use {@link LinBinaryIO} instead


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.