### PR TITLE
Draft: Adventure: Introduce WorldEdit to an adventure

### DIFF
--- a/buildSrc/src/main/kotlin/LibsConfig.kt
+++ b/buildSrc/src/main/kotlin/LibsConfig.kt
@@ -37,7 +37,7 @@ fun Project.applyLibrariesConfiguration() {
     group = "${rootProject.group}.worldedit-libs"
 
     val relocations = mapOf(
-        "net.kyori.text" to "com.sk89q.worldedit.util.formatting.text",
+        "net.kyori.adventure" to "com.sk89q.worldedit.util.formatting",
         "net.kyori.minecraft" to "com.sk89q.worldedit.util.kyori",
     )
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,9 +1,9 @@
 import org.gradle.api.Project
 
 object Versions {
-    const val TEXT = "3.0.4"
-    const val TEXT_EXTRAS = "3.0.6"
-    const val PISTON = "0.5.7"
+    const val KYORI_ADVENTURE = "4.14.0"
+    const val KYORI_PLATFORM_BUKKIT = "4.3.1"
+    const val PISTON = "0.6.0-SNAPSHOT"
     const val AUTO_VALUE = "1.9"
     const val JUNIT = "5.8.1"
     const val MOCKITO = "4.3.1"

--- a/worldedit-bukkit/adapters/adapter-1.17.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_17_R1_2/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.17.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_17_R1_2/PaperweightAdapter.java
@@ -51,7 +51,6 @@ import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.SideEffect;
 import com.sk89q.worldedit.util.concurrency.LazyReference;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.io.file.SafeFiles;
 import com.sk89q.worldedit.world.DataFixer;
 import com.sk89q.worldedit.world.RegenOptions;
@@ -544,17 +543,17 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
     @Override
     public Component getRichBlockName(BlockType blockType) {
-        return TranslatableComponent.of(getBlockFromType(blockType).getDescriptionId());
+        return Component.translatable(getBlockFromType(blockType).getDescriptionId());
     }
 
     @Override
     public Component getRichItemName(ItemType itemType) {
-        return TranslatableComponent.of(getItemFromType(itemType).getDescriptionId());
+        return Component.translatable(getItemFromType(itemType).getDescriptionId());
     }
 
     @Override
     public Component getRichItemName(BaseItemStack itemStack) {
-        return TranslatableComponent.of(CraftItemStack.asNMSCopy(BukkitAdapter.adapt(itemStack)).getDescriptionId());
+        return Component.translatable(CraftItemStack.asNMSCopy(BukkitAdapter.adapt(itemStack)).getDescriptionId());
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/worldedit-bukkit/adapters/adapter-1.18.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_18_R2/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.18.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_18_R2/PaperweightAdapter.java
@@ -51,7 +51,6 @@ import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.SideEffect;
 import com.sk89q.worldedit.util.concurrency.LazyReference;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.io.file.SafeFiles;
 import com.sk89q.worldedit.world.DataFixer;
 import com.sk89q.worldedit.world.RegenOptions;
@@ -536,17 +535,17 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
     @Override
     public Component getRichBlockName(BlockType blockType) {
-        return TranslatableComponent.of(getBlockFromType(blockType).getDescriptionId());
+        return Component.translatable(getBlockFromType(blockType).getDescriptionId());
     }
 
     @Override
     public Component getRichItemName(ItemType itemType) {
-        return TranslatableComponent.of(getItemFromType(itemType).getDescriptionId());
+        return Component.translatable(getItemFromType(itemType).getDescriptionId());
     }
 
     @Override
     public Component getRichItemName(BaseItemStack itemStack) {
-        return TranslatableComponent.of(CraftItemStack.asNMSCopy(BukkitAdapter.adapt(itemStack)).getDescriptionId());
+        return Component.translatable(CraftItemStack.asNMSCopy(BukkitAdapter.adapt(itemStack)).getDescriptionId());
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/worldedit-bukkit/adapters/adapter-1.19.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_19_R3/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.19.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_19_R3/PaperweightAdapter.java
@@ -52,7 +52,6 @@ import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.SideEffect;
 import com.sk89q.worldedit.util.concurrency.LazyReference;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.io.file.SafeFiles;
 import com.sk89q.worldedit.world.DataFixer;
 import com.sk89q.worldedit.world.RegenOptions;
@@ -568,17 +567,17 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
     @Override
     public Component getRichBlockName(BlockType blockType) {
-        return TranslatableComponent.of(getBlockFromType(blockType).getDescriptionId());
+        return Component.translatable(getBlockFromType(blockType).getDescriptionId());
     }
 
     @Override
     public Component getRichItemName(ItemType itemType) {
-        return TranslatableComponent.of(getItemFromType(itemType).getDescriptionId());
+        return Component.translatable(getItemFromType(itemType).getDescriptionId());
     }
 
     @Override
     public Component getRichItemName(BaseItemStack itemStack) {
-        return TranslatableComponent.of(CraftItemStack.asNMSCopy(BukkitAdapter.adapt(itemStack)).getDescriptionId());
+        return Component.translatable(CraftItemStack.asNMSCopy(BukkitAdapter.adapt(itemStack)).getDescriptionId());
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/worldedit-bukkit/adapters/adapter-1.20.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R2/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.20.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R2/PaperweightAdapter.java
@@ -52,7 +52,6 @@ import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.SideEffect;
 import com.sk89q.worldedit.util.concurrency.LazyReference;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.io.file.SafeFiles;
 import com.sk89q.worldedit.world.DataFixer;
 import com.sk89q.worldedit.world.RegenOptions;
@@ -568,17 +567,17 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
     @Override
     public Component getRichBlockName(BlockType blockType) {
-        return TranslatableComponent.of(getBlockFromType(blockType).getDescriptionId());
+        return Component.translatable(getBlockFromType(blockType).getDescriptionId());
     }
 
     @Override
     public Component getRichItemName(ItemType itemType) {
-        return TranslatableComponent.of(getItemFromType(itemType).getDescriptionId());
+        return Component.translatable(getItemFromType(itemType).getDescriptionId());
     }
 
     @Override
     public Component getRichItemName(BaseItemStack itemStack) {
-        return TranslatableComponent.of(CraftItemStack.asNMSCopy(BukkitAdapter.adapt(itemStack)).getDescriptionId());
+        return Component.translatable(CraftItemStack.asNMSCopy(BukkitAdapter.adapt(itemStack)).getDescriptionId());
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/worldedit-bukkit/adapters/adapter-1.20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R1/PaperweightAdapter.java
@@ -52,7 +52,6 @@ import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.SideEffect;
 import com.sk89q.worldedit.util.concurrency.LazyReference;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.io.file.SafeFiles;
 import com.sk89q.worldedit.world.DataFixer;
 import com.sk89q.worldedit.world.RegenOptions;
@@ -568,17 +567,17 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
     @Override
     public Component getRichBlockName(BlockType blockType) {
-        return TranslatableComponent.of(getBlockFromType(blockType).getDescriptionId());
+        return Component.translatable(getBlockFromType(blockType).getDescriptionId());
     }
 
     @Override
     public Component getRichItemName(ItemType itemType) {
-        return TranslatableComponent.of(getItemFromType(itemType).getDescriptionId());
+        return Component.translatable(getItemFromType(itemType).getDescriptionId());
     }
 
     @Override
     public Component getRichItemName(BaseItemStack itemStack) {
-        return TranslatableComponent.of(CraftItemStack.asNMSCopy(BukkitAdapter.adapt(itemStack)).getDescriptionId());
+        return Component.translatable(CraftItemStack.asNMSCopy(BukkitAdapter.adapt(itemStack)).getDescriptionId());
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBiomeRegistry.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBiomeRegistry.java
@@ -20,7 +20,6 @@
 package com.sk89q.worldedit.bukkit;
 
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.translation.TranslationManager;
 import com.sk89q.worldedit.world.biome.BiomeData;
 import com.sk89q.worldedit.world.biome.BiomeType;
@@ -39,7 +38,7 @@ class BukkitBiomeRegistry implements BiomeRegistry {
 
     @Override
     public Component getRichName(BiomeType biomeType) {
-        return TranslatableComponent.of(
+        return Component.translatable(
             TranslationManager.makeTranslationKey("biome", biomeType.getId())
         );
     }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockCommandSender.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockCommandSender.java
@@ -25,9 +25,7 @@ import com.sk89q.worldedit.session.SessionKey;
 import com.sk89q.worldedit.util.auth.AuthorizationException;
 import com.sk89q.worldedit.util.formatting.WorldEditText;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.adapter.bukkit.TextAdapter;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -70,7 +68,7 @@ public class BukkitBlockCommandSender extends AbstractCommandBlockActor {
     @Deprecated
     public void print(String msg) {
         for (String part : msg.split("\n")) {
-            print(TextComponent.of(part, TextColor.LIGHT_PURPLE));
+            print(Component.text(part, NamedTextColor.LIGHT_PURPLE));
         }
     }
 
@@ -78,7 +76,7 @@ public class BukkitBlockCommandSender extends AbstractCommandBlockActor {
     @Deprecated
     public void printDebug(String msg) {
         for (String part : msg.split("\n")) {
-            print(TextComponent.of(part, TextColor.GRAY));
+            print(Component.text(part, NamedTextColor.GRAY));
         }
     }
 
@@ -86,13 +84,13 @@ public class BukkitBlockCommandSender extends AbstractCommandBlockActor {
     @Deprecated
     public void printError(String msg) {
         for (String part : msg.split("\n")) {
-            print(TextComponent.of(part, TextColor.RED));
+            print(Component.text(part, NamedTextColor.RED));
         }
     }
 
     @Override
     public void print(Component component) {
-        TextAdapter.sendMessage(sender, WorldEditText.format(component, getLocale()));
+        plugin.getAudiences().sender(sender).sendMessage(WorldEditText.format(component, getLocale()));
     }
 
     @Override

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitCommandSender.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitCommandSender.java
@@ -24,7 +24,6 @@ import com.sk89q.worldedit.extension.platform.AbstractNonPlayerActor;
 import com.sk89q.worldedit.session.SessionKey;
 import com.sk89q.worldedit.util.formatting.WorldEditText;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.adapter.bukkit.TextAdapter;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -98,7 +97,7 @@ public class BukkitCommandSender extends AbstractNonPlayerActor {
 
     @Override
     public void print(Component component) {
-        TextAdapter.sendMessage(sender, WorldEditText.format(component, getLocale()));
+        plugin.getAudiences().sender(sender).sendMessage(WorldEditText.format(component, getLocale()));
     }
 
     @Override

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
@@ -34,11 +34,8 @@ import com.sk89q.worldedit.util.HandSide;
 import com.sk89q.worldedit.util.formatting.WorldEditText;
 import com.sk89q.worldedit.util.formatting.component.TextUtils;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
-import com.sk89q.worldedit.util.formatting.text.adapter.bukkit.TextAdapter;
 import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
@@ -141,7 +138,7 @@ public class BukkitPlayer extends AbstractPlayerActor {
 
     @Override
     public void print(Component component) {
-        TextAdapter.sendMessage(player, WorldEditText.format(component, getLocale()));
+        plugin.getAudiences().player(player).sendMessage(WorldEditText.format(component, getLocale()));
     }
 
     @Override
@@ -236,8 +233,8 @@ public class BukkitPlayer extends AbstractPlayerActor {
     @Override
     public void sendAnnouncements() {
         if (!WorldEditPlugin.getInstance().getLifecycledBukkitImplAdapter().isValid()) {
-            printError(TranslatableComponent.of("worldedit.version.bukkit.unsupported-adapter",
-                    TextComponent.of("https://enginehub.org/worldedit/#downloads", TextColor.AQUA)
+            printError(Component.translatable("worldedit.version.bukkit.unsupported-adapter",
+                    Component.text("https://enginehub.org/worldedit/#downloads", NamedTextColor.AQUA)
                         .clickEvent(ClickEvent.openUrl("https://enginehub.org/worldedit/#downloads"))));
         }
     }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -45,6 +45,7 @@ import com.sk89q.worldedit.internal.anvil.ChunkDeleter;
 import com.sk89q.worldedit.internal.command.CommandUtil;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.registry.state.Property;
+import com.sk89q.worldedit.util.formatting.platform.bukkit.BukkitAudiences;
 import com.sk89q.worldedit.util.lifecycle.Lifecycled;
 import com.sk89q.worldedit.util.lifecycle.SimpleLifecycled;
 import com.sk89q.worldedit.world.World;
@@ -121,6 +122,7 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
         SimpleLifecycled.invalid();
     private BukkitServerInterface platform;
     private BukkitConfiguration config;
+    private BukkitAudiences audiences;
 
     @Override
     public void onLoad() {
@@ -170,6 +172,8 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
         if (PaperLib.isPaper()) {
             getServer().getPluginManager().registerEvents(new AsyncTabCompleteListener(), this);
         }
+
+        audiences = BukkitAudiences.create(this);
 
         if (Bukkit.getWorlds().isEmpty()) {
             setupPreWorldData();
@@ -469,6 +473,15 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
      */
     public BukkitPlayer wrapPlayer(Player player) {
         return new BukkitPlayer(this, player);
+    }
+
+    /**
+     * Convert a player to an adventure audience.
+     *
+     * @return the parsed adventure audience
+     */
+    public BukkitAudiences getAudiences() {
+        return this.audiences;
     }
 
     public Actor wrapCommandSender(CommandSender sender) {

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/UnsupportedVersionEditException.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/UnsupportedVersionEditException.java
@@ -20,10 +20,10 @@
 package com.sk89q.worldedit.bukkit.adapter;
 
 import com.sk89q.worldedit.WorldEditException;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 
 public class UnsupportedVersionEditException extends WorldEditException {
     public UnsupportedVersionEditException() {
-        super(TranslatableComponent.of("worldedit.bukkit.no-edit-without-adapter"));
+        super(Component.translatable("worldedit.bukkit.no-edit-without-adapter"));
     }
 }

--- a/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLICommandSender.java
+++ b/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLICommandSender.java
@@ -27,7 +27,7 @@ import com.sk89q.worldedit.util.FileDialogUtil;
 import com.sk89q.worldedit.util.auth.AuthorizationException;
 import com.sk89q.worldedit.util.formatting.WorldEditText;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.serializer.plain.PlainComponentSerializer;
+import com.sk89q.worldedit.util.formatting.text.serializer.plain.PlainTextComponentSerializer;
 import org.apache.logging.log4j.Logger;
 
 import java.io.File;
@@ -103,7 +103,7 @@ public class CLICommandSender implements Actor {
 
     @Override
     public void print(Component component) {
-        print(PlainComponentSerializer.INSTANCE.serialize(WorldEditText.format(component, getLocale())));
+        print(PlainTextComponentSerializer.plainText().serialize(WorldEditText.format(component, getLocale())));
     }
 
     @Override

--- a/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIExtraCommands.java
+++ b/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIExtraCommands.java
@@ -24,7 +24,7 @@ import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.regions.selector.CuboidRegionSelector;
 import com.sk89q.worldedit.regions.selector.ExtendingCuboidRegionSelector;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.task.Task;
 import com.sk89q.worldedit.world.World;
 import org.enginehub.piston.annotation.Command;
@@ -46,7 +46,7 @@ public class CLIExtraCommands {
             selector = new CuboidRegionSelector(world, world.getMinimumPoint(), world.getMaximumPoint());
         }
         session.setRegionSelector(world, selector);
-        actor.printInfo(TextComponent.of("Selected the entire world."));
+        actor.printInfo(Component.text("Selected the entire world."));
     }
 
     @Command(

--- a/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIWorldEdit.java
+++ b/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIWorldEdit.java
@@ -38,7 +38,7 @@ import com.sk89q.worldedit.extent.clipboard.io.ClipboardReader;
 import com.sk89q.worldedit.internal.Constants;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.registry.state.Property;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockCategory;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -268,13 +268,13 @@ public class CLIWorldEdit {
                     continue;
                 }
                 if (line.equals("stop")) {
-                    commandSender.printInfo(TranslatableComponent.of("worldedit.cli.stopping"));
+                    commandSender.printInfo(Component.translatable("worldedit.cli.stopping"));
                     break;
                 }
                 CommandEvent event = new CommandEvent(commandSender, line);
                 WorldEdit.getInstance().getEventBus().post(event);
                 if (!event.isCancelled()) {
-                    commandSender.printError(TranslatableComponent.of("worldedit.cli.unknown-command"));
+                    commandSender.printError(Component.translatable("worldedit.cli.unknown-command"));
                 } else {
                     saveAllWorlds(false);
                 }

--- a/worldedit-core/doctools/src/main/kotlin/com/sk89q/worldedit/internal/util/DocumentationPrinter.kt
+++ b/worldedit-core/doctools/src/main/kotlin/com/sk89q/worldedit/internal/util/DocumentationPrinter.kt
@@ -37,7 +37,7 @@ import com.sk89q.worldedit.command.ToolUtilCommands
 import com.sk89q.worldedit.command.UtilityCommands
 import com.sk89q.worldedit.command.util.PermissionCondition
 import com.sk89q.worldedit.internal.command.CommandUtil
-import com.sk89q.worldedit.util.formatting.text.TextComponent
+import com.sk89q.worldedit.util.formatting.text.Component
 import org.enginehub.piston.Command
 import org.enginehub.piston.config.TextConfig
 import org.enginehub.piston.part.SubCommandPart
@@ -45,7 +45,6 @@ import org.enginehub.piston.util.HelpGenerator
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.stream.Stream
-import kotlin.streams.toList
 
 class DocumentationPrinter private constructor() {
 
@@ -306,7 +305,7 @@ Other Permissions
                 val footer = CommandUtil.footerWithoutDeprecation(command)
                 when {
                     footer.isPresent -> append(
-                            TextComponent.builder("\n\n").append(footer.get())
+                            Component.text("\n\n").append(footer.get())
                     )
                     else -> this
                 }

--- a/worldedit-core/doctools/src/main/kotlin/com/sk89q/worldedit/internal/util/RstWorldEditText.kt
+++ b/worldedit-core/doctools/src/main/kotlin/com/sk89q/worldedit/internal/util/RstWorldEditText.kt
@@ -41,8 +41,9 @@ private fun formatAsRst(component: Component, currentDeco: String? = null): Char
             val deco = when {
                 // Actions that suggest themselves as commands are marked as code
                 component.isSuggestingAsCommand(content.toString()) -> "``"
-                component.decorations().any { it == TextDecoration.BOLD } -> "**"
-                component.decorations().any { it == TextDecoration.ITALIC } -> "*"
+                // TODO: Fix this somehow
+                //component.decorations().any { it == TextDecoration.BOLD } -> "**"
+                //component.decorations().any { it == TextDecoration.ITALIC } -> "*"
                 else -> null
             }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -113,8 +113,7 @@ import com.sk89q.worldedit.util.TreeGenerator;
 import com.sk89q.worldedit.util.collection.BlockMap;
 import com.sk89q.worldedit.util.collection.DoubleArrayList;
 import com.sk89q.worldedit.util.eventbus.EventBus;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.NullWorld;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.biome.BiomeType;
@@ -932,7 +931,7 @@ public class EditSession implements Extent, AutoCloseable {
         List<TracingExtent> tracingExtents = getActiveTracingExtents();
         assert actor != null;
         if (tracingExtents.isEmpty()) {
-            actor.printError(TranslatableComponent.of("worldedit.trace.no-tracing-extents"));
+            actor.printError(Component.translatable("worldedit.trace.no-tracing-extents"));
             return;
         }
         // find the common stacks
@@ -955,13 +954,12 @@ public class EditSession implements Extent, AutoCloseable {
         stackToPosition.forEach((stack, position) -> {
             // stack can never be empty, something has to have touched the position
             TracingExtent failure = stack.get(0);
-            actor.printDebug(TranslatableComponent.builder("worldedit.trace.action-failed")
+            actor.printDebug(Component.translatable("worldedit.trace.action-failed")
                 .args(
-                    TextComponent.of(failure.getFailedActions().get(position).toString()),
-                    TextComponent.of(position.toString()),
-                    TextComponent.of(failure.getExtent().getClass().getName())
-                )
-                .build());
+                    Component.text(failure.getFailedActions().get(position).toString()),
+                    Component.text(position.toString()),
+                    Component.text(failure.getExtent().getClass().getName())
+                ));
         });
     }
 
@@ -1484,7 +1482,7 @@ public class EditSession implements Extent, AutoCloseable {
         BlockVector3 size = region.getMaximumPoint().subtract(region.getMinimumPoint()).add(1, 1, 1);
         BlockVector3 offsetAbs = offset.abs();
         if (offsetAbs.getX() < size.getX() && offsetAbs.getY() < size.getY() && offsetAbs.getZ() < size.getZ()) {
-            throw new RegionOperationException(TranslatableComponent.of("worldedit.stack.intersecting-region"));
+            throw new RegionOperationException(Component.translatable("worldedit.stack.intersecting-region"));
         }
         BlockVector3 to = region.getMinimumPoint();
         ForwardExtentCopy copy = new ForwardExtentCopy(this, region, this, to);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -51,7 +51,7 @@ import com.sk89q.worldedit.session.PlacementType;
 import com.sk89q.worldedit.session.request.Request;
 import com.sk89q.worldedit.util.Countable;
 import com.sk89q.worldedit.util.SideEffectSet;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -775,7 +775,7 @@ public class LocalSession {
      */
     public void setTool(ItemType item, @Nullable Tool tool) throws InvalidToolBindException {
         if (item.hasBlockType()) {
-            throw new InvalidToolBindException(item, TranslatableComponent.of("worldedit.tool.error.item-only"));
+            throw new InvalidToolBindException(item, Component.translatable("worldedit.tool.error.item-only"));
         }
         if (tool instanceof SelectionWand) {
             setSingleItemTool(id -> {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/MissingWorldException.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/MissingWorldException.java
@@ -19,7 +19,7 @@
 
 package com.sk89q.worldedit;
 
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 
 /**
  * Raised when a world is missing but is required.
@@ -27,6 +27,6 @@ import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 public class MissingWorldException extends WorldEditException {
 
     public MissingWorldException() {
-        super(TranslatableComponent.of("worldedit.error.missing-world"));
+        super(Component.translatable("worldedit.error.missing-world"));
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/NotABlockException.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/NotABlockException.java
@@ -19,8 +19,7 @@
 
 package com.sk89q.worldedit;
 
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.item.ItemType;
 
 /**
@@ -32,7 +31,7 @@ public class NotABlockException extends WorldEditException {
      * Create a new instance.
      */
     public NotABlockException() {
-        super(TranslatableComponent.of("worldedit.error.not-a-block"));
+        super(Component.translatable("worldedit.error.not-a-block"));
     }
 
     /**
@@ -42,7 +41,7 @@ public class NotABlockException extends WorldEditException {
      */
     @Deprecated
     public NotABlockException(String input) {
-        super(TranslatableComponent.of("worldedit.error.not-a-block.item", TextComponent.of(input)));
+        super(Component.translatable("worldedit.error.not-a-block.item", Component.text(input)));
     }
 
     /**
@@ -52,7 +51,7 @@ public class NotABlockException extends WorldEditException {
      */
     @Deprecated
     public NotABlockException(int input) {
-        super(TranslatableComponent.of("worldedit.error.not-a-block.item", TextComponent.of(input)));
+        super(Component.translatable("worldedit.error.not-a-block.item", Component.text(input)));
     }
 
     /**
@@ -61,6 +60,6 @@ public class NotABlockException extends WorldEditException {
      * @param input the input that was used
      */
     public NotABlockException(ItemType input) {
-        super(TranslatableComponent.of("worldedit.error.not-a-block.item", input.getRichName()));
+        super(Component.translatable("worldedit.error.not-a-block.item", input.getRichName()));
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/UnknownDirectionException.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/UnknownDirectionException.java
@@ -19,8 +19,7 @@
 
 package com.sk89q.worldedit;
 
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 
 /**
  * Thrown when an unknown direction is specified or detected.
@@ -35,7 +34,7 @@ public class UnknownDirectionException extends WorldEditException {
      * @param dir the input that was tried
      */
     public UnknownDirectionException(String dir) {
-        super(TranslatableComponent.of("worldedit.error.unknown-direction", TextComponent.of(dir)));
+        super(Component.translatable("worldedit.error.unknown-direction", Component.text(dir)));
         this.dir = dir;
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -57,9 +57,9 @@ import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.asset.AssetLoaders;
 import com.sk89q.worldedit.util.concurrency.EvenMoreExecutors;
 import com.sk89q.worldedit.util.eventbus.EventBus;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 import com.sk89q.worldedit.util.io.file.FileSelectionAbortedException;
 import com.sk89q.worldedit.util.io.file.FilenameException;
 import com.sk89q.worldedit.util.io.file.FilenameResolutionException;
@@ -325,7 +325,7 @@ public final class WorldEdit {
             }
 
             if (f == null) {
-                throw new FileSelectionAbortedException(TranslatableComponent.of("worldedit.error.no-file-selected"));
+                throw new FileSelectionAbortedException(Component.translatable("worldedit.error.no-file-selected"));
             }
         } else {
             List<String> exts = extensions == null ? ImmutableList.of(defaultExt) : Lists.asList(defaultExt, extensions);
@@ -344,12 +344,12 @@ public final class WorldEdit {
 
             boolean isSym = existingParent != null && !existingParent.toRealPath().equals(existingParent);
             if (!inDir || (!getConfiguration().allowSymlinks && isSym)) {
-                throw new FilenameResolutionException(filename, TranslatableComponent.of("worldedit.error.file-resolution.outside-root"));
+                throw new FilenameResolutionException(filename, Component.translatable("worldedit.error.file-resolution.outside-root"));
             }
 
             return filePath.toFile();
         } catch (IOException | InvalidPathException e) {
-            throw new FilenameResolutionException(filename, TranslatableComponent.of("worldedit.error.file-resolution.resolve-failed"));
+            throw new FilenameResolutionException(filename, Component.translatable("worldedit.error.file-resolution.resolve-failed"));
         }
     }
 
@@ -376,7 +376,7 @@ public final class WorldEdit {
             result = getSafeFileWithExtension(dir, filename, iter.next());
         }
         if (result == null) {
-            throw new InvalidFilenameException(filename, TranslatableComponent.of("worldedit.error.invalid-filename.invalid-characters"));
+            throw new InvalidFilenameException(filename, Component.translatable("worldedit.error.invalid-filename.invalid-characters"));
         }
         return result;
     }
@@ -599,22 +599,22 @@ public final class WorldEdit {
         Map<BlockType, Integer> missingBlocks = editSession.popMissingBlocks();
 
         if (!missingBlocks.isEmpty()) {
-            TextComponent.Builder str = TextComponent.builder();
-            str.append("Missing these blocks: ");
+            TextComponent.Builder str = Component.text();
+            str.content("Missing these blocks: ");
             int size = missingBlocks.size();
             int i = 0;
 
             for (Map.Entry<BlockType, Integer> blockTypeIntegerEntry : missingBlocks.entrySet()) {
                 str.append((blockTypeIntegerEntry.getKey()).getRichName());
 
-                str.append(" [Amt: ")
-                    .append(String.valueOf(blockTypeIntegerEntry.getValue()))
-                    .append("]");
+                str.append(Component.text(" [Amt: "))
+                    .append(Component.text(blockTypeIntegerEntry.getValue()))
+                    .append(Component.text("]"));
 
                 ++i;
 
                 if (i != size) {
-                    str.append(", ");
+                    str.append(Component.text(", "));
                 }
             }
 
@@ -712,7 +712,7 @@ public final class WorldEdit {
         String ext = filename.substring(index + 1);
 
         if (!ext.equalsIgnoreCase("js")) {
-            player.printError(TranslatableComponent.of("worldedit.script.unsupported"));
+            player.printError(Component.translatable("worldedit.script.unsupported"));
             return;
         }
 
@@ -725,7 +725,7 @@ public final class WorldEdit {
                 file = WorldEdit.class.getResourceAsStream("craftscripts/" + filename);
 
                 if (file == null) {
-                    player.printError(TranslatableComponent.of("worldedit.script.file-not-found", TextComponent.of(filename)));
+                    player.printError(Component.translatable("worldedit.script.file-not-found", Component.text(filename)));
                     return;
                 }
             } else {
@@ -738,7 +738,7 @@ public final class WorldEdit {
             in.close();
             script = new String(data, 0, data.length, StandardCharsets.UTF_8);
         } catch (IOException e) {
-            player.printError(TranslatableComponent.of("worldedit.script.read-error", TextComponent.of(e.getMessage())));
+            player.printError(Component.translatable("worldedit.script.read-error", Component.text(e.getMessage())));
             return;
         }
 
@@ -751,7 +751,7 @@ public final class WorldEdit {
         try {
             engine = new RhinoCraftScriptEngine();
         } catch (NoClassDefFoundError ignored) {
-            player.printError(TranslatableComponent.of("worldedit.script.no-script-engine"));
+            player.printError(Component.translatable("worldedit.script.no-script-engine"));
             return;
         }
 
@@ -767,14 +767,14 @@ public final class WorldEdit {
         } catch (ScriptException e) {
             // non-exceptional return check
             if (!(Throwables.getRootCause(e) instanceof ReturnException)) {
-                player.printError(TranslatableComponent.of("worldedit.script.failed", TextComponent.of(e.getMessage(), TextColor.WHITE)));
+                player.printError(Component.translatable("worldedit.script.failed", Component.text(e.getMessage(), NamedTextColor.WHITE)));
                 logger.warn("Failed to execute script", e);
             }
         } catch (NumberFormatException | WorldEditException e) {
             throw e;
         } catch (Throwable e) {
-            player.printError(TranslatableComponent.of("worldedit.script.failed-console", TextComponent.of(e.getClass().getCanonicalName(),
-                    TextColor.WHITE)));
+            player.printError(Component.translatable("worldedit.script.failed-console", Component.text(e.getClass().getCanonicalName(),
+                    NamedTextColor.WHITE)));
             logger.warn("Failed to execute script", e);
         } finally {
             for (EditSession editSession : scriptContext.getEditSessions()) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEditException.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEditException.java
@@ -21,7 +21,6 @@ package com.sk89q.worldedit;
 
 import com.sk89q.worldedit.util.formatting.WorldEditText;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
 
 import java.util.Locale;
 
@@ -49,7 +48,7 @@ public abstract class WorldEditException extends Exception {
     protected WorldEditException(String message) {
         super(message);
 
-        this.message = TextComponent.of(message);
+        this.message = Component.text(message);
     }
 
     /**
@@ -74,7 +73,7 @@ public abstract class WorldEditException extends Exception {
     protected WorldEditException(String message, Throwable cause) {
         super(message, cause);
 
-        this.message = TextComponent.of(message);
+        this.message = Component.text(message);
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ApplyBrushCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ApplyBrushCommands.java
@@ -39,9 +39,8 @@ import com.sk89q.worldedit.internal.annotation.Direction;
 import com.sk89q.worldedit.internal.command.CommandRegistrationHandler;
 import com.sk89q.worldedit.regions.factory.RegionFactory;
 import com.sk89q.worldedit.util.TreeGenerator;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.Component;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 import com.sk89q.worldedit.util.formatting.text.format.TextDecoration;
 import org.enginehub.piston.CommandManager;
 import org.enginehub.piston.CommandManagerService;
@@ -61,19 +60,19 @@ import static org.enginehub.piston.part.CommandParts.arg;
 @CommandContainer(superTypes = CommandPermissionsConditionGenerator.Registration.class)
 public class ApplyBrushCommands {
 
-    private static final CommandArgument REGION_FACTORY = arg(TranslatableComponent.of("shape"), TranslatableComponent.of("worldedit.brush.apply.shape"))
+    private static final CommandArgument REGION_FACTORY = arg(Component.translatable("shape"), Component.translatable("worldedit.brush.apply.shape"))
         .defaultsTo(ImmutableList.of())
         .ofTypes(ImmutableList.of(Key.of(RegionFactory.class)))
         .build();
 
-    private static final CommandArgument RADIUS = arg(TranslatableComponent.of("radius"), TranslatableComponent.of("worldedit.brush.apply.radius"))
+    private static final CommandArgument RADIUS = arg(Component.translatable("radius"), Component.translatable("worldedit.brush.apply.radius"))
         .defaultsTo(ImmutableList.of("5"))
         .ofTypes(ImmutableList.of(Key.of(double.class)))
         .build();
 
     public static void register(CommandManagerService service, CommandManager commandManager, CommandRegistrationHandler registration) {
         commandManager.register("apply", builder -> {
-            builder.description(TranslatableComponent.of("worldedit.brush.apply.description"));
+            builder.description(Component.translatable("worldedit.brush.apply.description"));
             builder.action(org.enginehub.piston.Command.Action.NULL_ACTION);
 
             CommandManager manager = service.newCommandManager();
@@ -86,7 +85,7 @@ public class ApplyBrushCommands {
             builder.condition(new PermissionCondition(ImmutableSet.of("worldedit.brush.apply")));
 
             builder.addParts(REGION_FACTORY, RADIUS);
-            builder.addPart(SubCommandPart.builder(TranslatableComponent.of("type"), TranslatableComponent.of("worldedit.brush.apply.type"))
+            builder.addPart(SubCommandPart.builder(Component.translatable("type"), Component.translatable("worldedit.brush.apply.type"))
                 .withCommands(manager.getAllCommands().collect(Collectors.toList()))
                 .required()
                 .build());
@@ -124,8 +123,8 @@ public class ApplyBrushCommands {
                      @Arg(desc = "The direction in which the item will be applied", def = "up")
                      @Direction(includeDiagonals = true)
                          com.sk89q.worldedit.util.Direction direction) throws WorldEditException {
-        player.print(TextComponent.builder().append("WARNING: ", TextColor.RED, TextDecoration.BOLD)
-                .append(TranslatableComponent.of("worldedit.brush.apply.item.warning")).build());
+        player.print(Component.text("WARNING: ", NamedTextColor.RED, TextDecoration.BOLD)
+                .append(Component.translatable("worldedit.brush.apply.item.warning")));
         setApplyBrush(parameters, player, localSession, new ItemUseFactory(item, direction));
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/BiomeCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/BiomeCommands.java
@@ -44,8 +44,6 @@ import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.formatting.component.PaginationBox;
 import com.sk89q.worldedit.util.formatting.component.TextUtils;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.biome.BiomeType;
@@ -90,11 +88,11 @@ public class BiomeCommands {
 
             PaginationBox paginationBox = PaginationBox.fromComponents("Available Biomes", "/biomelist -p %page%",
                 BiomeType.REGISTRY.values().stream()
-                    .map(biomeType -> TextComponent.builder()
-                        .append(biomeType.getId())
-                        .append(" (")
+                    .map(biomeType -> Component.text()
+                        .append(Component.text(biomeType.getId()))
+                        .append(Component.text(" ("))
                         .append(biomeRegistry.getRichName(biomeType))
-                        .append(")")
+                        .append(Component.text(")"))
                         .build())
                     .collect(Collectors.toList()));
             return paginationBox.create(page);
@@ -121,7 +119,7 @@ public class BiomeCommands {
             if (actor instanceof Player) {
                 Location blockPosition = ((Player) actor).getBlockTrace(300);
                 if (blockPosition == null) {
-                    actor.printError(TranslatableComponent.of("worldedit.raytrace.noblock"));
+                    actor.printError(Component.translatable("worldedit.raytrace.noblock"));
                     return;
                 }
 
@@ -130,7 +128,7 @@ public class BiomeCommands {
 
                 messageKey = "worldedit.biomeinfo.lineofsight";
             } else {
-                actor.printError(TranslatableComponent.of("worldedit.raytrace.require-player"));
+                actor.printError(Component.translatable("worldedit.raytrace.require-player"));
                 return;
             }
         } else if (usePosition) {
@@ -140,7 +138,7 @@ public class BiomeCommands {
 
                 messageKey = "worldedit.biomeinfo.position";
             } else {
-                actor.printError(TranslatableComponent.of("worldedit.biomeinfo.not-locatable"));
+                actor.printError(Component.translatable("worldedit.biomeinfo.not-locatable"));
                 return;
             }
         } else {
@@ -155,10 +153,10 @@ public class BiomeCommands {
 
         List<Component> components = biomes.stream().map(biome ->
             biomeRegistry.getRichName(biome).hoverEvent(
-                HoverEvent.showText(TextComponent.of(biome.getId()))
+                HoverEvent.showText(Component.text(biome.getId()))
             )
         ).collect(Collectors.toList());
-        actor.printInfo(TranslatableComponent.of(messageKey, TextUtils.join(components, TextComponent.of(", "))));
+        actor.printInfo(Component.translatable(messageKey, TextUtils.join(components, Component.text(", "))));
     }
 
     @Command(
@@ -180,7 +178,7 @@ public class BiomeCommands {
                 final BlockVector3 pos = ((Locatable) actor).getLocation().toVector().toBlockPoint();
                 region = new CuboidRegion(pos, pos);
             } else {
-                actor.printError(TranslatableComponent.of("worldedit.setbiome.not-locatable"));
+                actor.printError(Component.translatable("worldedit.setbiome.not-locatable"));
                 return;
             }
         } else {
@@ -194,12 +192,12 @@ public class BiomeCommands {
         RegionVisitor visitor = new RegionVisitor(region, replace);
         Operations.completeLegacy(visitor);
 
-        actor.printInfo(TranslatableComponent.of(
+        actor.printInfo(Component.translatable(
             "worldedit.setbiome.changed",
-            TextComponent.of(visitor.getAffected())
+            Component.text(visitor.getAffected())
         )
-            .append(TextComponent.newline())
-            .append(TranslatableComponent.of("worldedit.setbiome.warning")));
+            .append(Component.newline())
+            .append(Component.translatable("worldedit.setbiome.warning")));
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/BrushCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/BrushCommands.java
@@ -77,10 +77,8 @@ import com.sk89q.worldedit.util.asset.AssetLoadTask;
 import com.sk89q.worldedit.util.asset.AssetLoader;
 import com.sk89q.worldedit.util.asset.holder.ImageHeightmap;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockTypes;
 import com.sk89q.worldedit.world.generation.ConfiguredFeatureType;
@@ -102,9 +100,8 @@ public class BrushCommands {
 
     private final WorldEdit worldEdit;
 
-    private static final Component UNBIND_COMMAND_COMPONENT = TextComponent.builder("/brush unbind", TextColor.AQUA)
-                                                                   .clickEvent(ClickEvent.suggestCommand("/brush unbind"))
-                                                                   .build();
+    private static final Component UNBIND_COMMAND_COMPONENT = Component.text("/brush unbind", NamedTextColor.AQUA)
+                                                                   .clickEvent(ClickEvent.suggestCommand("/brush unbind"));
 
     /**
      * Create a new instance.
@@ -150,7 +147,7 @@ public class BrushCommands {
         tool.setFill(pattern);
         tool.setSize(radius);
 
-        player.printInfo(TranslatableComponent.of("worldedit.brush.sphere.equip", TextComponent.of(String.format("%.0f", radius))));
+        player.printInfo(Component.translatable("worldedit.brush.sphere.equip", Component.text(String.format("%.0f", radius))));
         ToolCommands.sendUnbindInstruction(player, UNBIND_COMMAND_COMPONENT);
     }
 
@@ -182,7 +179,7 @@ public class BrushCommands {
         tool.setFill(pattern);
         tool.setSize(radius);
 
-        player.printInfo(TranslatableComponent.of("worldedit.brush.cylinder.equip", TextComponent.of((int) radius), TextComponent.of(height)));
+        player.printInfo(Component.translatable("worldedit.brush.cylinder.equip", Component.text((int) radius), Component.text(height)));
         ToolCommands.sendUnbindInstruction(player, UNBIND_COMMAND_COMPONENT);
     }
 
@@ -202,7 +199,7 @@ public class BrushCommands {
         worldEdit.checkMaxBrushRadius(radius);
 
         if (decay < 0 || decay > 10) {
-            player.printError(TranslatableComponent.of("worldedit.brush.splatter.decay-out-of-range", TextComponent.of(decay)));
+            player.printError(Component.translatable("worldedit.brush.splatter.decay-out-of-range", Component.text(decay)));
             return;
         }
 
@@ -214,7 +211,7 @@ public class BrushCommands {
         tool.setFill(pattern);
         tool.setSize(radius);
 
-        player.printInfo(TranslatableComponent.of("worldedit.brush.splatter.equip", TextComponent.of((int) radius), TextComponent.of(decay)));
+        player.printInfo(Component.translatable("worldedit.brush.splatter.equip", Component.text((int) radius), Component.text(decay)));
         ToolCommands.sendUnbindInstruction(player, UNBIND_COMMAND_COMPONENT);
     }
 
@@ -257,7 +254,7 @@ public class BrushCommands {
             "worldedit.brush.clipboard"
         );
 
-        player.printInfo(TranslatableComponent.of("worldedit.brush.clipboard.equip"));
+        player.printInfo(Component.translatable("worldedit.brush.clipboard.equip"));
         ToolCommands.sendUnbindInstruction(player, UNBIND_COMMAND_COMPONENT);
     }
 
@@ -283,11 +280,11 @@ public class BrushCommands {
         );
         tool.setSize(radius);
 
-        player.printInfo(TranslatableComponent.of(
+        player.printInfo(Component.translatable(
                 "worldedit.brush.smooth.equip",
-                TextComponent.of((int) radius),
-                TextComponent.of(iterations),
-                TranslatableComponent.of("worldedit.brush.smooth." + (mask == null ? "no" : "") + "filter")
+                Component.text((int) radius),
+                Component.text(iterations),
+                Component.translatable("worldedit.brush.smooth." + (mask == null ? "no" : "") + "filter")
         ));
         ToolCommands.sendUnbindInstruction(player, UNBIND_COMMAND_COMPONENT);
     }
@@ -316,12 +313,12 @@ public class BrushCommands {
         );
         tool.setSize(radius);
 
-        player.printInfo(TranslatableComponent.of(
+        player.printInfo(Component.translatable(
                 "worldedit.brush.snowsmooth.equip",
-                TextComponent.of((int) radius),
-                TextComponent.of(iterations),
-                TranslatableComponent.of("worldedit.brush.snowsmooth." + (mask == null ? "no" : "") + "filter"),
-                TextComponent.of(snowBlockCount)
+                Component.text((int) radius),
+                Component.text(iterations),
+                Component.translatable("worldedit.brush.snowsmooth." + (mask == null ? "no" : "") + "filter"),
+                Component.text(snowBlockCount)
         ));
     }
 
@@ -345,7 +342,7 @@ public class BrushCommands {
         tool.setSize(radius);
         tool.setMask(new BlockTypeMask(new RequestExtent(), BlockTypes.FIRE));
 
-        player.printInfo(TranslatableComponent.of("worldedit.brush.extinguish.equip", TextComponent.of((int) radius)));
+        player.printInfo(Component.translatable("worldedit.brush.extinguish.equip", Component.text((int) radius)));
         ToolCommands.sendUnbindInstruction(player, UNBIND_COMMAND_COMPONENT);
     }
 
@@ -376,7 +373,7 @@ public class BrushCommands {
         );
         tool.setSize(radius);
 
-        player.printInfo(TranslatableComponent.of("worldedit.brush.gravity.equip", TextComponent.of((int) radius)));
+        player.printInfo(Component.translatable("worldedit.brush.gravity.equip", Component.text((int) radius)));
         ToolCommands.sendUnbindInstruction(player, UNBIND_COMMAND_COMPONENT);
     }
 
@@ -417,7 +414,7 @@ public class BrushCommands {
             maxRadius = Math.max(config.maxBrushRadius, config.butcherMaxRadius);
         }
         if (radius > maxRadius) {
-            player.printError(TranslatableComponent.of("worldedit.brush.radius-too-large", TextComponent.of(maxRadius)));
+            player.printError(Component.translatable("worldedit.brush.radius-too-large", Component.text(maxRadius)));
             return;
         }
 
@@ -438,7 +435,7 @@ public class BrushCommands {
         );
         tool.setSize(radius);
 
-        player.printInfo(TranslatableComponent.of("worldedit.brush.butcher.equip", TextComponent.of((int) radius)));
+        player.printInfo(Component.translatable("worldedit.brush.butcher.equip", Component.text((int) radius)));
         ToolCommands.sendUnbindInstruction(player, UNBIND_COMMAND_COMPONENT);
     }
 
@@ -468,9 +465,9 @@ public class BrushCommands {
             AssetLoadTask<ImageHeightmap> task = new AssetLoadTask<>(loader.get(), imageName);
             AsyncCommandBuilder.wrap(task, player)
                 .registerWithSupervisor(worldEdit.getSupervisor(), "Loading asset " + imageName)
-                .setDelayMessage(TranslatableComponent.of("worldedit.asset.load.loading"))
-                .setWorkingMessage(TranslatableComponent.of("worldedit.asset.load.still-loading"))
-                .onSuccess(TranslatableComponent.of("worldedit.brush.heightmap.equip", TextComponent.of((int) radius)), heightmap -> {
+                .setDelayMessage(Component.translatable("worldedit.asset.load.loading"))
+                .setWorkingMessage(Component.translatable("worldedit.asset.load.still-loading"))
+                .onSuccess(Component.translatable("worldedit.brush.heightmap.equip", Component.text((int) radius)), heightmap -> {
                     BrushTool tool;
                     try {
                         tool = session.forceBrush(
@@ -484,10 +481,10 @@ public class BrushCommands {
                     tool.setSize(radius);
                     ToolCommands.sendUnbindInstruction(player, UNBIND_COMMAND_COMPONENT);
                 })
-                .onFailure(TranslatableComponent.of("worldedit.asset.load.failed"), worldEdit.getPlatformManager().getPlatformCommandManager().getExceptionConverter())
+                .onFailure(Component.translatable("worldedit.asset.load.failed"), worldEdit.getPlatformManager().getPlatformCommandManager().getExceptionConverter())
                 .buildAndExec(worldEdit.getExecutorService());
         } else {
-            player.printError(TranslatableComponent.of("worldedit.brush.heightmap.unknown", TextComponent.of(imageName)));
+            player.printError(Component.translatable("worldedit.brush.heightmap.unknown", Component.text(imageName)));
         }
     }
 
@@ -642,14 +639,14 @@ public class BrushCommands {
             } else if (shape instanceof CuboidRegionFactory) {
                 shape = new FixedHeightCuboidRegionFactory(player.getWorld().getMinY(), player.getWorld().getMaxY());
             } else {
-                player.printError(TranslatableComponent.of("worldedit.brush.biome.column-supported-types"));
+                player.printError(Component.translatable("worldedit.brush.biome.column-supported-types"));
                 return;
             }
         }
 
         setOperationBasedBrush(player, localSession, radius,
             new ApplyRegion(new BiomeFactory(biomeType)), shape, "worldedit.brush.biome");
-        player.printInfo(TranslatableComponent.of("worldedit.setbiome.warning"));
+        player.printInfo(Component.translatable("worldedit.setbiome.warning"));
         ToolCommands.sendUnbindInstruction(player, UNBIND_COMMAND_COMPONENT);
     }
 
@@ -677,7 +674,7 @@ public class BrushCommands {
         );
         tool.setSize(brushSize);
 
-        player.printInfo(TranslatableComponent.of("worldedit.brush.morph.equip", TextComponent.of((int) brushSize)));
+        player.printInfo(Component.translatable("worldedit.brush.morph.equip", Component.text((int) brushSize)));
         ToolCommands.sendUnbindInstruction(player, UNBIND_COMMAND_COMPONENT);
     }
 
@@ -697,7 +694,7 @@ public class BrushCommands {
         );
         tool.setSize(brushSize);
 
-        player.printInfo(TranslatableComponent.of("worldedit.brush.morph.equip", TextComponent.of((int) brushSize)));
+        player.printInfo(Component.translatable("worldedit.brush.morph.equip", Component.text((int) brushSize)));
         ToolCommands.sendUnbindInstruction(player, UNBIND_COMMAND_COMPONENT);
     }
 
@@ -717,7 +714,7 @@ public class BrushCommands {
         );
         tool.setSize(brushSize);
 
-        player.printInfo(TranslatableComponent.of("worldedit.brush.morph.equip", TextComponent.of((int) brushSize)));
+        player.printInfo(Component.translatable("worldedit.brush.morph.equip", Component.text((int) brushSize)));
         ToolCommands.sendUnbindInstruction(player, UNBIND_COMMAND_COMPONENT);
     }
 
@@ -734,7 +731,7 @@ public class BrushCommands {
         tool.setSize(radius);
         tool.setFill(null);
 
-        player.printInfo(TranslatableComponent.of("worldedit.brush.operation.equip", TextComponent.of(factory.toString())));
+        player.printInfo(Component.translatable("worldedit.brush.operation.equip", Component.text(factory.toString())));
         ToolCommands.sendUnbindInstruction(player, UNBIND_COMMAND_COMPONENT);
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ChunkCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ChunkCommands.java
@@ -37,10 +37,8 @@ import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.formatting.component.PaginationBox;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.storage.LegacyChunkStore;
 import com.sk89q.worldedit.world.storage.McRegionChunkStore;
@@ -85,9 +83,9 @@ public class ChunkCommands {
         int chunkZ = (int) Math.floor(pos.getBlockZ() / 16.0);
 
         final BlockVector2 chunkPos = BlockVector2.at(chunkX, chunkZ);
-        player.printInfo(TranslatableComponent.of("worldedit.chunkinfo.chunk", TextComponent.of(chunkX), TextComponent.of(chunkZ)));
-        player.printInfo(TranslatableComponent.of("worldedit.chunkinfo.old-filename", TextComponent.of(LegacyChunkStore.getFilename(chunkPos))));
-        player.printInfo(TranslatableComponent.of("worldedit.chunkinfo.mcregion-filename", TextComponent.of(McRegionChunkStore.getFilename(chunkPos))));
+        player.printInfo(Component.translatable("worldedit.chunkinfo.chunk", Component.text(chunkX), Component.text(chunkZ)));
+        player.printInfo(Component.translatable("worldedit.chunkinfo.old-filename", Component.text(LegacyChunkStore.getFilename(chunkPos))));
+        player.printInfo(Component.translatable("worldedit.chunkinfo.mcregion-filename", Component.text(McRegionChunkStore.getFilename(chunkPos))));
     }
 
     @Command(
@@ -101,9 +99,9 @@ public class ChunkCommands {
 
         WorldEditAsyncCommandBuilder.createAndSendMessage(actor,
             () -> new ChunkListPaginationBox(region).create(page),
-            TranslatableComponent.of(
+            Component.translatable(
                 "worldedit.listchunks.listfor",
-                TextComponent.of(actor.getName())
+                Component.text(actor.getName())
             ));
     }
 
@@ -118,7 +116,7 @@ public class ChunkCommands {
                                     ZonedDateTime beforeTime) throws WorldEditException {
         Path worldDir = world.getStoragePath();
         if (worldDir == null) {
-            throw new StopExecutionException(TextComponent.of("Couldn't find world folder for this world."));
+            throw new StopExecutionException(Component.text("Couldn't find world folder for this world."));
         }
 
         Path chunkPath = worldEdit.getWorkingDirectoryPath(DELCHUNKS_FILE_NAME);
@@ -127,7 +125,7 @@ public class ChunkCommands {
             try {
                 currentInfo = ChunkDeleter.readInfo(chunkPath);
             } catch (IOException e) {
-                throw new StopExecutionException(TextComponent.of("Error reading existing chunk file."));
+                throw new StopExecutionException(Component.text("Error reading existing chunk file."));
             }
         }
         if (currentInfo == null) {
@@ -160,22 +158,22 @@ public class ChunkCommands {
         try {
             ChunkDeleter.writeInfo(currentInfo, chunkPath);
         } catch (IOException | JsonIOException e) {
-            throw new StopExecutionException(TextComponent.of("Failed to write chunk list: " + e.getMessage()));
+            throw new StopExecutionException(Component.text("Failed to write chunk list: " + e.getMessage()));
         }
 
-        actor.print(TextComponent.of(
+        actor.print(Component.text(
             String.format("%d chunk(s) have been marked for deletion the next time the server starts.",
                 newBatch.getChunkCount())
         ));
         if (currentInfo.batches.size() > 1) {
-            actor.printDebug(TextComponent.of(
+            actor.printDebug(Component.text(
                 String.format("%d chunks total marked for deletion. (May have overlaps).",
                     currentInfo.batches.stream().mapToInt(ChunkDeletionInfo.ChunkBatch::getChunkCount).sum())
             ));
         }
-        actor.print(TextComponent.of("You can mark more chunks for deletion, or to stop now, run: ", TextColor.LIGHT_PURPLE)
-                .append(TextComponent.of("/stop", TextColor.AQUA)
-                        .clickEvent(ClickEvent.of(ClickEvent.Action.SUGGEST_COMMAND, "/stop"))));
+        actor.print(Component.text("You can mark more chunks for deletion, or to stop now, run: ", NamedTextColor.LIGHT_PURPLE)
+                .append(Component.text("/stop", NamedTextColor.AQUA)
+                        .clickEvent(ClickEvent.suggestCommand("/stop"))));
     }
 
     private static class ChunkListPaginationBox extends PaginationBox {
@@ -193,7 +191,7 @@ public class ChunkCommands {
 
         @Override
         public Component getComponent(int number) {
-            return TextComponent.of(chunks.get(number).toString());
+            return Component.text(chunks.get(number).toString());
         }
 
         @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ClipboardCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ClipboardCommands.java
@@ -43,13 +43,10 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.math.transform.AffineTransform;
 import com.sk89q.worldedit.regions.Region;
-import com.sk89q.worldedit.regions.RegionSelector;
 import com.sk89q.worldedit.regions.selector.CuboidRegionSelector;
 import com.sk89q.worldedit.regions.selector.ExtendingCuboidRegionSelector;
 import com.sk89q.worldedit.session.ClipboardHolder;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.World;
 import org.enginehub.piston.annotation.Command;
 import org.enginehub.piston.annotation.CommandContainer;
@@ -204,9 +201,9 @@ public class ClipboardCommands {
         }
 
         if (onlySelect) {
-            actor.printInfo(TranslatableComponent.of("worldedit.paste.selected"));
+            actor.printInfo(Component.translatable("worldedit.paste.selected"));
         } else {
-            actor.printInfo(TranslatableComponent.of("worldedit.paste.pasted", TextComponent.of(to.toString())));
+            actor.printInfo(Component.translatable("worldedit.paste.pasted", Component.text(to.toString())));
         }
         messages.forEach(actor::print);
     }
@@ -229,7 +226,7 @@ public class ClipboardCommands {
         if (Math.abs(rotateY % 90) > 0.001
             || Math.abs(rotateX % 90) > 0.001
             || Math.abs(rotateZ % 90) > 0.001) {
-            actor.printDebug(TranslatableComponent.of("worldedit.rotate.no-interpolation"));
+            actor.printDebug(Component.translatable("worldedit.rotate.no-interpolation"));
         }
 
         ClipboardHolder holder = session.getClipboard();
@@ -238,7 +235,7 @@ public class ClipboardCommands {
         transform = transform.rotateX(-rotateX);
         transform = transform.rotateZ(-rotateZ);
         holder.setTransform(holder.getTransform().combine(transform));
-        actor.printInfo(TranslatableComponent.of("worldedit.rotate.rotated"));
+        actor.printInfo(Component.translatable("worldedit.rotate.rotated"));
     }
 
     @Command(
@@ -253,7 +250,7 @@ public class ClipboardCommands {
         AffineTransform transform = new AffineTransform();
         transform = transform.scale(direction.abs().multiply(-2).add(1, 1, 1).toVector3());
         holder.setTransform(holder.getTransform().combine(transform));
-        actor.printInfo(TranslatableComponent.of("worldedit.flip.flipped"));
+        actor.printInfo(Component.translatable("worldedit.flip.flipped"));
     }
 
     @Command(
@@ -263,6 +260,6 @@ public class ClipboardCommands {
     @CommandPermissions("worldedit.clipboard.clear")
     public void clearClipboard(Actor actor, LocalSession session) {
         session.setClipboard(null);
-        actor.printInfo(TranslatableComponent.of("worldedit.clearclipboard.cleared"));
+        actor.printInfo(Component.translatable("worldedit.clearclipboard.cleared"));
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ExpandCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ExpandCommands.java
@@ -32,8 +32,7 @@ import com.sk89q.worldedit.internal.command.CommandRegistrationHandler;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionOperationException;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.World;
 import org.enginehub.piston.Command;
 import org.enginehub.piston.CommandManager;
@@ -73,8 +72,8 @@ public class ExpandCommands {
             command.condition(new PermissionCondition(ImmutableSet.of("worldedit.selection.expand")));
 
             command.addPart(SubCommandPart.builder(
-                TranslatableComponent.of("vert"),
-                TextComponent.of("Vertical expansion sub-command")
+                Component.translatable("vert"),
+                Component.text("Vertical expansion sub-command")
             )
                 .withCommands(ImmutableSet.of(createVertCommand(commandManager)))
                 .optional()
@@ -88,7 +87,7 @@ public class ExpandCommands {
 
     private static Command createVertCommand(CommandManager commandManager) {
         return commandManager.newCommand("vert")
-            .description(TranslatableComponent.of("worldedit.expand.description.vert"))
+            .description(Component.translatable("worldedit.expand.description.vert"))
             .action(parameters -> {
                 expandVert(
                     requireIV(Key.of(LocalSession.class), "localSession", parameters),
@@ -113,10 +112,10 @@ public class ExpandCommands {
             session.getRegionSelector(world).explainRegionAdjust(actor, session);
             long changeSize = newSize - oldSize;
             actor.printInfo(
-                TranslatableComponent.of("worldedit.expand.expanded.vert", TextComponent.of(changeSize))
+                Component.translatable("worldedit.expand.expanded.vert", Component.text(changeSize))
             );
         } catch (RegionOperationException e) {
-            actor.printError(TextComponent.of(e.getMessage()));
+            actor.printError(Component.text(e.getMessage()));
         }
     }
 
@@ -152,7 +151,7 @@ public class ExpandCommands {
         session.getRegionSelector(world).explainRegionAdjust(actor, session);
 
         long changeSize = newSize - oldSize;
-        actor.printInfo(TranslatableComponent.of("worldedit.expand.expanded", TextComponent.of(changeSize)));
+        actor.printInfo(Component.translatable("worldedit.expand.expanded", Component.text(changeSize)));
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
@@ -52,9 +52,7 @@ import com.sk89q.worldedit.util.auth.AuthorizationException;
 import com.sk89q.worldedit.util.formatting.component.PaginationBox;
 import com.sk89q.worldedit.util.formatting.component.SideEffectBox;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.item.ItemType;
 import org.enginehub.piston.CommandManager;
@@ -121,7 +119,7 @@ public class GeneralCommands {
         }
         ImmutableList<String> args = oldParams.getMetadata().getArguments();
         if (args.isEmpty()) {
-            return TextComponent.of("There is not yet a replacement for //fast"
+            return Component.text("There is not yet a replacement for //fast"
                 + " with no arguments");
         }
         String arg0 = args.get(0).toLowerCase(Locale.ENGLISH);
@@ -134,7 +132,7 @@ public class GeneralCommands {
                 flipped = "on";
                 break;
             default:
-                return TextComponent.of("There is no replacement for //fast " + arg0);
+                return Component.text("There is no replacement for //fast " + arg0);
         }
         return CommandUtil.createNewCommandReplacementText("//perf " + flipped);
     }
@@ -166,15 +164,15 @@ public class GeneralCommands {
         limit = limit == null ? config.defaultChangeLimit : Math.max(-1, limit);
         if (!mayDisable && config.maxChangeLimit > -1) {
             if (limit > config.maxChangeLimit) {
-                actor.printError(TranslatableComponent.of("worldedit.limit.too-high", TextComponent.of(config.maxChangeLimit)));
+                actor.printError(Component.translatable("worldedit.limit.too-high", Component.text(config.maxChangeLimit)));
                 return;
             }
         }
 
         session.setBlockChangeLimit(limit);
-        Component component = TextComponent.empty().append(TranslatableComponent.of("worldedit.limit.set", TextComponent.of(limit)));
+        Component component = Component.empty().append(Component.translatable("worldedit.limit.set", Component.text(limit)));
         if (limit != config.defaultChangeLimit) {
-            component.append(TextComponent.space()).append(TranslatableComponent.of("worldedit.limit.return-to-default", TextColor.GRAY));
+            component = component.append(Component.space()).append(Component.translatable("worldedit.limit.return-to-default", NamedTextColor.GRAY));
         }
         actor.printInfo(component);
     }
@@ -193,15 +191,15 @@ public class GeneralCommands {
         limit = limit == null ? config.calculationTimeout : Math.max(-1, limit);
         if (!mayDisable && config.maxCalculationTimeout > -1) {
             if (limit > config.maxCalculationTimeout) {
-                actor.printError(TranslatableComponent.of("worldedit.timeout.too-high", TextComponent.of(config.maxCalculationTimeout)));
+                actor.printError(Component.translatable("worldedit.timeout.too-high", Component.text(config.maxCalculationTimeout)));
                 return;
             }
         }
 
         session.setTimeout(limit);
-        Component component = TextComponent.empty().append(TranslatableComponent.of("worldedit.timeout.set", TextComponent.of(limit)));
+        Component component = Component.empty().append(Component.translatable("worldedit.timeout.set", Component.text(limit)));
         if (limit != config.calculationTimeout) {
-            component.append(TranslatableComponent.of("worldedit.timeout.return-to-default", TextColor.GRAY));
+            component = component.append(Component.translatable("worldedit.timeout.return-to-default", NamedTextColor.GRAY));
         }
         actor.printInfo(component);
     }
@@ -217,16 +215,16 @@ public class GeneralCommands {
                   Boolean fastMode) {
         boolean hasFastMode = session.hasFastMode();
         if (fastMode != null && fastMode == hasFastMode) {
-            actor.printError(TranslatableComponent.of(fastMode ? "worldedit.fast.enabled.already" : "worldedit.fast.disabled.already"));
+            actor.printError(Component.translatable(fastMode ? "worldedit.fast.enabled.already" : "worldedit.fast.disabled.already"));
             return;
         }
 
         if (hasFastMode) {
             session.setFastMode(false);
-            actor.printInfo(TranslatableComponent.of("worldedit.fast.disabled"));
+            actor.printInfo(Component.translatable("worldedit.fast.disabled"));
         } else {
             session.setFastMode(true);
-            actor.printInfo(TranslatableComponent.of("worldedit.fast.enabled"));
+            actor.printInfo(Component.translatable("worldedit.fast.enabled"));
         }
     }
 
@@ -248,10 +246,10 @@ public class GeneralCommands {
             SideEffect.State currentState = session.getSideEffectSet().getState(sideEffect);
             if (newState != null && newState == currentState) {
                 if (!showInfoBox) {
-                    actor.printError(TranslatableComponent.of(
+                    actor.printError(Component.translatable(
                             "worldedit.perf.sideeffect.already-set",
-                            TranslatableComponent.of(sideEffect.getDisplayName()),
-                            TranslatableComponent.of(newState.getDisplayName())
+                            Component.translatable(sideEffect.getDisplayName()),
+                            Component.translatable(newState.getDisplayName())
                     ));
                 }
                 return;
@@ -260,17 +258,17 @@ public class GeneralCommands {
             if (newState != null) {
                 session.setSideEffectSet(session.getSideEffectSet().with(sideEffect, newState));
                 if (!showInfoBox) {
-                    actor.printInfo(TranslatableComponent.of(
+                    actor.printInfo(Component.translatable(
                             "worldedit.perf.sideeffect.set",
-                            TranslatableComponent.of(sideEffect.getDisplayName()),
-                            TranslatableComponent.of(newState.getDisplayName())
+                            Component.translatable(sideEffect.getDisplayName()),
+                            Component.translatable(newState.getDisplayName())
                     ));
                 }
             } else {
-                actor.printInfo(TranslatableComponent.of(
+                actor.printInfo(Component.translatable(
                         "worldedit.perf.sideeffect.get",
-                        TranslatableComponent.of(sideEffect.getDisplayName()),
-                        TranslatableComponent.of(currentState.getDisplayName())
+                        Component.translatable(sideEffect.getDisplayName()),
+                        Component.translatable(currentState.getDisplayName())
                 ));
             }
         } else if (newState != null) {
@@ -280,9 +278,9 @@ public class GeneralCommands {
             }
             session.setSideEffectSet(applier);
             if (!showInfoBox) {
-                actor.printInfo(TranslatableComponent.of(
+                actor.printInfo(Component.translatable(
                         "worldedit.perf.sideeffect.set-all",
-                        TranslatableComponent.of(newState.getDisplayName())
+                        Component.translatable(newState.getDisplayName())
                 ));
             }
         }
@@ -313,7 +311,7 @@ public class GeneralCommands {
         RegionVisitor visitor = new RegionVisitor(session.getSelection(injectedWorld), apply);
         Operations.complete(visitor);
 
-        actor.printInfo(TranslatableComponent.of("worldedit.update"));
+        actor.printInfo(Component.translatable("worldedit.update"));
     }
 
     @Command(
@@ -326,10 +324,10 @@ public class GeneralCommands {
                             @Arg(desc = "The reorder mode", def = "")
                                 EditSession.ReorderMode reorderMode) {
         if (reorderMode == null) {
-            actor.printInfo(TranslatableComponent.of("worldedit.reorder.current", TextComponent.of(session.getReorderMode().getDisplayName())));
+            actor.printInfo(Component.translatable("worldedit.reorder.current", Component.text(session.getReorderMode().getDisplayName())));
         } else {
             session.setReorderMode(reorderMode);
-            actor.printInfo(TranslatableComponent.of("worldedit.reorder.set", TextComponent.of(session.getReorderMode().getDisplayName())));
+            actor.printInfo(Component.translatable("worldedit.reorder.set", Component.text(session.getReorderMode().getDisplayName())));
         }
     }
 
@@ -342,28 +340,28 @@ public class GeneralCommands {
                               @Arg(desc = "The new draw selection state", def = "")
                                   Boolean drawSelection) throws WorldEditException {
         if (!WorldEdit.getInstance().getConfiguration().serverSideCUI) {
-            throw new AuthorizationException(TranslatableComponent.of("worldedit.error.disabled"));
+            throw new AuthorizationException(Component.translatable("worldedit.error.disabled"));
         }
         boolean useServerCui = session.shouldUseServerCUI();
         if (drawSelection != null && drawSelection == useServerCui) {
-            player.printError(TranslatableComponent.of("worldedit.drawsel." + (useServerCui ? "enabled" : "disabled") + ".already"));
+            player.printError(Component.translatable("worldedit.drawsel." + (useServerCui ? "enabled" : "disabled") + ".already"));
 
             return;
         }
         if (useServerCui) {
             session.setUseServerCUI(false);
             session.updateServerCUI(player);
-            player.printInfo(TranslatableComponent.of("worldedit.drawsel.disabled"));
+            player.printInfo(Component.translatable("worldedit.drawsel.disabled"));
         } else {
             session.setUseServerCUI(true);
             session.updateServerCUI(player);
 
             int maxSize = ServerCUIHandler.getMaxServerCuiSize();
-            player.printInfo(TranslatableComponent.of(
+            player.printInfo(Component.translatable(
                 "worldedit.drawsel.enabled",
-                TextComponent.of(maxSize),
-                TextComponent.of(maxSize),
-                TextComponent.of(maxSize)
+                Component.text(maxSize),
+                Component.text(maxSize),
+                Component.text(maxSize)
             ));
         }
     }
@@ -377,9 +375,9 @@ public class GeneralCommands {
             @Arg(desc = "The world override", def = "") World world) {
         session.setWorldOverride(world);
         if (world == null) {
-            actor.printInfo(TranslatableComponent.of("worldedit.world.remove"));
+            actor.printInfo(Component.translatable("worldedit.world.remove"));
         } else {
-            actor.printInfo(TranslatableComponent.of("worldedit.world.set", TextComponent.of(world.getId())));
+            actor.printInfo(Component.translatable("worldedit.world.set", Component.text(world.getId())));
         }
     }
 
@@ -394,16 +392,16 @@ public class GeneralCommands {
                          @Arg(desc = "The mode to set the watchdog hook to", def = "")
                              HookMode hookMode) {
         if (WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.GAME_HOOKS).getWatchdog() == null) {
-            actor.printError(TranslatableComponent.of("worldedit.watchdog.no-hook"));
+            actor.printError(Component.translatable("worldedit.watchdog.no-hook"));
             return;
         }
         boolean previousMode = session.isTickingWatchdog();
         if (hookMode != null && (hookMode == HookMode.ACTIVE) == previousMode) {
-            actor.printError(TranslatableComponent.of(previousMode ? "worldedit.watchdog.active.already" : "worldedit.watchdog.inactive.already"));
+            actor.printError(Component.translatable(previousMode ? "worldedit.watchdog.active.already" : "worldedit.watchdog.inactive.already"));
             return;
         }
         session.setTickingWatchdog(!previousMode);
-        actor.printInfo(TranslatableComponent.of(previousMode ? "worldedit.watchdog.inactive" : "worldedit.watchdog.active"));
+        actor.printInfo(Component.translatable(previousMode ? "worldedit.watchdog.inactive" : "worldedit.watchdog.active"));
     }
 
     @Command(
@@ -417,16 +415,16 @@ public class GeneralCommands {
                           Mask mask) {
         if (mask == null) {
             session.setMask(null);
-            actor.printInfo(TranslatableComponent.of("worldedit.gmask.disabled"));
+            actor.printInfo(Component.translatable("worldedit.gmask.disabled"));
         } else {
             session.setMask(mask);
-            actor.printInfo(TranslatableComponent.of("worldedit.gmask.set"));
+            actor.printInfo(Component.translatable("worldedit.gmask.set"));
         }
     }
 
     private static void placementImpl(Actor actor, LocalSession session, Placement placement) {
         if (!placement.canBeUsedBy(actor)) {
-            actor.printError(TranslatableComponent.of("worldedit.toggleplace.not-locatable"));
+            actor.printError(Component.translatable("worldedit.toggleplace.not-locatable"));
             return;
         }
 
@@ -463,7 +461,7 @@ public class GeneralCommands {
         offset = offset.multiply(multiplier);
         if (placementType == PlacementType.HERE) {
             if (!placementType.canBeUsedBy(actor)) {
-                actor.printError(TranslatableComponent.of("worldedit.toggleplace.not-locatable"));
+                actor.printError(Component.translatable("worldedit.toggleplace.not-locatable"));
                 return;
             }
             // Replace "//placement here" by "//placement <current player coordinates>"
@@ -490,16 +488,16 @@ public class GeneralCommands {
                                List<String> query) {
         String search = String.join(" ", query);
         if (search.length() <= 2) {
-            actor.printError(TranslatableComponent.of("worldedit.searchitem.too-short"));
+            actor.printError(Component.translatable("worldedit.searchitem.too-short"));
             return;
         }
         if (blocksOnly && itemsOnly) {
-            actor.printError(TranslatableComponent.of("worldedit.searchitem.either-b-or-i"));
+            actor.printError(Component.translatable("worldedit.searchitem.either-b-or-i"));
             return;
         }
 
         WorldEditAsyncCommandBuilder.createAndSendMessage(actor, new ItemSearcher(search, blocksOnly, itemsOnly, page),
-                TranslatableComponent.of("worldedit.searchitem.searching"));
+                Component.translatable("worldedit.searchitem.searching"));
     }
 
     private static class ItemSearcher implements Callable<Component> {
@@ -532,9 +530,9 @@ public class GeneralCommands {
                 final String id = searchType.getId();
                 if (id.contains(idMatch)) {
                     Component name = searchType.getRichName();
-                    results.put(id, TextComponent.builder()
+                    results.put(id, Component.text()
                         .append(name)
-                        .append(" (" + id + ")")
+                        .append(Component.text(" (" + id + ")"))
                         .build());
                 }
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GenerationCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GenerationCommands.java
@@ -36,8 +36,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.util.TreeGenerator.TreeType;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.generation.ConfiguredFeatureType;
 import com.sk89q.worldedit.world.generation.StructureType;
@@ -118,7 +117,7 @@ public class GenerationCommands {
                 break;
 
             default:
-                actor.printError(TranslatableComponent.of("worldedit.cyl.invalid-radius"));
+                actor.printError(Component.translatable("worldedit.cyl.invalid-radius"));
                 return 0;
         }
 
@@ -128,7 +127,7 @@ public class GenerationCommands {
 
         BlockVector3 pos = session.getPlacementPosition(actor);
         int affected = editSession.makeCylinder(pos, pattern, radiusX, radiusZ, height, !hollow);
-        actor.printInfo(TranslatableComponent.of("worldedit.cyl.created", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.cyl.created", Component.text(affected)));
         return affected;
     }
 
@@ -160,7 +159,7 @@ public class GenerationCommands {
                 radiusZ = Math.max(1, radii.get(1));
             }
             default -> {
-                actor.printError(TranslatableComponent.of("worldedit.cone.invalid-radius"));
+                actor.printError(Component.translatable("worldedit.cone.invalid-radius"));
                 return 0;
             }
         }
@@ -171,7 +170,7 @@ public class GenerationCommands {
 
         BlockVector3 pos = session.getPlacementPosition(actor);
         int affected = editSession.makeCone(pos, pattern, radiusX, radiusZ, height, !hollow, thickness);
-        actor.printInfo(TranslatableComponent.of("worldedit.cone.created", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.cone.created", Component.text(affected)));
         return affected;
     }
 
@@ -223,7 +222,7 @@ public class GenerationCommands {
                 break;
 
             default:
-                actor.printError(TranslatableComponent.of("worldedit.sphere.invalid-radius"));
+                actor.printError(Component.translatable("worldedit.sphere.invalid-radius"));
                 return 0;
         }
 
@@ -240,7 +239,7 @@ public class GenerationCommands {
         if (actor instanceof Player) {
             ((Player) actor).findFreePosition();
         }
-        actor.printInfo(TranslatableComponent.of("worldedit.sphere.created", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.sphere.created", Component.text(affected)));
         return affected;
     }
 
@@ -261,7 +260,7 @@ public class GenerationCommands {
         worldEdit.checkMaxRadius(size);
         density /= 100;
         int affected = editSession.makeForest(session.getPlacementPosition(actor), size, density, type);
-        actor.printInfo(TranslatableComponent.of("worldedit.forestgen.created", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.forestgen.created", Component.text(affected)));
         return affected;
     }
 
@@ -276,7 +275,7 @@ public class GenerationCommands {
                             int size) throws WorldEditException {
         worldEdit.checkMaxRadius(size);
         int affected = editSession.makePumpkinPatches(session.getPlacementPosition(actor), size);
-        actor.printInfo(TranslatableComponent.of("worldedit.pumpkins.created", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.pumpkins.created", Component.text(affected)));
         return affected;
     }
 
@@ -290,9 +289,9 @@ public class GenerationCommands {
                        @Arg(desc = "The feature")
                        ConfiguredFeatureType feature) throws WorldEditException {
         if (editSession.getWorld().generateFeature(feature, editSession, session.getPlacementPosition(actor))) {
-            actor.printInfo(TranslatableComponent.of("worldedit.feature.created"));
+            actor.printInfo(Component.translatable("worldedit.feature.created"));
         } else {
-            actor.printError(TranslatableComponent.of("worldedit.feature.failed"));
+            actor.printError(Component.translatable("worldedit.feature.failed"));
         }
         return 0;
     }
@@ -307,9 +306,9 @@ public class GenerationCommands {
                         @Arg(desc = "The structure")
                         StructureType feature) throws WorldEditException {
         if (editSession.getWorld().generateStructure(feature, editSession, session.getPlacementPosition(actor))) {
-            actor.printInfo(TranslatableComponent.of("worldedit.structure.created"));
+            actor.printInfo(Component.translatable("worldedit.structure.created"));
         } else {
-            actor.printError(TranslatableComponent.of("worldedit.structure.failed"));
+            actor.printError(Component.translatable("worldedit.structure.failed"));
         }
         return 0;
     }
@@ -347,7 +346,7 @@ public class GenerationCommands {
         if (actor instanceof Player) {
             ((Player) actor).findFreePosition();
         }
-        actor.printInfo(TranslatableComponent.of("worldedit.pyramid.created", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.pyramid.created", Component.text(affected)));
         return affected;
     }
 
@@ -412,10 +411,10 @@ public class GenerationCommands {
             if (actor instanceof Player) {
                 ((Player) actor).findFreePosition();
             }
-            actor.printInfo(TranslatableComponent.of("worldedit.generate.created", TextComponent.of(affected)));
+            actor.printInfo(Component.translatable("worldedit.generate.created", Component.text(affected)));
             return affected;
         } catch (ExpressionException e) {
-            actor.printError(TextComponent.of(e.getMessage()));
+            actor.printError(Component.text(e.getMessage()));
             return 0;
         }
     }
@@ -477,10 +476,10 @@ public class GenerationCommands {
 
         try {
             final int affected = editSession.makeBiomeShape(region, zero, unit, target, String.join(" ", expression), hollow, session.getTimeout());
-            actor.printInfo(TranslatableComponent.of("worldedit.generatebiome.changed", TextComponent.of(affected)));
+            actor.printInfo(Component.translatable("worldedit.generatebiome.changed", Component.text(affected)));
             return affected;
         } catch (ExpressionException e) {
-            actor.printError(TextComponent.of(e.getMessage()));
+            actor.printError(Component.text(e.getMessage()));
             return 0;
         }
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/HistoryCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/HistoryCommands.java
@@ -28,8 +28,7 @@ import com.sk89q.worldedit.command.util.CommandPermissionsConditionGenerator;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extent.inventory.BlockBag;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import org.enginehub.piston.annotation.Command;
 import org.enginehub.piston.annotation.CommandContainer;
 import org.enginehub.piston.annotation.param.Arg;
@@ -71,7 +70,7 @@ public class HistoryCommands {
             actor.checkPermission("worldedit.history.undo.other");
             undoSession = worldEdit.getSessionManager().findByName(playerName);
             if (undoSession == null) {
-                actor.printError(TranslatableComponent.of("worldedit.session.cant-find-session", TextComponent.of(playerName)));
+                actor.printError(Component.translatable("worldedit.session.cant-find-session", Component.text(playerName)));
                 return;
             }
         }
@@ -87,9 +86,9 @@ public class HistoryCommands {
             }
         }
         if (timesUndone > 0) {
-            actor.printInfo(TranslatableComponent.of("worldedit.undo.undone", TextComponent.of(timesUndone)));
+            actor.printInfo(Component.translatable("worldedit.undo.undone", Component.text(timesUndone)));
         } else {
-            actor.printError(TranslatableComponent.of("worldedit.undo.none"));
+            actor.printError(Component.translatable("worldedit.undo.none"));
         }
     }
 
@@ -110,7 +109,7 @@ public class HistoryCommands {
             actor.checkPermission("worldedit.history.redo.other");
             redoSession = worldEdit.getSessionManager().findByName(playerName);
             if (redoSession == null) {
-                actor.printError(TranslatableComponent.of("worldedit.session.cant-find-session", TextComponent.of(playerName)));
+                actor.printError(Component.translatable("worldedit.session.cant-find-session", Component.text(playerName)));
                 return;
             }
         }
@@ -126,9 +125,9 @@ public class HistoryCommands {
             }
         }
         if (timesRedone > 0) {
-            actor.printInfo(TranslatableComponent.of("worldedit.redo.redone", TextComponent.of(timesRedone)));
+            actor.printInfo(Component.translatable("worldedit.redo.redone", Component.text(timesRedone)));
         } else {
-            actor.printError(TranslatableComponent.of("worldedit.redo.none"));
+            actor.printError(Component.translatable("worldedit.redo.none"));
         }
     }
 
@@ -140,7 +139,7 @@ public class HistoryCommands {
     @CommandPermissions("worldedit.history.clear")
     public void clearHistory(Actor actor, LocalSession session) {
         session.clearHistory();
-        actor.printInfo(TranslatableComponent.of("worldedit.clearhistory.cleared"));
+        actor.printInfo(Component.translatable("worldedit.clearhistory.cleared"));
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/LegacySnapshotCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/LegacySnapshotCommands.java
@@ -28,11 +28,9 @@ import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.util.formatting.component.PaginationBox;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
 import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.snapshot.InvalidSnapshotException;
 import com.sk89q.worldedit.world.snapshot.Snapshot;
@@ -67,7 +65,7 @@ class LegacySnapshotCommands {
             if (!snapshots.isEmpty()) {
                 actor.print(new SnapshotListBox(world.getName(), snapshots).create(page));
             } else {
-                actor.printError(TranslatableComponent.of("worldedit.restore.none-found-console"));
+                actor.printError(Component.translatable("worldedit.restore.none-found-console"));
 
                 // Okay, let's toss some debugging information!
                 File dir = config.snapshotRepo.getDirectory();
@@ -82,7 +80,7 @@ class LegacySnapshotCommands {
                 }
             }
         } catch (MissingWorldException ex) {
-            actor.printError(TranslatableComponent.of("worldedit.restore.none-for-world"));
+            actor.printError(Component.translatable("worldedit.restore.none-for-world"));
         }
     }
 
@@ -96,19 +94,19 @@ class LegacySnapshotCommands {
 
                 if (snapshot != null) {
                     session.setSnapshot(null);
-                    actor.printInfo(TranslatableComponent.of("worldedit.snapshot.use.newest"));
+                    actor.printInfo(Component.translatable("worldedit.snapshot.use.newest"));
                 } else {
-                    actor.printError(TranslatableComponent.of("worldedit.restore.none-found"));
+                    actor.printError(Component.translatable("worldedit.restore.none-found"));
                 }
             } catch (MissingWorldException ex) {
-                actor.printError(TranslatableComponent.of("worldedit.restore.none-for-world"));
+                actor.printError(Component.translatable("worldedit.restore.none-for-world"));
             }
         } else {
             try {
                 session.setSnapshot(config.snapshotRepo.getSnapshot(name));
-                actor.printInfo(TranslatableComponent.of("worldedit.snapshot.use", TextComponent.of(name)));
+                actor.printInfo(Component.translatable("worldedit.snapshot.use", Component.text(name)));
             } catch (InvalidSnapshotException e) {
-                actor.printError(TranslatableComponent.of("worldedit.restore.not-available"));
+                actor.printError(Component.translatable("worldedit.restore.not-available"));
             }
         }
     }
@@ -117,25 +115,25 @@ class LegacySnapshotCommands {
         LocalConfiguration config = we.getConfiguration();
 
         if (index < 1) {
-            actor.printError(TranslatableComponent.of("worldedit.snapshot.index-above-0"));
+            actor.printError(Component.translatable("worldedit.snapshot.index-above-0"));
             return;
         }
 
         try {
             List<Snapshot> snapshots = config.snapshotRepo.getSnapshots(true, world.getName());
             if (snapshots.size() < index) {
-                actor.printError(TranslatableComponent.of("worldedit.snapshot.index-oob", TextComponent.of(snapshots.size())));
+                actor.printError(Component.translatable("worldedit.snapshot.index-oob", Component.text(snapshots.size())));
                 return;
             }
             Snapshot snapshot = snapshots.get(index - 1);
             if (snapshot == null) {
-                actor.printError(TranslatableComponent.of("worldedit.restore.not-available"));
+                actor.printError(Component.translatable("worldedit.restore.not-available"));
                 return;
             }
             session.setSnapshot(snapshot);
-            actor.printInfo(TranslatableComponent.of("worldedit.snapshot.use", TextComponent.of(snapshot.getName())));
+            actor.printInfo(Component.translatable("worldedit.snapshot.use", Component.text(snapshot.getName())));
         } catch (MissingWorldException e) {
-            actor.printError(TranslatableComponent.of("worldedit.restore.none-for-world"));
+            actor.printError(Component.translatable("worldedit.restore.none-for-world"));
         }
     }
 
@@ -146,16 +144,16 @@ class LegacySnapshotCommands {
             Snapshot snapshot = config.snapshotRepo.getSnapshotBefore(date, world.getName());
 
             if (snapshot == null) {
-                actor.printError(TranslatableComponent.of(
+                actor.printError(Component.translatable(
                     "worldedit.snapshot.none-before",
-                    TextComponent.of(dateFormat.withZone(session.getTimeZone()).format(date)))
+                    Component.text(dateFormat.withZone(session.getTimeZone()).format(date)))
                 );
             } else {
                 session.setSnapshot(snapshot);
-                actor.printInfo(TranslatableComponent.of("worldedit.snapshot.use", TextComponent.of(snapshot.getName())));
+                actor.printInfo(Component.translatable("worldedit.snapshot.use", Component.text(snapshot.getName())));
             }
         } catch (MissingWorldException ex) {
-            actor.printError(TranslatableComponent.of("worldedit.restore.none-for-world"));
+            actor.printError(Component.translatable("worldedit.restore.none-for-world"));
         }
     }
 
@@ -165,16 +163,16 @@ class LegacySnapshotCommands {
         try {
             Snapshot snapshot = config.snapshotRepo.getSnapshotAfter(date, world.getName());
             if (snapshot == null) {
-                actor.printError(TranslatableComponent.of(
+                actor.printError(Component.translatable(
                     "worldedit.snapshot.none-after",
-                    TextComponent.of(dateFormat.withZone(session.getTimeZone()).format(date)))
+                    Component.text(dateFormat.withZone(session.getTimeZone()).format(date)))
                 );
             } else {
                 session.setSnapshot(snapshot);
-                actor.printInfo(TranslatableComponent.of("worldedit.snapshot.use", TextComponent.of(snapshot.getName())));
+                actor.printInfo(Component.translatable("worldedit.snapshot.use", Component.text(snapshot.getName())));
             }
         } catch (MissingWorldException ex) {
-            actor.printError(TranslatableComponent.of("worldedit.restore.none-for-world"));
+            actor.printError(Component.translatable("worldedit.restore.none-for-world"));
         }
     }
 
@@ -189,10 +187,10 @@ class LegacySnapshotCommands {
         @Override
         public Component getComponent(int number) {
             final Snapshot snapshot = snapshots.get(number);
-            return TextComponent.of(number + 1 + ". ", TextColor.GOLD)
-                    .append(TextComponent.of(snapshot.getName(), TextColor.LIGHT_PURPLE)
-                            .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TextComponent.of("Click to use")))
-                            .clickEvent(ClickEvent.of(ClickEvent.Action.RUN_COMMAND, "/snap use " + snapshot.getName())));
+            return Component.text(number + 1 + ". ", NamedTextColor.GOLD)
+                    .append(Component.text(snapshot.getName(), NamedTextColor.LIGHT_PURPLE)
+                            .hoverEvent(HoverEvent.showText(Component.text("Click to use")))
+                            .clickEvent(ClickEvent.runCommand("/snap use " + snapshot.getName())));
         }
 
         @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/LegacySnapshotUtilCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/LegacySnapshotUtilCommands.java
@@ -26,8 +26,7 @@ import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.regions.Region;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.DataException;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.snapshot.InvalidSnapshotException;
@@ -58,7 +57,7 @@ class LegacySnapshotUtilCommands {
             try {
                 snapshot = config.snapshotRepo.getSnapshot(snapshotName);
             } catch (InvalidSnapshotException e) {
-                actor.printError(TranslatableComponent.of("worldedit.restore.not-available"));
+                actor.printError(Component.translatable("worldedit.restore.not-available"));
                 return;
             }
         } else {
@@ -71,7 +70,7 @@ class LegacySnapshotUtilCommands {
                 snapshot = config.snapshotRepo.getDefaultSnapshot(world.getName());
 
                 if (snapshot == null) {
-                    actor.printError(TranslatableComponent.of("worldedit.restore.none-found-console"));
+                    actor.printError(Component.translatable("worldedit.restore.none-found-console"));
 
                     // Okay, let's toss some debugging information!
                     File dir = config.snapshotRepo.getDirectory();
@@ -88,7 +87,7 @@ class LegacySnapshotUtilCommands {
                     return;
                 }
             } catch (MissingWorldException ex) {
-                actor.printError(TranslatableComponent.of("worldedit.restore.none-for-world"));
+                actor.printError(Component.translatable("worldedit.restore.none-for-world"));
                 return;
             }
         }
@@ -98,9 +97,9 @@ class LegacySnapshotUtilCommands {
         // Load chunk store
         try {
             chunkStore = snapshot.getChunkStore();
-            actor.printInfo(TranslatableComponent.of("worldedit.restore.loaded", TextComponent.of(snapshot.getName())));
+            actor.printInfo(Component.translatable("worldedit.restore.loaded", Component.text(snapshot.getName())));
         } catch (DataException | IOException e) {
-            actor.printError(TranslatableComponent.of("worldedit.restore.failed", TextComponent.of(e.getMessage())));
+            actor.printError(Component.translatable("worldedit.restore.failed", Component.text(e.getMessage())));
             return;
         }
 
@@ -114,17 +113,17 @@ class LegacySnapshotUtilCommands {
             if (restore.hadTotalFailure()) {
                 String error = restore.getLastErrorMessage();
                 if (!restore.getMissingChunks().isEmpty()) {
-                    actor.printError(TranslatableComponent.of("worldedit.restore.chunk-not-present"));
+                    actor.printError(Component.translatable("worldedit.restore.chunk-not-present"));
                 } else if (error != null) {
-                    actor.printError(TranslatableComponent.of("worldedit.restore.block-place-failed"));
-                    actor.printError(TranslatableComponent.of("worldedit.restore.block-place-error", TextComponent.of(error)));
+                    actor.printError(Component.translatable("worldedit.restore.block-place-failed"));
+                    actor.printError(Component.translatable("worldedit.restore.block-place-error", Component.text(error)));
                 } else {
-                    actor.printError(TranslatableComponent.of("worldedit.restore.chunk-load-failed"));
+                    actor.printError(Component.translatable("worldedit.restore.chunk-load-failed"));
                 }
             } else {
-                actor.printInfo(TranslatableComponent.of("worldedit.restore.restored",
-                    TextComponent.of(restore.getMissingChunks().size()),
-                    TextComponent.of(restore.getErrorChunks().size())));
+                actor.printInfo(Component.translatable("worldedit.restore.restored",
+                    Component.text(restore.getMissingChunks().size()),
+                    Component.text(restore.getErrorChunks().size())));
             }
         } finally {
             try {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/NavigationCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/NavigationCommands.java
@@ -27,8 +27,7 @@ import com.sk89q.worldedit.command.util.CommandPermissionsConditionGenerator;
 import com.sk89q.worldedit.command.util.Logging;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.util.Location;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import org.enginehub.piston.annotation.Command;
 import org.enginehub.piston.annotation.CommandContainer;
 import org.enginehub.piston.annotation.param.Arg;
@@ -63,7 +62,7 @@ public class NavigationCommands {
     @CommandPermissions("worldedit.navigation.unstuck")
     public void unstuck(Player player) throws WorldEditException {
         player.findFreePosition();
-        player.printInfo(TranslatableComponent.of("worldedit.unstuck.moved"));
+        player.printInfo(Component.translatable("worldedit.unstuck.moved"));
     }
 
     @Command(
@@ -83,9 +82,9 @@ public class NavigationCommands {
             }
         }
         if (ascentLevels == 0) {
-            player.printError(TranslatableComponent.of("worldedit.ascend.obstructed"));
+            player.printError(Component.translatable("worldedit.ascend.obstructed"));
         } else {
-            player.printInfo(TranslatableComponent.of("worldedit.ascend.moved", TextComponent.of(ascentLevels)));
+            player.printInfo(Component.translatable("worldedit.ascend.moved", Component.text(ascentLevels)));
         }
     }
 
@@ -106,9 +105,9 @@ public class NavigationCommands {
             }
         }
         if (descentLevels == 0) {
-            player.printError(TranslatableComponent.of("worldedit.descend.obstructed"));
+            player.printError(Component.translatable("worldedit.descend.obstructed"));
         } else {
-            player.printInfo(TranslatableComponent.of("worldedit.descend.moved", TextComponent.of(descentLevels)));
+            player.printInfo(Component.translatable("worldedit.descend.moved", Component.text(descentLevels)));
         }
     }
 
@@ -129,9 +128,9 @@ public class NavigationCommands {
 
         boolean alwaysGlass = getAlwaysGlass(forceFlight, forceGlass);
         if (player.ascendToCeiling(clearance, alwaysGlass)) {
-            player.printInfo(TranslatableComponent.of("worldedit.ceil.moved"));
+            player.printInfo(Component.translatable("worldedit.ceil.moved"));
         } else {
-            player.printError(TranslatableComponent.of("worldedit.ceil.obstructed"));
+            player.printError(Component.translatable("worldedit.ceil.obstructed"));
         }
     }
 
@@ -142,9 +141,9 @@ public class NavigationCommands {
     @CommandPermissions("worldedit.navigation.thru.command")
     public void thru(Player player) throws WorldEditException {
         if (player.passThroughForwardWall(6)) {
-            player.printInfo(TranslatableComponent.of("worldedit.thru.moved"));
+            player.printInfo(Component.translatable("worldedit.thru.moved"));
         } else {
-            player.printError(TranslatableComponent.of("worldedit.thru.obstructed"));
+            player.printError(Component.translatable("worldedit.thru.obstructed"));
         }
     }
 
@@ -159,9 +158,9 @@ public class NavigationCommands {
         Location pos = player.getSolidBlockTrace(300);
         if (pos != null) {
             player.findFreePosition(pos);
-            player.printInfo(TranslatableComponent.of("worldedit.jumpto.moved"));
+            player.printInfo(Component.translatable("worldedit.jumpto.moved"));
         } else {
-            player.printError(TranslatableComponent.of("worldedit.jumpto.none"));
+            player.printError(Component.translatable("worldedit.jumpto.none"));
         }
     }
 
@@ -180,9 +179,9 @@ public class NavigationCommands {
                        boolean forceGlass) throws WorldEditException {
         boolean alwaysGlass = getAlwaysGlass(forceFlight, forceGlass);
         if (player.ascendUpwards(distance, alwaysGlass)) {
-            player.printInfo(TranslatableComponent.of("worldedit.up.moved"));
+            player.printInfo(Component.translatable("worldedit.up.moved"));
         } else {
-            player.printError(TranslatableComponent.of("worldedit.up.obstructed"));
+            player.printError(Component.translatable("worldedit.up.obstructed"));
         }
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/PaintBrushCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/PaintBrushCommands.java
@@ -39,9 +39,8 @@ import com.sk89q.worldedit.internal.annotation.Direction;
 import com.sk89q.worldedit.internal.command.CommandRegistrationHandler;
 import com.sk89q.worldedit.regions.factory.RegionFactory;
 import com.sk89q.worldedit.util.TreeGenerator;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.Component;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 import com.sk89q.worldedit.util.formatting.text.format.TextDecoration;
 import org.enginehub.piston.CommandManager;
 import org.enginehub.piston.CommandManagerService;
@@ -61,24 +60,24 @@ import static org.enginehub.piston.part.CommandParts.arg;
 @CommandContainer(superTypes = CommandPermissionsConditionGenerator.Registration.class)
 public class PaintBrushCommands {
 
-    private static final CommandArgument REGION_FACTORY = arg(TranslatableComponent.of("shape"), TranslatableComponent.of("worldedit.brush.paint.shape"))
+    private static final CommandArgument REGION_FACTORY = arg(Component.translatable("shape"), Component.translatable("worldedit.brush.paint.shape"))
         .defaultsTo(ImmutableList.of())
         .ofTypes(ImmutableList.of(Key.of(RegionFactory.class)))
         .build();
 
-    private static final CommandArgument RADIUS = arg(TranslatableComponent.of("radius"), TranslatableComponent.of("worldedit.brush.paint.size"))
+    private static final CommandArgument RADIUS = arg(Component.translatable("radius"), Component.translatable("worldedit.brush.paint.size"))
         .defaultsTo(ImmutableList.of("5"))
         .ofTypes(ImmutableList.of(Key.of(double.class)))
         .build();
 
-    private static final CommandArgument DENSITY = arg(TranslatableComponent.of("density"), TranslatableComponent.of("worldedit.brush.paint.density"))
+    private static final CommandArgument DENSITY = arg(Component.translatable("density"), Component.translatable("worldedit.brush.paint.density"))
         .defaultsTo(ImmutableList.of("20"))
         .ofTypes(ImmutableList.of(Key.of(double.class)))
         .build();
 
     public static void register(CommandManagerService service, CommandManager commandManager, CommandRegistrationHandler registration) {
         commandManager.register("paint", builder -> {
-            builder.description(TranslatableComponent.of("worldedit.brush.paint.description"));
+            builder.description(Component.translatable("worldedit.brush.paint.description"));
             builder.action(org.enginehub.piston.Command.Action.NULL_ACTION);
 
             CommandManager manager = service.newCommandManager();
@@ -91,7 +90,7 @@ public class PaintBrushCommands {
             builder.condition(new PermissionCondition(ImmutableSet.of("worldedit.brush.paint")));
 
             builder.addParts(REGION_FACTORY, RADIUS, DENSITY);
-            builder.addPart(SubCommandPart.builder(TranslatableComponent.of("type"), TranslatableComponent.of("worldedit.brush.paint.type"))
+            builder.addPart(SubCommandPart.builder(Component.translatable("type"), Component.translatable("worldedit.brush.paint.type"))
                 .withCommands(manager.getAllCommands().collect(Collectors.toList()))
                 .required()
                 .build());
@@ -130,8 +129,8 @@ public class PaintBrushCommands {
                      @Arg(desc = "The direction in which the item will be applied", def = "up")
                      @Direction(includeDiagonals = true)
                          com.sk89q.worldedit.util.Direction direction) throws WorldEditException {
-        player.print(TextComponent.builder().append("WARNING: ", TextColor.RED, TextDecoration.BOLD)
-                .append(TranslatableComponent.of("worldedit.brush.paint.item.warning")).build());
+        player.print(Component.text("WARNING: ", NamedTextColor.RED, TextDecoration.BOLD)
+                .append(Component.translatable("worldedit.brush.paint.item.warning")));
         setPaintBrush(parameters, player, localSession, new ItemUseFactory(item, direction));
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -58,8 +58,6 @@ import com.sk89q.worldedit.regions.RegionOperationException;
 import com.sk89q.worldedit.util.TreeGenerator.TreeType;
 import com.sk89q.worldedit.util.formatting.component.TextUtils;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.RegenOptions;
 import com.sk89q.worldedit.world.World;
 import org.enginehub.piston.annotation.Command;
@@ -107,9 +105,9 @@ public class RegionCommands {
         Operations.completeBlindly(visitor);
         List<Component> messages = Lists.newArrayList(visitor.getStatusMessages());
         if (messages.isEmpty()) {
-            actor.printInfo(TranslatableComponent.of("worldedit.set.done"));
+            actor.printInfo(Component.translatable("worldedit.set.done"));
         } else {
-            actor.printInfo(TranslatableComponent.of("worldedit.set.done.verbose", TextUtils.join(messages, TextComponent.of(", "))));
+            actor.printInfo(Component.translatable("worldedit.set.done.verbose", TextUtils.join(messages, Component.text(", "))));
         }
 
         return visitor.getAffected();
@@ -131,7 +129,7 @@ public class RegionCommands {
                     @Switch(name = 'h', desc = "Generate only a shell")
                         boolean shell) throws WorldEditException {
         if (!((region instanceof CuboidRegion) || (region instanceof ConvexPolyhedralRegion))) {
-            actor.printError(TranslatableComponent.of("worldedit.line.invalid-type"));
+            actor.printError(Component.translatable("worldedit.line.invalid-type"));
             return 0;
         }
         checkCommandArgument(thickness >= 0, "Thickness must be >= 0");
@@ -148,7 +146,7 @@ public class RegionCommands {
 
         int blocksChanged = editSession.drawLine(pattern, vectors, thickness, !shell);
 
-        actor.printInfo(TranslatableComponent.of("worldedit.line.changed", TextComponent.of(blocksChanged)));
+        actor.printInfo(Component.translatable("worldedit.line.changed", Component.text(blocksChanged)));
         return blocksChanged;
     }
 
@@ -168,7 +166,7 @@ public class RegionCommands {
                      @Switch(name = 'h', desc = "Generate only a shell")
                          boolean shell) throws WorldEditException {
         if (!(region instanceof ConvexPolyhedralRegion)) {
-            actor.printError(TranslatableComponent.of("worldedit.curve.invalid-type"));
+            actor.printError(Component.translatable("worldedit.curve.invalid-type"));
             return 0;
         }
         checkCommandArgument(thickness >= 0, "Thickness must be >= 0");
@@ -178,7 +176,7 @@ public class RegionCommands {
 
         int blocksChanged = editSession.drawSpline(pattern, vectors, 0, 0, 0, 10, thickness, !shell);
 
-        actor.printInfo(TranslatableComponent.of("worldedit.curve.changed", TextComponent.of(blocksChanged)));
+        actor.printInfo(Component.translatable("worldedit.curve.changed", Component.text(blocksChanged)));
         return blocksChanged;
     }
 
@@ -198,7 +196,7 @@ public class RegionCommands {
             from = new ExistingBlockMask(editSession);
         }
         int affected = editSession.replaceBlocks(region, from, to);
-        actor.printInfo(TranslatableComponent.of("worldedit.replace.replaced", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.replace.replaced", Component.text(affected)));
         return affected;
     }
 
@@ -212,7 +210,7 @@ public class RegionCommands {
                        @Arg(desc = "The pattern of blocks to overlay")
                            Pattern pattern) throws WorldEditException {
         int affected = editSession.overlayCuboidBlocks(region, pattern);
-        actor.printInfo(TranslatableComponent.of("worldedit.overlay.overlaid", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.overlay.overlaid", Component.text(affected)));
         return affected;
     }
 
@@ -227,7 +225,7 @@ public class RegionCommands {
                       @Arg(desc = "The pattern of blocks to set")
                           Pattern pattern) throws WorldEditException {
         int affected = editSession.center(region, pattern);
-        actor.printInfo(TranslatableComponent.of("worldedit.center.changed", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.center.changed", Component.text(affected)));
         return affected;
     }
 
@@ -239,7 +237,7 @@ public class RegionCommands {
     @Logging(REGION)
     public int naturalize(Actor actor, EditSession editSession, @Selection Region region) throws WorldEditException {
         int affected = editSession.naturalizeCuboidBlocks(region);
-        actor.printInfo(TranslatableComponent.of("worldedit.naturalize.naturalized", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.naturalize.naturalized", Component.text(affected)));
         return affected;
     }
 
@@ -253,7 +251,7 @@ public class RegionCommands {
                      @Arg(desc = "The pattern of blocks to set")
                          Pattern pattern) throws WorldEditException {
         int affected = editSession.makeWalls(region, pattern);
-        actor.printInfo(TranslatableComponent.of("worldedit.walls.changed", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.walls.changed", Component.text(affected)));
         return affected;
     }
 
@@ -268,7 +266,7 @@ public class RegionCommands {
                      @Arg(desc = "The pattern of blocks to set")
                          Pattern pattern) throws WorldEditException {
         int affected = editSession.makeFaces(region, pattern);
-        actor.printInfo(TranslatableComponent.of("worldedit.faces.changed", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.faces.changed", Component.text(affected)));
         return affected;
     }
 
@@ -287,7 +285,7 @@ public class RegionCommands {
         HeightMap heightMap = new HeightMap(editSession, region, mask);
         HeightMapFilter filter = new HeightMapFilter(new GaussianKernel(5, 1.0));
         int affected = heightMap.applyFilter(filter, iterations);
-        actor.printInfo(TranslatableComponent.of("worldedit.smooth.changed", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.smooth.changed", Component.text(affected)));
         return affected;
     }
 
@@ -309,7 +307,7 @@ public class RegionCommands {
         HeightMapFilter filter = new HeightMapFilter(new GaussianKernel(5, 1.0));
         float[] changed = heightMap.applyFilter(filter, iterations);
         int affected = heightMap.applyChanges(changed, snowBlockCount);
-        actor.printInfo(TranslatableComponent.of("worldedit.snowsmooth.changed", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.snowsmooth.changed", Component.text(affected)));
         return affected;
     }
 
@@ -364,7 +362,7 @@ public class RegionCommands {
             }
         }
 
-        actor.printInfo(TranslatableComponent.of("worldedit.move.moved", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.move.moved", Component.text(affected)));
         return affected;
     }
 
@@ -428,7 +426,7 @@ public class RegionCommands {
             }
         }
 
-        actor.printInfo(TranslatableComponent.of("worldedit.stack.changed", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.stack.changed", Component.text(affected)));
         return affected;
     }
 
@@ -457,9 +455,9 @@ public class RegionCommands {
             session.setMask(mask);
         }
         if (success) {
-            actor.printInfo(TranslatableComponent.of("worldedit.regen.regenerated"));
+            actor.printInfo(Component.translatable("worldedit.regen.regenerated"));
         } else {
-            actor.printError(TranslatableComponent.of("worldedit.regen.failed"));
+            actor.printError(Component.translatable("worldedit.regen.failed"));
         }
     }
 
@@ -520,10 +518,10 @@ public class RegionCommands {
             if (actor instanceof Player) {
                 ((Player) actor).findFreePosition();
             }
-            actor.printInfo(TranslatableComponent.of("worldedit.deform.deformed", TextComponent.of(affected)));
+            actor.printInfo(Component.translatable("worldedit.deform.deformed", Component.text(affected)));
             return affected;
         } catch (ExpressionException e) {
-            actor.printError(TextComponent.of(e.getMessage()));
+            actor.printError(Component.text(e.getMessage()));
             return 0;
         }
     }
@@ -544,7 +542,7 @@ public class RegionCommands {
         checkCommandArgument(thickness >= 0, "Thickness must be >= 0");
 
         int affected = editSession.hollowOutRegion(region, thickness, pattern);
-        actor.printInfo(TranslatableComponent.of("worldedit.hollow.changed", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.hollow.changed", Component.text(affected)));
         return affected;
     }
 
@@ -561,7 +559,7 @@ public class RegionCommands {
                           double density) throws WorldEditException {
         checkCommandArgument(0 <= density && density <= 100, "Density must be in [0, 100]");
         int affected = editSession.makeForest(region, density / 100, type);
-        actor.printInfo(TranslatableComponent.of("worldedit.forest.created", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.forest.created", Component.text(affected)));
         return affected;
     }
 
@@ -583,7 +581,7 @@ public class RegionCommands {
         Operations.completeLegacy(visitor);
 
         int affected = ground.getAffected();
-        actor.printInfo(TranslatableComponent.of("worldedit.flora.created", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.flora.created", Component.text(affected)));
         return affected;
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -47,11 +47,9 @@ import com.sk89q.worldedit.util.formatting.component.ErrorFormat;
 import com.sk89q.worldedit.util.formatting.component.PaginationBox;
 import com.sk89q.worldedit.util.formatting.component.SubtleFormat;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
 import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 import com.sk89q.worldedit.util.io.Closer;
 import com.sk89q.worldedit.util.io.file.FilenameException;
 import com.sk89q.worldedit.util.io.file.MorePaths;
@@ -120,7 +118,7 @@ public class SchematicCommands {
                 ClipboardFormats.getFileExtensionArray());
 
         if (!f.exists()) {
-            actor.printError(TranslatableComponent.of("worldedit.schematic.load.does-not-exist", TextComponent.of(filename)));
+            actor.printError(Component.translatable("worldedit.schematic.load.does-not-exist", Component.text(filename)));
             return;
         }
 
@@ -132,11 +130,11 @@ public class SchematicCommands {
         SchematicLoadTask task = new SchematicLoadTask(actor, f, format);
         AsyncCommandBuilder.wrap(task, actor)
                 .registerWithSupervisor(worldEdit.getSupervisor(), "Loading schematic " + filename)
-                .setDelayMessage(TranslatableComponent.of("worldedit.schematic.load.loading"))
-                .setWorkingMessage(TranslatableComponent.of("worldedit.schematic.load.still-loading"))
-                .onSuccess(TextComponent.of(filename, TextColor.GOLD)
-                                .append(TextComponent.of(" loaded. Paste it with ", TextColor.LIGHT_PURPLE))
-                                .append(CodeFormat.wrap("//paste").clickEvent(ClickEvent.of(ClickEvent.Action.SUGGEST_COMMAND, "//paste"))),
+                .setDelayMessage(Component.translatable("worldedit.schematic.load.loading"))
+                .setWorkingMessage(Component.translatable("worldedit.schematic.load.still-loading"))
+                .onSuccess(Component.text(filename, NamedTextColor.GOLD)
+                                .append(Component.text(" loaded. Paste it with ", NamedTextColor.LIGHT_PURPLE))
+                                .append(CodeFormat.wrap("//paste").clickEvent(ClickEvent.suggestCommand("//paste"))),
                         session::setClipboard)
                 .onFailure("Failed to load schematic", worldEdit.getPlatformManager().getPlatformCommandManager().getExceptionConverter())
                 .buildAndExec(worldEdit.getExecutorService());
@@ -155,7 +153,7 @@ public class SchematicCommands {
                      @Switch(name = 'f', desc = "Overwrite an existing file.")
                          boolean allowOverwrite) throws WorldEditException {
         if (worldEdit.getPlatformManager().queryCapability(Capability.GAME_HOOKS).getDataVersion() == -1) {
-            actor.printError(TranslatableComponent.of("worldedit.schematic.unsupported-minecraft-version"));
+            actor.printError(Component.translatable("worldedit.schematic.unsupported-minecraft-version"));
             return;
         }
 
@@ -168,10 +166,10 @@ public class SchematicCommands {
         boolean overwrite = f.exists();
         if (overwrite) {
             if (!actor.hasPermission("worldedit.schematic.delete")) {
-                throw new StopExecutionException(TextComponent.of("That schematic already exists!"));
+                throw new StopExecutionException(Component.text("That schematic already exists!"));
             }
             if (!allowOverwrite) {
-                actor.printError(TranslatableComponent.of("worldedit.schematic.save.already-exists"));
+                actor.printError(Component.translatable("worldedit.schematic.save.already-exists"));
                 return;
             }
         }
@@ -180,7 +178,7 @@ public class SchematicCommands {
         File parent = f.getParentFile();
         if (parent != null && !parent.exists()) {
             if (!parent.mkdirs()) {
-                throw new StopExecutionException(TranslatableComponent.of(
+                throw new StopExecutionException(Component.translatable(
                         "worldedit.schematic.save.failed-directory"));
             }
         }
@@ -190,8 +188,8 @@ public class SchematicCommands {
         SchematicSaveTask task = new SchematicSaveTask(actor, f, format, holder, overwrite);
         AsyncCommandBuilder.wrap(task, actor)
                 .registerWithSupervisor(worldEdit.getSupervisor(), "Saving schematic " + filename)
-                .setDelayMessage(TranslatableComponent.of("worldedit.schematic.save.saving"))
-                .setWorkingMessage(TranslatableComponent.of("worldedit.schematic.save.still-saving"))
+                .setDelayMessage(Component.translatable("worldedit.schematic.save.saving"))
+                .setWorkingMessage(Component.translatable("worldedit.schematic.save.still-saving"))
                 .onSuccess(filename + " saved" + (overwrite ? " (overwriting previous file)." : "."), null)
                 .onFailure("Failed to save schematic", worldEdit.getPlatformManager().getPlatformCommandManager().getExceptionConverter())
                 .buildAndExec(worldEdit.getExecutorService());
@@ -210,7 +208,7 @@ public class SchematicCommands {
                       @Arg(desc = "Format name", def = "")
                           ClipboardFormat format) throws WorldEditException {
         if (worldEdit.getPlatformManager().queryCapability(Capability.GAME_HOOKS).getDataVersion() == -1) {
-            actor.printError(TranslatableComponent.of("worldedit.schematic.unsupported-minecraft-version"));
+            actor.printError(Component.translatable("worldedit.schematic.unsupported-minecraft-version"));
             return;
         }
 
@@ -219,10 +217,10 @@ public class SchematicCommands {
         }
 
         if (!destination.supportsFormat(format)) {
-            actor.printError(TranslatableComponent.of(
+            actor.printError(Component.translatable(
                 "worldedit.schematic.share.unsupported-format",
-                TextComponent.of(destination.getName()),
-                TextComponent.of(format.getName())
+                Component.text(destination.getName()),
+                Component.text(format.getName())
             ));
             return;
         }
@@ -232,8 +230,8 @@ public class SchematicCommands {
         SchematicShareTask task = new SchematicShareTask(actor, holder, destination, format, schematicName);
         AsyncCommandBuilder.wrap(task, actor)
             .registerWithSupervisor(worldEdit.getSupervisor(), "Sharing schematic")
-            .setDelayMessage(TranslatableComponent.of("worldedit.schematic.save.saving"))
-            .setWorkingMessage(TranslatableComponent.of("worldedit.schematic.save.still-saving"))
+            .setDelayMessage(Component.translatable("worldedit.schematic.save.saving"))
+            .setWorkingMessage(Component.translatable("worldedit.schematic.save.still-saving"))
             .onSuccess("Shared", (consumer -> consumer.accept(actor)))
             .onFailure("Failed to share schematic", worldEdit.getPlatformManager().getPlatformCommandManager().getExceptionConverter())
             .buildAndExec(worldEdit.getExecutorService());
@@ -255,16 +253,16 @@ public class SchematicCommands {
                 dir, filename, "schematic", ClipboardFormats.getFileExtensionArray());
 
         if (!f.exists()) {
-            actor.printError(TranslatableComponent.of("worldedit.schematic.delete.does-not-exist", TextComponent.of(filename)));
+            actor.printError(Component.translatable("worldedit.schematic.delete.does-not-exist", Component.text(filename)));
             return;
         }
 
         if (!f.delete()) {
-            actor.printError(TranslatableComponent.of("worldedit.schematic.delete.failed", TextComponent.of(filename)));
+            actor.printError(Component.translatable("worldedit.schematic.delete.failed", Component.text(filename)));
             return;
         }
 
-        actor.printInfo(TranslatableComponent.of("worldedit.schematic.delete.deleted", TextComponent.of(filename)));
+        actor.printInfo(Component.translatable("worldedit.schematic.delete.deleted", Component.text(filename)));
         try {
             LOGGER.info(actor.getName() + " deleted " + f.getCanonicalPath());
         } catch (IOException e) {
@@ -279,7 +277,7 @@ public class SchematicCommands {
     )
     @CommandPermissions("worldedit.schematic.formats")
     public void formats(Actor actor) {
-        actor.printInfo(TranslatableComponent.of("worldedit.schematic.formats.title"));
+        actor.printInfo(Component.translatable("worldedit.schematic.formats.title"));
         StringBuilder builder;
         boolean first = true;
         for (ClipboardFormat format : ClipboardFormats.getAll()) {
@@ -293,7 +291,7 @@ public class SchematicCommands {
                 first = false;
             }
             first = true;
-            actor.printInfo(TextComponent.of(builder.toString()));
+            actor.printInfo(Component.text(builder.toString()));
         }
     }
 
@@ -312,7 +310,7 @@ public class SchematicCommands {
                      @Switch(name = 'n', desc = "Sort by date, newest first")
                          boolean newFirst) {
         if (oldFirst && newFirst) {
-            throw new StopExecutionException(TextComponent.of("Cannot sort by oldest and newest."));
+            throw new StopExecutionException(Component.text("Cannot sort by oldest and newest."));
         }
         final String saveDir = worldEdit.getConfiguration().saveDir;
         Comparator<Path> pathComparator;
@@ -402,7 +400,7 @@ public class SchematicCommands {
                 LOGGER.info(actor.getName() + " saved " + file.getCanonicalPath() + (overwrite ? " (overwriting previous file)" : ""));
             } catch (IOException e) {
                 file.delete();
-                throw new CommandException(TextComponent.of(e.getMessage()), e, ImmutableList.of());
+                throw new CommandException(Component.text(e.getMessage()), e, ImmutableList.of());
             }
             return null;
         }
@@ -507,16 +505,15 @@ public class SchematicCommands {
                     ? file.getFileName().toString()
                     : file.toString().substring(rootDir.toString().length());
 
-            return TextComponent.builder()
-                    .content("")
-                    .append(TextComponent.of("[L]")
-                            .color(TextColor.GOLD)
-                            .clickEvent(ClickEvent.of(ClickEvent.Action.RUN_COMMAND, "/schem load \"" + path + "\""))
-                            .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TextComponent.of("Click to load"))))
-                    .append(TextComponent.space())
-                    .append(TextComponent.of(path)
-                            .color(TextColor.DARK_GREEN)
-                            .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TextComponent.of(format))))
+            return Component.text()
+                    .append(Component.text("[L]")
+                            .color(NamedTextColor.GOLD)
+                            .clickEvent(ClickEvent.runCommand("/schem load \"" + path + "\""))
+                            .hoverEvent(HoverEvent.showText(Component.text("Click to load"))))
+                    .append(Component.space())
+                    .append(Component.text(path)
+                            .color(NamedTextColor.DARK_GREEN)
+                            .hoverEvent(HoverEvent.showText(Component.text(format))))
                     .build();
         }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ScriptingCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ScriptingCommands.java
@@ -26,7 +26,7 @@ import com.sk89q.worldedit.command.util.CommandPermissions;
 import com.sk89q.worldedit.command.util.CommandPermissionsConditionGenerator;
 import com.sk89q.worldedit.command.util.Logging;
 import com.sk89q.worldedit.entity.Player;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import org.enginehub.piston.annotation.Command;
 import org.enginehub.piston.annotation.CommandContainer;
 import org.enginehub.piston.annotation.param.Arg;
@@ -69,7 +69,7 @@ public class ScriptingCommands {
                         @Arg(desc = "Arguments to the CraftScript", def = "", variable = true)
                             List<String> args) throws WorldEditException {
         if (!player.hasPermission("worldedit.scripting.execute." + filename)) {
-            player.printError(TranslatableComponent.of("worldedit.execute.script-permissions"));
+            player.printError(Component.translatable("worldedit.execute.script-permissions"));
             return;
         }
 
@@ -95,12 +95,12 @@ public class ScriptingCommands {
         String lastScript = session.getLastScript();
 
         if (!player.hasPermission("worldedit.scripting.execute." + lastScript)) {
-            player.printError(TranslatableComponent.of("worldedit.execute.script-permissions"));
+            player.printError(Component.translatable("worldedit.execute.script-permissions"));
             return;
         }
 
         if (lastScript == null) {
-            player.printError(TranslatableComponent.of("worldedit.executelast.no-script"));
+            player.printError(Component.translatable("worldedit.executelast.no-script"));
             return;
         }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SelectionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SelectionCommands.java
@@ -67,10 +67,9 @@ import com.sk89q.worldedit.util.formatting.component.SubtleFormat;
 import com.sk89q.worldedit.util.formatting.component.TextComponentProducer;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
 import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
@@ -110,7 +109,7 @@ public class SelectionCommands {
         if (actor instanceof Locatable locatable) {
             return locatable.getLocation().toVector().toBlockPoint();
         }
-        actor.printError(TranslatableComponent.of("worldedit.pos.console-require-coords"));
+        actor.printError(Component.translatable("worldedit.pos.console-require-coords"));
         return null;
     }
 
@@ -162,7 +161,7 @@ public class SelectionCommands {
         for (Component line : regionSelector.getSelectionInfoLines()) {
             actor.printInfo(line);
         }
-        actor.printInfo(TranslatableComponent.of("worldedit.selection.updated"));
+        actor.printInfo(Component.translatable("worldedit.selection.updated"));
     }
 
     @Command(
@@ -182,7 +181,7 @@ public class SelectionCommands {
         }
 
         if (!session.getRegionSelector(world).selectPrimary(coordinates, ActorSelectorLimits.forActor(actor))) {
-            actor.printError(TranslatableComponent.of("worldedit.pos.already-set"));
+            actor.printError(Component.translatable("worldedit.pos.already-set"));
             return;
         }
 
@@ -206,7 +205,7 @@ public class SelectionCommands {
         }
 
         if (!session.getRegionSelector(world).selectSecondary(coordinates, ActorSelectorLimits.forActor(actor))) {
-            actor.printError(TranslatableComponent.of("worldedit.pos.already-set"));
+            actor.printError(Component.translatable("worldedit.pos.already-set"));
             return;
         }
 
@@ -224,14 +223,14 @@ public class SelectionCommands {
 
         if (pos != null) {
             if (!session.getRegionSelector(player.getWorld()).selectPrimary(pos.toVector().toBlockPoint(), ActorSelectorLimits.forActor(player))) {
-                player.printError(TranslatableComponent.of("worldedit.hpos.already-set"));
+                player.printError(Component.translatable("worldedit.hpos.already-set"));
                 return;
             }
 
             session.getRegionSelector(player.getWorld())
                     .explainPrimarySelection(player, session, pos.toVector().toBlockPoint());
         } else {
-            player.printError(TranslatableComponent.of("worldedit.hpos.no-block"));
+            player.printError(Component.translatable("worldedit.hpos.no-block"));
         }
     }
 
@@ -246,14 +245,14 @@ public class SelectionCommands {
 
         if (pos != null) {
             if (!session.getRegionSelector(player.getWorld()).selectSecondary(pos.toVector().toBlockPoint(), ActorSelectorLimits.forActor(player))) {
-                player.printError(TranslatableComponent.of("worldedit.hpos.already-set"));
+                player.printError(Component.translatable("worldedit.hpos.already-set"));
                 return;
             }
 
             session.getRegionSelector(player.getWorld())
                     .explainSecondarySelection(player, session, pos.toVector().toBlockPoint());
         } else {
-            player.printError(TranslatableComponent.of("worldedit.hpos.no-block"));
+            player.printError(Component.translatable("worldedit.hpos.no-block"));
         }
     }
 
@@ -288,14 +287,14 @@ public class SelectionCommands {
             min = minChunk.shl(CHUNK_SHIFTS, CHUNK_SHIFTS_Y, CHUNK_SHIFTS);
             max = maxChunk.shl(CHUNK_SHIFTS, CHUNK_SHIFTS_Y, CHUNK_SHIFTS).add(15, 255, 15);
 
-            actor.printInfo(TranslatableComponent.of(
+            actor.printInfo(Component.translatable(
                 "worldedit.chunk.selected-multiple",
-                TextComponent.of(minChunk.getBlockX()),
-                TextComponent.of(minChunk.getBlockY()),
-                TextComponent.of(minChunk.getBlockZ()),
-                TextComponent.of(maxChunk.getBlockX()),
-                TextComponent.of(maxChunk.getBlockY()),
-                TextComponent.of(maxChunk.getBlockZ())
+                Component.text(minChunk.getBlockX()),
+                Component.text(minChunk.getBlockY()),
+                Component.text(minChunk.getBlockZ()),
+                Component.text(maxChunk.getBlockX()),
+                Component.text(maxChunk.getBlockY()),
+                Component.text(maxChunk.getBlockZ())
             ));
         } else {
             BlockVector3 minChunk;
@@ -309,17 +308,17 @@ public class SelectionCommands {
                 if (actor instanceof Locatable) {
                     minChunk = ChunkStore.toChunk3d(((Locatable) actor).getBlockLocation().toVector().toBlockPoint());
                 } else {
-                    throw new StopExecutionException(TextComponent.of("A player or coordinates are required."));
+                    throw new StopExecutionException(Component.text("A player or coordinates are required."));
                 }
             }
 
             min = minChunk.shl(CHUNK_SHIFTS, CHUNK_SHIFTS_Y, CHUNK_SHIFTS);
             max = min.add(15, 255, 15);
 
-            actor.printInfo(TranslatableComponent.of("worldedit.chunk.selected",
-                TextComponent.of(minChunk.getBlockX()),
-                TextComponent.of(minChunk.getBlockY()),
-                TextComponent.of(minChunk.getBlockZ())));
+            actor.printInfo(Component.translatable("worldedit.chunk.selected",
+                Component.text(minChunk.getBlockX()),
+                Component.text(minChunk.getBlockY()),
+                Component.text(minChunk.getBlockZ())));
         }
 
         final CuboidRegionSelector selector;
@@ -348,7 +347,7 @@ public class SelectionCommands {
                          boolean navWand) throws WorldEditException {
         Tool tool = navWand ? new NavigationWand() : new SelectionWand();
         if (!tool.canUse(player)) {
-            player.printError(TranslatableComponent.of("worldedit.command.permissions"));
+            player.printError(Component.translatable("worldedit.command.permissions"));
             return;
         }
         String wandId = navWand ? session.getNavWandItem() : session.getWandItem();
@@ -357,12 +356,12 @@ public class SelectionCommands {
         }
         ItemType itemType = ItemTypes.get(wandId);
         if (itemType == null) {
-            player.printError(TranslatableComponent.of("worldedit.wand.invalid"));
+            player.printError(Component.translatable("worldedit.wand.invalid"));
             return;
         }
         player.giveItem(new BaseItemStack(itemType, 1));
         session.setTool(itemType, tool);
-        player.printInfo(TranslatableComponent.of("worldedit.wand." + (navWand ? "nav" : "sel" ) + "wand.info"));
+        player.printInfo(Component.translatable("worldedit.wand." + (navWand ? "nav" : "sel" ) + "wand.info"));
     }
 
     @Command(
@@ -372,14 +371,14 @@ public class SelectionCommands {
     @CommandPermissions("worldedit.wand.toggle")
     public void toggleWand(Player player) {
         player.printInfo(
-            TranslatableComponent.of(
+            Component.translatable(
                 "worldedit.wand.selwand.now.tool",
-                TextComponent.of("/tool none", TextColor.AQUA).clickEvent(
-                    ClickEvent.of(ClickEvent.Action.RUN_COMMAND, "/tool none")),
-                TextComponent.of("/tool selwand", TextColor.AQUA).clickEvent(
-                    ClickEvent.of(ClickEvent.Action.RUN_COMMAND, "/tool selwand")),
-                TextComponent.of("//wand", TextColor.AQUA).clickEvent(
-                    ClickEvent.of(ClickEvent.Action.RUN_COMMAND, "//wand"))
+                Component.text("/tool none", NamedTextColor.AQUA).clickEvent(
+                    ClickEvent.runCommand("/tool none")),
+                Component.text("/tool selwand", NamedTextColor.AQUA).clickEvent(
+                    ClickEvent.runCommand("/tool selwand")),
+                Component.text("//wand", NamedTextColor.AQUA).clickEvent(
+                    ClickEvent.runCommand("//wand"))
             )
         );
     }
@@ -415,9 +414,9 @@ public class SelectionCommands {
 
             session.getRegionSelector(world).explainRegionAdjust(actor, session);
 
-            actor.printInfo(TranslatableComponent.of("worldedit.contract.contracted", TextComponent.of(oldSize - newSize)));
+            actor.printInfo(Component.translatable("worldedit.contract.contracted", Component.text(oldSize - newSize)));
         } catch (RegionOperationException e) {
-            actor.printError(TextComponent.of(e.getMessage()));
+            actor.printError(Component.text(e.getMessage()));
         }
     }
 
@@ -444,9 +443,9 @@ public class SelectionCommands {
 
             session.getRegionSelector(world).explainRegionAdjust(actor, session);
 
-            actor.printInfo(TranslatableComponent.of("worldedit.shift.shifted"));
+            actor.printInfo(Component.translatable("worldedit.shift.shifted"));
         } catch (RegionOperationException e) {
-            actor.printError(TextComponent.of(e.getMessage()));
+            actor.printError(Component.text(e.getMessage()));
         }
     }
 
@@ -467,7 +466,7 @@ public class SelectionCommands {
         region.expand(getChangesForEachDir(amount, onlyHorizontal, onlyVertical));
         session.getRegionSelector(world).learnChanges();
         session.getRegionSelector(world).explainRegionAdjust(actor, session);
-        actor.printInfo(TranslatableComponent.of("worldedit.outset.outset"));
+        actor.printInfo(Component.translatable("worldedit.outset.outset"));
     }
 
     @Command(
@@ -487,7 +486,7 @@ public class SelectionCommands {
         region.contract(getChangesForEachDir(amount, onlyHorizontal, onlyVertical));
         session.getRegionSelector(world).learnChanges();
         session.getRegionSelector(world).explainRegionAdjust(actor, session);
-        actor.printInfo(TranslatableComponent.of("worldedit.inset.inset"));
+        actor.printInfo(Component.translatable("worldedit.inset.inset"));
     }
 
     private BlockVector3[] getChangesForEachDir(int amount, boolean onlyHorizontal, boolean onlyVertical) {
@@ -551,7 +550,7 @@ public class SelectionCommands {
 
         // If anything was found in the first pass, then the remaining variables are guaranteed to be set
         if (!found) {
-            throw new StopExecutionException(TranslatableComponent.of(
+            throw new StopExecutionException(Component.translatable(
                         "worldedit.trim.no-blocks"));
         }
 
@@ -640,7 +639,7 @@ public class SelectionCommands {
 
         session.getRegionSelector(world).learnChanges();
         session.getRegionSelector(world).explainRegionAdjust(actor, session);
-        actor.printInfo(TranslatableComponent.of("worldedit.trim.trim"));
+        actor.printInfo(Component.translatable("worldedit.trim.trim"));
     }
 
     @Command(
@@ -658,11 +657,11 @@ public class SelectionCommands {
             region = clipboard.getRegion();
 
             BlockVector3 origin = clipboard.getOrigin();
-            actor.printInfo(TranslatableComponent.of("worldedit.size.offset", TextComponent.of(origin.toString())));
+            actor.printInfo(Component.translatable("worldedit.size.offset", Component.text(origin.toString())));
         } else {
             region = session.getSelection(world);
 
-            actor.printInfo(TranslatableComponent.of("worldedit.size.type", TextComponent.of(session.getRegionSelector(world).getTypeName())));
+            actor.printInfo(Component.translatable("worldedit.size.type", Component.text(session.getRegionSelector(world).getTypeName())));
 
             for (Component line : session.getRegionSelector(world).getSelectionInfoLines()) {
                 actor.printInfo(line);
@@ -672,9 +671,9 @@ public class SelectionCommands {
                 .subtract(region.getMinimumPoint())
                 .add(1, 1, 1);
 
-        actor.printInfo(TranslatableComponent.of("worldedit.size.size", TextComponent.of(size.toString())));
-        actor.printInfo(TranslatableComponent.of("worldedit.size.distance", TextComponent.of(region.getMaximumPoint().distance(region.getMinimumPoint()))));
-        actor.printInfo(TranslatableComponent.of("worldedit.size.blocks", TextComponent.of(region.getVolume())));
+        actor.printInfo(Component.translatable("worldedit.size.size", Component.text(size.toString())));
+        actor.printInfo(Component.translatable("worldedit.size.distance", Component.text(region.getMaximumPoint().distance(region.getMinimumPoint()))));
+        actor.printInfo(Component.translatable("worldedit.size.blocks", Component.text(region.getVolume())));
     }
 
     @Command(
@@ -686,7 +685,7 @@ public class SelectionCommands {
                       @Arg(desc = "The mask of blocks to match")
                           Mask mask) throws WorldEditException {
         int count = editSession.countBlocks(session.getSelection(world), mask);
-        actor.printInfo(TranslatableComponent.of("worldedit.count.counted", TextComponent.of(count)));
+        actor.printInfo(Component.translatable("worldedit.count.counted", Component.text(count)));
         return count;
     }
 
@@ -721,13 +720,13 @@ public class SelectionCommands {
         } else {
             distribution = session.getLastDistribution();
             if (distribution == null) {
-                actor.printError(TranslatableComponent.of("worldedit.distr.no-previous"));
+                actor.printError(Component.translatable("worldedit.distr.no-previous"));
                 return;
             }
         }
 
         if (distribution.isEmpty()) {  // *Should* always be false
-            actor.printError(TranslatableComponent.of("worldedit.distr.no-blocks"));
+            actor.printError(Component.translatable("worldedit.distr.no-blocks"));
             return;
         }
 
@@ -754,7 +753,7 @@ public class SelectionCommands {
         if (selectorChoiceOrList == null) {
             session.getRegionSelector(world).clear();
             session.dispatchCUISelection(actor);
-            actor.printInfo(TranslatableComponent.of("worldedit.select.cleared"));
+            actor.printInfo(Component.translatable("worldedit.select.cleared"));
             return;
         }
 
@@ -763,13 +762,13 @@ public class SelectionCommands {
             box.setHidingHelp(true);
             TextComponentProducer contents = box.getContents();
             contents.append(SubtleFormat.wrap("Select one of the modes below:")).newline();
-            box.appendCommand("cuboid", TranslatableComponent.of("worldedit.select.cuboid.description"), "//sel cuboid");
-            box.appendCommand("extend", TranslatableComponent.of("worldedit.select.extend.description"), "//sel extend");
-            box.appendCommand("poly", TranslatableComponent.of("worldedit.select.poly.description"), "//sel poly");
-            box.appendCommand("ellipsoid", TranslatableComponent.of("worldedit.select.ellipsoid.description"), "//sel ellipsoid");
-            box.appendCommand("sphere", TranslatableComponent.of("worldedit.select.sphere.description"), "//sel sphere");
-            box.appendCommand("cyl", TranslatableComponent.of("worldedit.select.cyl.description"), "//sel cyl");
-            box.appendCommand("convex", TranslatableComponent.of("worldedit.select.convex.description"), "//sel convex");
+            box.appendCommand("cuboid", Component.translatable("worldedit.select.cuboid.description"), "//sel cuboid");
+            box.appendCommand("extend", Component.translatable("worldedit.select.extend.description"), "//sel extend");
+            box.appendCommand("poly", Component.translatable("worldedit.select.poly.description"), "//sel poly");
+            box.appendCommand("ellipsoid", Component.translatable("worldedit.select.ellipsoid.description"), "//sel ellipsoid");
+            box.appendCommand("sphere", Component.translatable("worldedit.select.sphere.description"), "//sel sphere");
+            box.appendCommand("cyl", Component.translatable("worldedit.select.cyl.description"), "//sel cyl");
+            box.appendCommand("convex", Component.translatable("worldedit.select.convex.description"), "//sel convex");
             actor.print(box.create(1));
             return;
         }
@@ -791,7 +790,7 @@ public class SelectionCommands {
 
             if (found != null) {
                 session.setDefaultRegionSelector(found);
-                actor.printInfo(TranslatableComponent.of("worldedit.select.default-set", TextComponent.of(found.name())));
+                actor.printInfo(Component.translatable("worldedit.select.default-set", Component.text(found.name())));
             } else {
                 throw new RuntimeException("Something unexpected happened. Please report this.");
             }
@@ -819,29 +818,29 @@ public class SelectionCommands {
         @Override
         public Component getComponent(int number) {
             Countable<BlockState> c = distribution.get(number);
-            TextComponent.Builder line = TextComponent.builder();
+            TextComponent.Builder line = Component.text();
 
             final int count = c.getAmount();
 
             final double perc = count / (double) totalBlocks * 100;
             final int maxDigits = (int) (Math.log10(totalBlocks) + 1);
             final int curDigits = (int) (Math.log10(count) + 1);
-            line.append(String.format("%s%.3f%%  ", perc < 10 ? "  " : "", perc), TextColor.GOLD);
+            line.append(Component.text(String.format("%s%.3f%%  ", perc < 10 ? "  " : "", perc), NamedTextColor.GOLD));
             final int space = maxDigits - curDigits;
             String pad = Strings.repeat(" ", space == 0 ? 2 : 2 * space + 1);
-            line.append(String.format("%s%s", count, pad), TextColor.YELLOW);
+            line.append(Component.text(String.format("%s%s", count, pad), NamedTextColor.YELLOW));
 
             final BlockState state = c.getID();
             final BlockType blockType = state.getBlockType();
-            Component blockName = blockType.getRichName().color(TextColor.LIGHT_PURPLE);
+            Component blockName = blockType.getRichName().color(NamedTextColor.LIGHT_PURPLE);
             TextComponent toolTip;
             if (separateStates && state != blockType.getDefaultState()) {
-                toolTip = TextComponent.of(state.getAsString(), TextColor.GRAY);
-                blockName = blockName.append(TextComponent.of("*", TextColor.LIGHT_PURPLE));
+                toolTip = Component.text(state.getAsString(), NamedTextColor.GRAY);
+                blockName = blockName.append(Component.text("*", NamedTextColor.LIGHT_PURPLE));
             } else {
-                toolTip = TextComponent.of(blockType.getId(), TextColor.GRAY);
+                toolTip = Component.text(blockType.getId(), NamedTextColor.GRAY);
             }
-            blockName = blockName.hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, toolTip));
+            blockName = blockName.hoverEvent(HoverEvent.showText(toolTip));
             line.append(blockName);
 
             return line.build();
@@ -854,8 +853,8 @@ public class SelectionCommands {
 
         @Override
         public Component create(int page) throws InvalidComponentException {
-            super.getContents().append(TranslatableComponent.of("worldedit.distr.total", TextColor.GRAY, TextComponent.of(totalBlocks)))
-                    .append(TextComponent.newline());
+            super.getContents().append(Component.translatable("worldedit.distr.total", NamedTextColor.GRAY, Component.text(totalBlocks)))
+                    .append(Component.newline());
             return super.create(page);
         }
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SnapshotCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SnapshotCommands.java
@@ -30,11 +30,9 @@ import com.sk89q.worldedit.command.util.CommandPermissionsConditionGenerator;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.util.formatting.component.PaginationBox;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
 import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.snapshot.experimental.Snapshot;
 import com.sk89q.worldedit.world.snapshot.experimental.fs.FileSystemSnapshotDatabase;
@@ -74,7 +72,7 @@ public class SnapshotCommands {
 
     static void checkSnapshotsConfigured(LocalConfiguration localConfiguration) {
         if (!localConfiguration.snapshotsConfigured) {
-            throw new StopExecutionException(TranslatableComponent.of(
+            throw new StopExecutionException(Component.translatable(
                 "worldedit.restore.not-configured"
             ));
         }
@@ -120,9 +118,9 @@ public class SnapshotCommands {
         if (!snapshots.isEmpty()) {
             actor.print(new SnapshotListBox(world.getName(), snapshots).create(page));
         } else {
-            actor.printError(TranslatableComponent.of(
+            actor.printError(Component.translatable(
                 "worldedit.restore.none-for-specific-world",
-                TextComponent.of(world.getName())
+                Component.text(world.getName())
             ));
 
             if (config.snapshotDatabase instanceof FileSystemSnapshotDatabase) {
@@ -169,9 +167,9 @@ public class SnapshotCommands {
                     session.getSnapshotExperimental().close();
                 }
                 session.setSnapshot(null);
-                actor.printInfo(TranslatableComponent.of("worldedit.snapshot.use.newest"));
+                actor.printInfo(Component.translatable("worldedit.snapshot.use.newest"));
             } else {
-                actor.printError(TranslatableComponent.of("worldedit.restore.none-for-world"));
+                actor.printError(Component.translatable("worldedit.restore.none-for-world"));
             }
         } else {
             URI uri = resolveSnapshotName(config, name);
@@ -181,11 +179,11 @@ public class SnapshotCommands {
                     session.getSnapshotExperimental().close();
                 }
                 session.setSnapshotExperimental(snapshot.get());
-                actor.printInfo(TranslatableComponent.of(
-                    "worldedit.snapshot.use", TextComponent.of(name)
+                actor.printInfo(Component.translatable(
+                    "worldedit.snapshot.use", Component.text(name)
                 ));
             } else {
-                actor.printError(TranslatableComponent.of("worldedit.restore.not-available"));
+                actor.printError(Component.translatable("worldedit.restore.not-available"));
             }
         }
     }
@@ -207,7 +205,7 @@ public class SnapshotCommands {
         }
 
         if (index < 1) {
-            actor.printError(TranslatableComponent.of("worldedit.snapshot.index-above-0"));
+            actor.printError(Component.translatable("worldedit.snapshot.index-above-0"));
             return;
         }
 
@@ -218,24 +216,24 @@ public class SnapshotCommands {
                 .collect(toList());
         }
         if (snapshots.size() < index) {
-            actor.printError(TranslatableComponent.of(
+            actor.printError(Component.translatable(
                 "worldedit.snapshot.index-oob",
-                TextComponent.of(snapshots.size())
+                Component.text(snapshots.size())
             ));
             return;
         }
         Snapshot snapshot = snapshots.get(index - 1);
         if (snapshot == null) {
-            actor.printError(TranslatableComponent.of("worldedit.restore.not-available"));
+            actor.printError(Component.translatable("worldedit.restore.not-available"));
             return;
         }
         if (session.getSnapshotExperimental() != null) {
             session.getSnapshotExperimental().close();
         }
         session.setSnapshotExperimental(snapshot);
-        actor.printInfo(TranslatableComponent.of(
+        actor.printInfo(Component.translatable(
             "worldedit.snapshot.use",
-            TextComponent.of(snapshot.getInfo().getDisplayName())
+            Component.text(snapshot.getInfo().getDisplayName())
         ));
     }
 
@@ -263,18 +261,18 @@ public class SnapshotCommands {
         }
 
         if (snapshot == null) {
-            actor.printError(TranslatableComponent.of(
+            actor.printError(Component.translatable(
                 "worldedit.snapshot.none-before",
-                TextComponent.of(dateFormat.withZone(session.getTimeZone()).format(date)))
+                Component.text(dateFormat.withZone(session.getTimeZone()).format(date)))
             );
         } else {
             if (session.getSnapshotExperimental() != null) {
                 session.getSnapshotExperimental().close();
             }
             session.setSnapshotExperimental(snapshot);
-            actor.printInfo(TranslatableComponent.of(
+            actor.printInfo(Component.translatable(
                 "worldedit.snapshot.use",
-                TextComponent.of(snapshot.getInfo().getDisplayName())
+                Component.text(snapshot.getInfo().getDisplayName())
             ));
         }
     }
@@ -302,18 +300,18 @@ public class SnapshotCommands {
                 .findFirst().orElse(null);
         }
         if (snapshot == null) {
-            actor.printError(TranslatableComponent.of(
+            actor.printError(Component.translatable(
                 "worldedit.snapshot.none-after",
-                TextComponent.of(dateFormat.withZone(session.getTimeZone()).format(date)))
+                Component.text(dateFormat.withZone(session.getTimeZone()).format(date)))
             );
         } else {
             if (session.getSnapshotExperimental() != null) {
                 session.getSnapshotExperimental().close();
             }
             session.setSnapshotExperimental(snapshot);
-            actor.printInfo(TranslatableComponent.of(
+            actor.printInfo(Component.translatable(
                 "worldedit.snapshot.use",
-                TextComponent.of(snapshot.getInfo().getDisplayName())
+                Component.text(snapshot.getInfo().getDisplayName())
             ));
         }
     }
@@ -330,9 +328,9 @@ public class SnapshotCommands {
         public Component getComponent(int number) {
             final Snapshot snapshot = snapshots.get(number);
             String displayName = snapshot.getInfo().getDisplayName();
-            return TextComponent.of(number + 1 + ". ", TextColor.GOLD)
-                .append(TextComponent.builder(displayName, TextColor.LIGHT_PURPLE)
-                    .hoverEvent(HoverEvent.showText(TextComponent.of("Click to use")))
+            return Component.text(number + 1 + ". ", NamedTextColor.GOLD)
+                .append(Component.text(displayName, NamedTextColor.LIGHT_PURPLE)
+                    .hoverEvent(HoverEvent.showText(Component.text("Click to use")))
                     .clickEvent(ClickEvent.runCommand("/snap use " + displayName)));
         }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SnapshotUtilCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SnapshotUtilCommands.java
@@ -29,8 +29,7 @@ import com.sk89q.worldedit.command.util.CommandPermissionsConditionGenerator;
 import com.sk89q.worldedit.command.util.Logging;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.regions.Region;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.snapshot.experimental.Snapshot;
 import com.sk89q.worldedit.world.snapshot.experimental.SnapshotRestore;
@@ -83,7 +82,7 @@ public class SnapshotUtilCommands {
             URI uri = resolveSnapshotName(config, snapshotName);
             Optional<Snapshot> snapOpt = config.snapshotDatabase.getSnapshot(uri);
             if (!snapOpt.isPresent()) {
-                actor.printError(TranslatableComponent.of("worldedit.restore.not-available"));
+                actor.printError(Component.translatable("worldedit.restore.not-available"));
                 return;
             }
             snapshot = snapOpt.get();
@@ -100,16 +99,16 @@ public class SnapshotUtilCommands {
             }
 
             if (snapshot == null) {
-                actor.printError(TranslatableComponent.of(
+                actor.printError(Component.translatable(
                     "worldedit.restore.none-for-specific-world",
-                    TextComponent.of(world.getName())
+                    Component.text(world.getName())
                 ));
                 return;
             }
         }
-        actor.printInfo(TranslatableComponent.of(
+        actor.printInfo(Component.translatable(
             "worldedit.restore.loaded",
-            TextComponent.of(snapshot.getInfo().getDisplayName())
+            Component.text(snapshot.getInfo().getDisplayName())
         ));
 
         try {
@@ -122,17 +121,17 @@ public class SnapshotUtilCommands {
             if (restore.hadTotalFailure()) {
                 String error = restore.getLastErrorMessage();
                 if (!restore.getMissingChunks().isEmpty()) {
-                    actor.printError(TranslatableComponent.of("worldedit.restore.chunk-not-present"));
+                    actor.printError(Component.translatable("worldedit.restore.chunk-not-present"));
                 } else if (error != null) {
-                    actor.printError(TranslatableComponent.of("worldedit.restore.block-place-failed"));
-                    actor.printError(TranslatableComponent.of("worldedit.restore.block-place-error", TextComponent.of(error)));
+                    actor.printError(Component.translatable("worldedit.restore.block-place-failed"));
+                    actor.printError(Component.translatable("worldedit.restore.block-place-error", Component.text(error)));
                 } else {
-                    actor.printError(TranslatableComponent.of("worldedit.restore.chunk-load-failed"));
+                    actor.printError(Component.translatable("worldedit.restore.chunk-load-failed"));
                 }
             } else {
-                actor.printInfo(TranslatableComponent.of("worldedit.restore.restored",
-                    TextComponent.of(restore.getMissingChunks().size()),
-                    TextComponent.of(restore.getErrorChunks().size())));
+                actor.printInfo(Component.translatable("worldedit.restore.restored",
+                    Component.text(restore.getMissingChunks().size()),
+                    Component.text(restore.getErrorChunks().size())));
             }
         } finally {
             try {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SuperPickaxeCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SuperPickaxeCommands.java
@@ -29,8 +29,7 @@ import com.sk89q.worldedit.command.tool.SinglePickaxe;
 import com.sk89q.worldedit.command.util.CommandPermissions;
 import com.sk89q.worldedit.command.util.CommandPermissionsConditionGenerator;
 import com.sk89q.worldedit.entity.Player;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import org.enginehub.piston.annotation.Command;
 import org.enginehub.piston.annotation.CommandContainer;
 import org.enginehub.piston.annotation.param.Arg;
@@ -51,7 +50,7 @@ public class SuperPickaxeCommands {
     public void single(Player player, LocalSession session) throws WorldEditException {
         session.setSuperPickaxe(new SinglePickaxe());
         session.enableSuperPickAxe();
-        player.printInfo(TranslatableComponent.of("worldedit.tool.superpickaxe.mode.single"));
+        player.printInfo(Component.translatable("worldedit.tool.superpickaxe.mode.single"));
     }
 
     @Command(
@@ -66,13 +65,13 @@ public class SuperPickaxeCommands {
         LocalConfiguration config = we.getConfiguration();
 
         if (range > config.maxSuperPickaxeSize) {
-            player.printError(TranslatableComponent.of("worldedit.tool.superpickaxe.max-range", TextComponent.of(config.maxSuperPickaxeSize)));
+            player.printError(Component.translatable("worldedit.tool.superpickaxe.max-range", Component.text(config.maxSuperPickaxeSize)));
             return;
         }
 
         session.setSuperPickaxe(new AreaPickaxe(range));
         session.enableSuperPickAxe();
-        player.printInfo(TranslatableComponent.of("worldedit.tool.superpickaxe.mode.area"));
+        player.printInfo(Component.translatable("worldedit.tool.superpickaxe.mode.area"));
     }
 
     @Command(
@@ -88,12 +87,12 @@ public class SuperPickaxeCommands {
         LocalConfiguration config = we.getConfiguration();
 
         if (range > config.maxSuperPickaxeSize) {
-            player.printError(TranslatableComponent.of("worldedit.tool.superpickaxe.max-range", TextComponent.of(config.maxSuperPickaxeSize)));
+            player.printError(Component.translatable("worldedit.tool.superpickaxe.max-range", Component.text(config.maxSuperPickaxeSize)));
             return;
         }
 
         session.setSuperPickaxe(new RecursivePickaxe(range));
         session.enableSuperPickAxe();
-        player.printInfo(TranslatableComponent.of("worldedit.tool.superpickaxe.mode.recursive"));
+        player.printInfo(Component.translatable("worldedit.tool.superpickaxe.mode.recursive"));
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
@@ -49,10 +49,8 @@ import com.sk89q.worldedit.internal.command.CommandUtil;
 import com.sk89q.worldedit.util.HandSide;
 import com.sk89q.worldedit.util.TreeGenerator;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.item.ItemType;
 import org.enginehub.piston.CommandManager;
@@ -71,9 +69,8 @@ import java.util.stream.Collectors;
 @CommandContainer(superTypes = CommandPermissionsConditionGenerator.Registration.class)
 public class ToolCommands {
 
-    private static final Component UNBIND_COMMAND_COMPONENT = TextComponent.builder("/tool unbind", TextColor.AQUA)
-                                                                   .clickEvent(ClickEvent.suggestCommand("/tool unbind"))
-                                                                   .build();
+    private static final Component UNBIND_COMMAND_COMPONENT = Component.text("/tool unbind", NamedTextColor.AQUA)
+                                                                   .clickEvent(ClickEvent.suggestCommand("/tool unbind"));
 
     public static void register(CommandRegistrationHandler registration,
                                 CommandManager commandManager,
@@ -119,13 +116,13 @@ public class ToolCommands {
             .collect(Collectors.toSet());
         commandManager.register("tool", command -> {
             command.addPart(SubCommandPart.builder(
-                TranslatableComponent.of("tool"),
-                TextComponent.of("The tool to bind")
+                Component.translatable("tool"),
+                Component.text("The tool to bind")
             )
                 .withCommands(nonGlobalCommands)
                 .required()
                 .build());
-            command.description(TextComponent.of("Binds a tool to the item in your hand"));
+            command.description(Component.text("Binds a tool to the item in your hand"));
 
             command.condition(new SubCommandPermissionCondition.Generator(nonGlobalCommands).build());
         });
@@ -148,21 +145,21 @@ public class ToolCommands {
             || type.getId().equals(session.getNavWandItem());
         if (set) {
             session.setTool(type, null);
-            player.printInfo(TranslatableComponent.of(isBrush ? "worldedit.brush.none.equip" : "worldedit.tool.none.equip"));
+            player.printInfo(Component.translatable(isBrush ? "worldedit.brush.none.equip" : "worldedit.tool.none.equip"));
         } else {
-            player.printInfo(TranslatableComponent.of("worldedit.tool.none.to.unequip"));
+            player.printInfo(Component.translatable("worldedit.tool.none.to.unequip"));
         }
     }
 
     static void sendUnbindInstruction(Player sender, Component commandComponent) {
-        sender.printDebug(TranslatableComponent.of("worldedit.tool.unbind-instruction", commandComponent));
+        sender.printDebug(Component.translatable("worldedit.tool.unbind-instruction", commandComponent));
     }
 
     private static void setTool(Player player, LocalSession session, Tool tool,
                                 String translationKey) throws InvalidToolBindException {
         BaseItemStack itemStack = player.getItemInHand(HandSide.MAIN_HAND);
         session.setTool(itemStack.getType(), tool);
-        player.printInfo(TranslatableComponent.of(translationKey, itemStack.getRichName()));
+        player.printInfo(Component.translatable(translationKey, itemStack.getRichName()));
         sendUnbindInstruction(player, UNBIND_COMMAND_COMPONENT);
     }
 
@@ -269,7 +266,7 @@ public class ToolCommands {
         LocalConfiguration config = we.getConfiguration();
 
         if (range > config.maxSuperPickaxeSize) {
-            player.printError(TranslatableComponent.of("worldedit.tool.superpickaxe.max-range", TextComponent.of(config.maxSuperPickaxeSize)));
+            player.printError(Component.translatable("worldedit.tool.superpickaxe.max-range", Component.text(config.maxSuperPickaxeSize)));
             return;
         }
         setTool(player, session, new FloodFillTool(range, pattern), "worldedit.tool.floodfill.equip");
@@ -310,13 +307,13 @@ public class ToolCommands {
         if (primary instanceof BlockStateHolder) {
             primaryName = ((BlockStateHolder<?>) primary).getBlockType().getRichName();
         } else {
-            primaryName = TextComponent.of("pattern");
+            primaryName = Component.text("pattern");
         }
         if (secondary instanceof BlockStateHolder) {
             secondaryName = ((BlockStateHolder<?>) secondary).getBlockType().getRichName();
         } else {
-            secondaryName = TextComponent.of("pattern");
+            secondaryName = Component.text("pattern");
         }
-        player.printInfo(TranslatableComponent.of("worldedit.tool.lrbuild.set", primaryName, secondaryName));
+        player.printInfo(Component.translatable("worldedit.tool.lrbuild.set", primaryName, secondaryName));
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolUtilCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolUtilCommands.java
@@ -29,7 +29,7 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.util.HandSide;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import org.enginehub.piston.annotation.Command;
 import org.enginehub.piston.annotation.CommandContainer;
 import org.enginehub.piston.annotation.param.Arg;
@@ -56,15 +56,15 @@ public class ToolUtilCommands {
                                   Boolean superPickaxe) {
         boolean hasSuperPickAxe = session.hasSuperPickAxe();
         if (superPickaxe != null && superPickaxe == hasSuperPickAxe) {
-            player.printError(TranslatableComponent.of(superPickaxe ? "worldedit.tool.superpickaxe.enabled.already" : "worldedit.tool.superpickaxe.disabled.already"));
+            player.printError(Component.translatable(superPickaxe ? "worldedit.tool.superpickaxe.enabled.already" : "worldedit.tool.superpickaxe.disabled.already"));
             return;
         }
         if (hasSuperPickAxe) {
             session.disableSuperPickAxe();
-            player.printInfo(TranslatableComponent.of("worldedit.tool.superpickaxe.disabled"));
+            player.printInfo(Component.translatable("worldedit.tool.superpickaxe.disabled"));
         } else {
             session.enableSuperPickAxe();
-            player.printInfo(TranslatableComponent.of("worldedit.tool.superpickaxe.enabled"));
+            player.printInfo(Component.translatable("worldedit.tool.superpickaxe.enabled"));
         }
 
     }
@@ -79,14 +79,14 @@ public class ToolUtilCommands {
                          Mask mask) throws WorldEditException {
         BrushTool brushTool = session.getBrush(player.getItemInHand(HandSide.MAIN_HAND).getType());
         if (brushTool == null) {
-            player.printError(TranslatableComponent.of("worldedit.brush.none.equipped"));
+            player.printError(Component.translatable("worldedit.brush.none.equipped"));
             return;
         }
         brushTool.setMask(mask);
         if (mask == null) {
-            player.printInfo(TranslatableComponent.of("worldedit.tool.mask.disabled"));
+            player.printInfo(Component.translatable("worldedit.tool.mask.disabled"));
         } else {
-            player.printInfo(TranslatableComponent.of("worldedit.tool.mask.set"));
+            player.printInfo(Component.translatable("worldedit.tool.mask.set"));
         }
     }
 
@@ -101,11 +101,11 @@ public class ToolUtilCommands {
                              Pattern pattern) throws WorldEditException {
         BrushTool brushTool = session.getBrush(player.getItemInHand(HandSide.MAIN_HAND).getType());
         if (brushTool == null) {
-            player.printError(TranslatableComponent.of("worldedit.brush.none.equipped"));
+            player.printError(Component.translatable("worldedit.brush.none.equipped"));
             return;
         }
         brushTool.setFill(pattern);
-        player.printInfo(TranslatableComponent.of("worldedit.tool.material.set"));
+        player.printInfo(Component.translatable("worldedit.tool.material.set"));
     }
 
     @Command(
@@ -118,11 +118,11 @@ public class ToolUtilCommands {
                           int range) throws WorldEditException {
         BrushTool brushTool = session.getBrush(player.getItemInHand(HandSide.MAIN_HAND).getType());
         if (brushTool == null) {
-            player.printError(TranslatableComponent.of("worldedit.brush.none.equipped"));
+            player.printError(Component.translatable("worldedit.brush.none.equipped"));
             return;
         }
         brushTool.setRange(range);
-        player.printInfo(TranslatableComponent.of("worldedit.tool.range.set"));
+        player.printInfo(Component.translatable("worldedit.tool.range.set"));
     }
 
     @Command(
@@ -137,11 +137,11 @@ public class ToolUtilCommands {
 
         BrushTool brushTool = session.getBrush(player.getItemInHand(HandSide.MAIN_HAND).getType());
         if (brushTool == null) {
-            player.printError(TranslatableComponent.of("worldedit.brush.none.equipped"));
+            player.printError(Component.translatable("worldedit.brush.none.equipped"));
             return;
         }
         brushTool.setSize(size);
-        player.printInfo(TranslatableComponent.of("worldedit.tool.size.set"));
+        player.printInfo(Component.translatable("worldedit.tool.size.set"));
     }
 
     @Command(
@@ -154,14 +154,14 @@ public class ToolUtilCommands {
                              Mask mask) throws WorldEditException {
         BrushTool brushTool = session.getBrush(player.getItemInHand(HandSide.MAIN_HAND).getType());
         if (brushTool == null) {
-            player.printError(TranslatableComponent.of("worldedit.brush.none.equipped"));
+            player.printError(Component.translatable("worldedit.brush.none.equipped"));
             return;
         }
         brushTool.setTraceMask(mask);
         if (mask == null) {
-            player.printInfo(TranslatableComponent.of("worldedit.tool.tracemask.disabled"));
+            player.printInfo(Component.translatable("worldedit.tool.tracemask.disabled"));
         } else {
-            player.printInfo(TranslatableComponent.of("worldedit.tool.tracemask.set"));
+            player.printInfo(Component.translatable("worldedit.tool.tracemask.set"));
         }
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/UtilityCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/UtilityCommands.java
@@ -53,9 +53,7 @@ import com.sk89q.worldedit.regions.CylinderRegion;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.util.formatting.component.SubtleFormat;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BlockTypes;
 import org.enginehub.piston.annotation.Command;
@@ -104,7 +102,7 @@ public class UtilityCommands {
 
         BlockVector3 pos = session.getPlacementPosition(actor);
         int affected = editSession.fillXZ(pos, pattern, radius, depth, false);
-        actor.printInfo(TranslatableComponent.of("worldedit.fill.created", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.fill.created", Component.text(affected)));
         return affected;
     }
 
@@ -128,7 +126,7 @@ public class UtilityCommands {
 
         BlockVector3 pos = session.getPlacementPosition(actor);
         int affected = editSession.fillXZ(pos, pattern, radius, depth, true);
-        actor.printInfo(TranslatableComponent.of("worldedit.fillr.created", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.fillr.created", Component.text(affected)));
         return affected;
     }
 
@@ -146,7 +144,7 @@ public class UtilityCommands {
         radius = Math.max(0, radius);
         we.checkMaxRadius(radius);
         int affected = editSession.drainArea(session.getPlacementPosition(actor), radius, waterlogged);
-        actor.printInfo(TranslatableComponent.of("worldedit.drain.drained", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.drain.drained", Component.text(affected)));
         return affected;
     }
 
@@ -163,7 +161,7 @@ public class UtilityCommands {
         radius = Math.max(0, radius);
         we.checkMaxRadius(radius);
         int affected = editSession.fixLiquid(session.getPlacementPosition(actor), radius, BlockTypes.LAVA);
-        actor.printInfo(TranslatableComponent.of("worldedit.fixlava.fixed", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.fixlava.fixed", Component.text(affected)));
         return affected;
     }
 
@@ -180,7 +178,7 @@ public class UtilityCommands {
         radius = Math.max(0, radius);
         we.checkMaxRadius(radius);
         int affected = editSession.fixLiquid(session.getPlacementPosition(actor), radius, BlockTypes.WATER);
-        actor.printInfo(TranslatableComponent.of("worldedit.fixwater.fixed", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.fixwater.fixed", Component.text(affected)));
         return affected;
     }
 
@@ -204,7 +202,7 @@ public class UtilityCommands {
         we.checkMaxRadius(size);
 
         int affected = editSession.removeAbove(session.getPlacementPosition(actor), size, height);
-        actor.printInfo(TranslatableComponent.of("worldedit.removeabove.removed", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.removeabove.removed", Component.text(affected)));
         return affected;
     }
 
@@ -228,7 +226,7 @@ public class UtilityCommands {
         we.checkMaxRadius(size);
 
         int affected = editSession.removeBelow(session.getPlacementPosition(actor), size, height);
-        actor.printInfo(TranslatableComponent.of("worldedit.removebelow.removed", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.removebelow.removed", Component.text(affected)));
         return affected;
     }
 
@@ -248,7 +246,7 @@ public class UtilityCommands {
         we.checkMaxRadius(radius);
 
         int affected = editSession.removeNear(session.getPlacementPosition(actor), mask, radius);
-        actor.printInfo(TranslatableComponent.of("worldedit.removenear.removed", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.removenear.removed", Component.text(affected)));
         return affected;
     }
 
@@ -279,7 +277,7 @@ public class UtilityCommands {
         }
 
         int affected = editSession.replaceBlocks(region, from, to);
-        actor.printInfo(TranslatableComponent.of("worldedit.replacenear.replaced", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.replacenear.replaced", Component.text(affected)));
         return affected;
     }
 
@@ -309,8 +307,8 @@ public class UtilityCommands {
 
         CylinderRegion region = new CylinderRegion(position, Vector2.at(size, size), position.getBlockY() - height, position.getBlockY() + height);
         int affected = editSession.simulateSnow(region, stack);
-        actor.printInfo(TranslatableComponent.of(
-            "worldedit.snow.created", TextComponent.of(affected)
+        actor.printInfo(Component.translatable(
+            "worldedit.snow.created", Component.text(affected)
         ));
         return affected;
     }
@@ -336,8 +334,8 @@ public class UtilityCommands {
         we.checkMaxRadius(size);
 
         int affected = editSession.thaw(session.getPlacementPosition(actor), size, height);
-        actor.printInfo(TranslatableComponent.of(
-            "worldedit.thaw.removed", TextComponent.of(affected)
+        actor.printInfo(Component.translatable(
+            "worldedit.thaw.removed", Component.text(affected)
         ));
         return affected;
     }
@@ -368,8 +366,8 @@ public class UtilityCommands {
         final int affected = editSession.green(
             session.getPlacementPosition(actor), size, height, onlyNormalDirt
         );
-        actor.printInfo(TranslatableComponent.of(
-            "worldedit.green.changed", TextComponent.of(affected)
+        actor.printInfo(Component.translatable(
+            "worldedit.green.changed", Component.text(affected)
         ));
         return affected;
     }
@@ -393,7 +391,7 @@ public class UtilityCommands {
 
         Mask mask = new BlockTypeMask(editSession, BlockTypes.FIRE);
         int affected = editSession.removeNear(session.getPlacementPosition(actor), mask, size);
-        actor.printInfo(TranslatableComponent.of("worldedit.extinguish.removed", TextComponent.of(affected)));
+        actor.printInfo(Component.translatable("worldedit.extinguish.removed", Component.text(affected)));
         return affected;
     }
 
@@ -429,7 +427,7 @@ public class UtilityCommands {
         if (radius == null) {
             radius = config.butcherDefaultRadius;
         } else if (radius < -1) {
-            actor.printError(TranslatableComponent.of("worldedit.butcher.explain-all"));
+            actor.printError(Component.translatable("worldedit.butcher.explain-all"));
             return 0;
         } else if (radius == -1) {
             if (config.butcherMaxRadius != -1) {
@@ -453,10 +451,10 @@ public class UtilityCommands {
 
         int killed = killMatchingEntities(radius, actor, flags::createFunction);
 
-        actor.printInfo(TranslatableComponent.of(
+        actor.printInfo(Component.translatable(
                 "worldedit.butcher.killed",
-                TextComponent.of(killed),
-                TextComponent.of(radius)
+                Component.text(killed),
+                Component.text(radius)
         ));
 
         return killed;
@@ -475,12 +473,12 @@ public class UtilityCommands {
                       @Arg(desc = "The radius of the cuboid to remove from")
                           int radius) throws WorldEditException {
         if (radius < -1) {
-            actor.printError(TranslatableComponent.of("worldedit.remove.explain-all"));
+            actor.printError(Component.translatable("worldedit.remove.explain-all"));
             return 0;
         }
 
         int removed = killMatchingEntities(radius, actor, remover::createFunction);
-        actor.printInfo(TranslatableComponent.of("worldedit.remove.removed", TextComponent.of(removed)));
+        actor.printInfo(Component.translatable("worldedit.remove.removed", Component.text(removed)));
         return removed;
     }
 
@@ -530,10 +528,10 @@ public class UtilityCommands {
         try {
             expression = Expression.compile(String.join(" ", input));
         } catch (ExpressionException e) {
-            actor.printError(TranslatableComponent.of(
+            actor.printError(Component.translatable(
                 "worldedit.calc.invalid.with-error",
-                TextComponent.of(String.join(" ", input)),
-                TextComponent.of(e.getMessage())
+                Component.text(String.join(" ", input)),
+                Component.text(e.getMessage())
             ));
             return;
         }
@@ -541,7 +539,7 @@ public class UtilityCommands {
             double result = expression.evaluate(
                     new double[]{}, WorldEdit.getInstance().getSessionManager().get(actor).getTimeout());
             String formatted = Double.isNaN(result) ? "NaN" : formatForLocale(actor.getLocale()).format(result);
-            return SubtleFormat.wrap(input + " = ").append(TextComponent.of(formatted, TextColor.LIGHT_PURPLE));
+            return SubtleFormat.wrap(input + " = ").append(Component.text(formatted, NamedTextColor.LIGHT_PURPLE));
         }, (Component) null);
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/WorldEditCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/WorldEditCommands.java
@@ -34,10 +34,9 @@ import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.extension.platform.PlatformManager;
 import com.sk89q.worldedit.util.formatting.component.MessageBox;
 import com.sk89q.worldedit.util.formatting.component.TextComponentProducer;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 import com.sk89q.worldedit.util.paste.ActorCallbackPaste;
 import com.sk89q.worldedit.util.paste.PasteMetadata;
 import com.sk89q.worldedit.util.report.ConfigReport;
@@ -76,32 +75,32 @@ public class WorldEditCommands {
         desc = "Get WorldEdit version"
     )
     public void version(Actor actor) {
-        actor.printInfo(TranslatableComponent.of("worldedit.version.version", TextComponent.of(WorldEdit.getVersion())));
-        actor.printInfo(TextComponent.of("https://github.com/EngineHub/WorldEdit/"));
+        actor.printInfo(Component.translatable("worldedit.version.version", Component.text(WorldEdit.getVersion())));
+        actor.printInfo(Component.text("https://github.com/EngineHub/WorldEdit/"));
 
         PlatformManager pm = we.getPlatformManager();
 
         TextComponentProducer producer = new TextComponentProducer();
         for (Platform platform : pm.getPlatforms()) {
             producer.append(
-                    TextComponent.of("* ", TextColor.GRAY)
-                    .append(TextComponent.of(platform.getPlatformName())
-                        .hoverEvent(HoverEvent.showText(TextComponent.of(platform.getId()))))
-                    .append(TextComponent.of("(" + platform.getPlatformVersion() + ")"))
+                    Component.text("* ", NamedTextColor.GRAY)
+                    .append(Component.text(platform.getPlatformName())
+                        .hoverEvent(HoverEvent.showText(Component.text(platform.getId()))))
+                    .append(Component.text("(" + platform.getPlatformVersion() + ")"))
             ).newline();
         }
-        actor.print(new MessageBox("Platforms", producer, TextColor.GRAY).create());
+        actor.print(new MessageBox("Platforms", producer, NamedTextColor.GRAY).create());
 
         producer.reset();
         for (Capability capability : Capability.values()) {
             Platform platform = pm.queryCapability(capability);
             producer.append(
-                    TextComponent.of(capability.name(), TextColor.GRAY)
-                    .append(TextComponent.of(": ")
-                    .append(TextComponent.of(platform != null ? platform.getPlatformName() : "none")))
+                    Component.text(capability.name(), NamedTextColor.GRAY)
+                    .append(Component.text(": ")
+                    .append(Component.text(platform != null ? platform.getPlatformName() : "none")))
             ).newline();
         }
-        actor.print(new MessageBox("Capabilities", producer, TextColor.GRAY).create());
+        actor.print(new MessageBox("Capabilities", producer, NamedTextColor.GRAY).create());
     }
 
     @Command(
@@ -112,7 +111,7 @@ public class WorldEditCommands {
     public void reload(Actor actor) {
         we.getPlatformManager().queryCapability(Capability.CONFIGURATION).reload();
         we.getEventBus().post(new ConfigurationLoadEvent(we.getPlatformManager().queryCapability(Capability.CONFIGURATION).getConfiguration()));
-        actor.printInfo(TranslatableComponent.of("worldedit.reload.config"));
+        actor.printInfo(Component.translatable("worldedit.reload.config"));
     }
 
     @Command(
@@ -131,9 +130,9 @@ public class WorldEditCommands {
         try {
             Path dest = we.getConfiguration().getWorkingDirectoryPath().resolve("report.txt");
             Files.writeString(dest, result, StandardCharsets.UTF_8);
-            actor.printInfo(TranslatableComponent.of("worldedit.report.written", TextComponent.of(dest.toAbsolutePath().toString())));
+            actor.printInfo(Component.translatable("worldedit.report.written", Component.text(dest.toAbsolutePath().toString())));
         } catch (IOException e) {
-            actor.printError(TranslatableComponent.of("worldedit.report.error", TextComponent.of(e.getMessage())));
+            actor.printError(Component.translatable("worldedit.report.error", Component.text(e.getMessage())));
         }
 
         if (pastebin) {
@@ -141,7 +140,7 @@ public class WorldEditCommands {
             PasteMetadata metadata = new PasteMetadata();
             metadata.author = actor.getName();
             metadata.extension = "report";
-            ActorCallbackPaste.pastebin(we.getSupervisor(), actor, result, metadata, TranslatableComponent.builder("worldedit.report.callback"));
+            ActorCallbackPaste.pastebin(we.getSupervisor(), actor, result, metadata, Component.translatable("worldedit.report.callback"));
         }
     }
 
@@ -157,14 +156,14 @@ public class WorldEditCommands {
         if (hookMode != null) {
             newMode = hookMode == HookMode.ACTIVE;
             if (newMode == previousMode) {
-                actor.printError(TranslatableComponent.of(previousMode ? "worldedit.trace.active.already" : "worldedit.trace.inactive.already"));
+                actor.printError(Component.translatable(previousMode ? "worldedit.trace.active.already" : "worldedit.trace.inactive.already"));
                 return;
             }
         } else {
             newMode = !previousMode;
         }
         session.setTracingActions(newMode);
-        actor.printInfo(TranslatableComponent.of(newMode ? "worldedit.trace.active" : "worldedit.trace.inactive"));
+        actor.printInfo(Component.translatable(newMode ? "worldedit.trace.active" : "worldedit.trace.inactive"));
     }
 
     @Command(
@@ -186,13 +185,13 @@ public class WorldEditCommands {
         try {
             ZoneId tz = ZoneId.of(timezone);
             session.setTimezone(tz);
-            actor.printInfo(TranslatableComponent.of("worldedit.timezone.set", TextComponent.of(tz.getDisplayName(
+            actor.printInfo(Component.translatable("worldedit.timezone.set", Component.text(tz.getDisplayName(
                     TextStyle.FULL, actor.getLocale()
             ))));
-            actor.printInfo(TranslatableComponent.of("worldedit.timezone.current",
-                    TextComponent.of(dateFormat.withLocale(actor.getLocale()).format(ZonedDateTime.now(tz)))));
+            actor.printInfo(Component.translatable("worldedit.timezone.current",
+                    Component.text(dateFormat.withLocale(actor.getLocale()).format(ZonedDateTime.now(tz)))));
         } catch (ZoneRulesException e) {
-            actor.printError(TranslatableComponent.of("worldedit.timezone.invalid"));
+            actor.printError(Component.translatable("worldedit.timezone.invalid"));
         }
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/AbstractDirectionConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/AbstractDirectionConverter.java
@@ -29,7 +29,6 @@ import com.sk89q.worldedit.internal.annotation.Direction;
 import com.sk89q.worldedit.internal.annotation.MultiDirection;
 import com.sk89q.worldedit.internal.annotation.OptionalArg;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import org.enginehub.piston.CommandManager;
 import org.enginehub.piston.converter.ArgumentConverter;
 import org.enginehub.piston.converter.ConversionResult;
@@ -106,7 +105,7 @@ public abstract class AbstractDirectionConverter<D> implements ArgumentConverter
 
     @Override
     public Component describeAcceptableArguments() {
-        return TextComponent.of("`me` to use facing direction, or any "
+        return Component.text("`me` to use facing direction, or any "
             + (includeDiagonals ? "direction" : "non-diagonal direction"));
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/Chunk3dVectorConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/Chunk3dVectorConverter.java
@@ -25,7 +25,6 @@ import com.google.common.reflect.TypeToken;
 import com.sk89q.worldedit.internal.annotation.Chunk3d;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import org.enginehub.piston.CommandManager;
 import org.enginehub.piston.converter.ArgumentConverter;
 import org.enginehub.piston.converter.ArgumentConverters;
@@ -77,7 +76,7 @@ public class Chunk3dVectorConverter<C, T> implements ArgumentConverter<T> {
 
     @Override
     public Component describeAcceptableArguments() {
-        return TextComponent.of("any " + acceptableArguments);
+        return Component.text("any " + acceptableArguments);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/ClipboardFormatConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/ClipboardFormatConverter.java
@@ -48,7 +48,7 @@ public class ClipboardFormatConverter implements ArgumentConverter<ClipboardForm
     private final TextComponent choices;
 
     private ClipboardFormatConverter() {
-        this.choices = TextComponent.of("any clipboard format");
+        this.choices = Component.text("any clipboard format");
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/ClipboardShareDestinationConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/ClipboardShareDestinationConverter.java
@@ -47,7 +47,7 @@ public class ClipboardShareDestinationConverter implements ArgumentConverter<Cli
     private final TextComponent choices;
 
     private ClipboardShareDestinationConverter() {
-        this.choices = TextComponent.of("any clipboard share destination");
+        this.choices = Component.text("any clipboard share destination");
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/CommaSeparatedValuesConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/CommaSeparatedValuesConverter.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.sk89q.worldedit.util.formatting.text.TextComponent.space;
 
 public class CommaSeparatedValuesConverter<T> implements ArgumentConverter<T> {
 
@@ -71,13 +70,13 @@ public class CommaSeparatedValuesConverter<T> implements ArgumentConverter<T> {
 
     @Override
     public Component describeAcceptableArguments() {
-        TextComponent.Builder result = TextComponent.builder("");
+        TextComponent.Builder result = Component.text();
         if (maximum > -1) {
-            result.append(TextComponent.of("up to "))
-                .append(TextComponent.of(maximum))
-                .append(space());
+            result.append(Component.text("up to "))
+                .append(Component.text(maximum))
+                .append(Component.space());
         }
-        result.append(TextComponent.of("comma separated values of: "))
+        result.append(Component.text("comma separated values of: "))
             .append(delegate.describeAcceptableArguments());
         return result.build();
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/EntityRemoverConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/EntityRemoverConverter.java
@@ -22,7 +22,6 @@ package com.sk89q.worldedit.command.argument;
 import com.google.common.collect.ImmutableList;
 import com.sk89q.worldedit.command.util.EntityRemover;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import org.enginehub.piston.CommandManager;
 import org.enginehub.piston.converter.ArgumentConverter;
 import org.enginehub.piston.converter.ConversionResult;
@@ -49,7 +48,7 @@ public class EntityRemoverConverter implements ArgumentConverter<EntityRemover> 
 
     @Override
     public Component describeAcceptableArguments() {
-        return TextComponent.of(
+        return Component.text(
             "projectiles, items, paintings, itemframes, boats, minecarts, tnt, xp, or all"
         );
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/FactoryConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/FactoryConverter.java
@@ -37,7 +37,6 @@ import com.sk89q.worldedit.math.transform.Transform;
 import com.sk89q.worldedit.session.ClipboardHolder;
 import com.sk89q.worldedit.session.request.RequestExtent;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.world.World;
 import org.enginehub.piston.CommandManager;
 import org.enginehub.piston.converter.ArgumentConverter;
@@ -145,6 +144,6 @@ public class FactoryConverter<T> implements ArgumentConverter<T> {
 
     @Override
     public Component describeAcceptableArguments() {
-        return TextComponent.of("any " + description);
+        return Component.text("any " + description);
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/HeightConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/HeightConverter.java
@@ -24,7 +24,6 @@ import com.sk89q.worldedit.LocalConfiguration;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.internal.annotation.VertHeight;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import org.enginehub.piston.CommandManager;
 import org.enginehub.piston.converter.ArgumentConverter;
 import org.enginehub.piston.converter.ArgumentConverters;
@@ -59,7 +58,7 @@ public class HeightConverter implements ArgumentConverter<Integer> {
 
     @Override
     public Component describeAcceptableArguments() {
-        return TextComponent.of("Any integer");
+        return Component.text("Any integer");
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/OffsetConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/OffsetConverter.java
@@ -31,7 +31,6 @@ import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.math.transform.AffineTransform;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import org.enginehub.piston.CommandManager;
 import org.enginehub.piston.converter.ArgumentConverter;
 import org.enginehub.piston.converter.ConversionResult;
@@ -61,9 +60,9 @@ public class OffsetConverter implements ArgumentConverter<BlockVector3> {
 
     @Override
     public Component describeAcceptableArguments() {
-        return TextComponent.builder()
+        return Component.text()
             .append(directionVectorConverter.describeAcceptableArguments())
-            .append(", or ")
+            .append(Component.text(", or "))
             .append(vectorConverter.describeAcceptableArguments())
             .build();
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/RegistryConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/RegistryConverter.java
@@ -93,7 +93,7 @@ public final class RegistryConverter<V extends Keyed> implements ArgumentConvert
 
     private RegistryConverter(Registry<V> registry) {
         this.registry = registry;
-        this.choices = TextComponent.of("any " + registry.getName());
+        this.choices = Component.text("any " + registry.getName());
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/SelectorChoice.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/SelectorChoice.java
@@ -30,8 +30,6 @@ import com.sk89q.worldedit.regions.selector.ExtendingCuboidRegionSelector;
 import com.sk89q.worldedit.regions.selector.Polygonal2DRegionSelector;
 import com.sk89q.worldedit.regions.selector.SphereRegionSelector;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.World;
 
 import java.util.Optional;
@@ -45,8 +43,8 @@ public enum SelectorChoice implements SelectorChoiceOrList {
         public void explainNewSelector(Actor actor) {
             super.explainNewSelector(actor);
             Optional<Integer> limit = ActorSelectorLimits.forActor(actor).getPolygonVertexLimit();
-            limit.ifPresent(integer -> actor.printInfo(TranslatableComponent.of(
-                "worldedit.select.poly.limit-message", TextComponent.of(integer)
+            limit.ifPresent(integer -> actor.printInfo(Component.translatable(
+                "worldedit.select.poly.limit-message", Component.text(integer)
             )));
         }
     },
@@ -58,8 +56,8 @@ public enum SelectorChoice implements SelectorChoiceOrList {
         public void explainNewSelector(Actor actor) {
             super.explainNewSelector(actor);
             Optional<Integer> limit = ActorSelectorLimits.forActor(actor).getPolyhedronVertexLimit();
-            limit.ifPresent(integer -> actor.printInfo(TranslatableComponent.of(
-                "worldedit.select.convex.limit-message", TextComponent.of(integer)
+            limit.ifPresent(integer -> actor.printInfo(Component.translatable(
+                "worldedit.select.convex.limit-message", Component.text(integer)
             )));
         }
     },
@@ -74,7 +72,7 @@ public enum SelectorChoice implements SelectorChoiceOrList {
                    String message) {
         this.newFromWorld = newFromWorld;
         this.newFromOld = newFromOld;
-        this.messageComponent = TranslatableComponent.of(message);
+        this.messageComponent = Component.translatable(message);
     }
 
     public RegionSelector createNewSelector(World world) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/SideEffectConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/SideEffectConverter.java
@@ -43,7 +43,7 @@ public class SideEffectConverter implements ArgumentConverter<SideEffect> {
         commandManager.registerConverter(Key.of(SideEffect.class), new SideEffectConverter());
     }
 
-    private final TextComponent choices = TextComponent.of("any side effect");
+    private final TextComponent choices = Component.text("any side effect");
 
     private SideEffectConverter() {
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/SideEffectSetConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/SideEffectSetConverter.java
@@ -44,7 +44,7 @@ public class SideEffectSetConverter implements ArgumentConverter<SideEffectSet> 
         );
     }
 
-    private final TextComponent choices = TextComponent.of("any side effects");
+    private final TextComponent choices = Component.text("any side effects");
     private final CommaSeparatedValuesConverter<SideEffect> sideEffectConverter;
 
     private SideEffectSetConverter(CommaSeparatedValuesConverter<SideEffect> sideEffectConverter) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/VectorConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/VectorConverter.java
@@ -26,7 +26,6 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector2;
 import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import org.enginehub.piston.CommandManager;
 import org.enginehub.piston.converter.ArgumentConverter;
 import org.enginehub.piston.converter.ArgumentConverters;
@@ -95,7 +94,7 @@ public class VectorConverter<C, T> implements ArgumentConverter<T> {
 
     @Override
     public Component describeAcceptableArguments() {
-        return TextComponent.of("any " + acceptableArguments);
+        return Component.text("any " + acceptableArguments);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/WorldConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/WorldConverter.java
@@ -47,7 +47,7 @@ public class WorldConverter implements ArgumentConverter<World> {
     private final TextComponent choices;
 
     private WorldConverter() {
-        this.choices = TextComponent.of("any world");
+        this.choices = Component.text("any world");
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/ZonedDateTimeConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/ZonedDateTimeConverter.java
@@ -21,7 +21,6 @@ package com.sk89q.worldedit.command.argument;
 
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import org.enginehub.piston.CommandManager;
 import org.enginehub.piston.converter.ArgumentConverter;
 import org.enginehub.piston.converter.ConversionResult;
@@ -45,7 +44,7 @@ public class ZonedDateTimeConverter implements ArgumentConverter<ZonedDateTime> 
 
     @Override
     public Component describeAcceptableArguments() {
-        return TextComponent.of("any date");
+        return Component.text("any date");
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/AreaPickaxe.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/AreaPickaxe.java
@@ -29,7 +29,7 @@ import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.Location;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
@@ -87,7 +87,7 @@ public class AreaPickaxe implements BlockTool {
                     }
                 }
             } catch (MaxChangedBlocksException e) {
-                player.printError(TranslatableComponent.of("worldedit.tool.max-block-changes"));
+                player.printError(Component.translatable("worldedit.tool.max-block-changes"));
             } finally {
                 session.remember(editSession);
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockDataCyler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockDataCyler.java
@@ -31,8 +31,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.Location;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BaseBlock;
 
@@ -65,12 +64,12 @@ public class BlockDataCyler implements DoubleActionBlockTool {
         if (!config.allowedDataCycleBlocks.isEmpty()
                 && !player.hasPermission("worldedit.override.data-cycler")
                 && !config.allowedDataCycleBlocks.contains(block.getBlockType().getId())) {
-            player.printError(TranslatableComponent.of("worldedit.tool.data-cycler.block-not-permitted"));
+            player.printError(Component.translatable("worldedit.tool.data-cycler.block-not-permitted"));
             return true;
         }
 
         if (block.getStates().keySet().isEmpty()) {
-            player.printError(TranslatableComponent.of("worldedit.tool.data-cycler.cant-cycle"));
+            player.printError(Component.translatable("worldedit.tool.data-cycler.cant-cycle"));
         } else {
             Property<?> currentProperty = selectedProperties.get(player.getUniqueId());
 
@@ -92,13 +91,13 @@ public class BlockDataCyler implements DoubleActionBlockTool {
 
                     try {
                         editSession.setBlock(blockPoint, newBlock);
-                        player.printInfo(TranslatableComponent.of(
+                        player.printInfo(Component.translatable(
                                 "worldedit.tool.data-cycler.new-value",
-                                TextComponent.of(currentProperty.getName()),
-                                TextComponent.of(String.valueOf(currentProperty.getValues().get(index)))
+                                Component.text(currentProperty.getName()),
+                                Component.text(String.valueOf(currentProperty.getValues().get(index)))
                         ));
                     } catch (MaxChangedBlocksException e) {
-                        player.printError(TranslatableComponent.of("worldedit.tool.max-block-changes"));
+                        player.printError(Component.translatable("worldedit.tool.max-block-changes"));
                     } finally {
                         session.remember(editSession);
                     }
@@ -109,7 +108,7 @@ public class BlockDataCyler implements DoubleActionBlockTool {
                 index = (index + 1) % properties.size();
                 currentProperty = properties.get(index);
                 selectedProperties.put(player.getUniqueId(), currentProperty);
-                player.printInfo(TranslatableComponent.of("worldedit.tool.data-cycler.cycling", TextComponent.of(currentProperty.getName())));
+                player.printInfo(Component.translatable("worldedit.tool.data-cycler.cycling", Component.text(currentProperty.getName())));
             }
         }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockReplacer.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockReplacer.java
@@ -31,7 +31,7 @@ import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.Location;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.block.BaseBlock;
 
 import javax.annotation.Nullable;
@@ -81,7 +81,7 @@ public class BlockReplacer implements DoubleActionBlockTool {
 
         if (targetBlock != null) {
             pattern = targetBlock;
-            player.printInfo(TranslatableComponent.of("worldedit.tool.repl.switched", targetBlock.getBlockType().getRichName()));
+            player.printInfo(Component.translatable("worldedit.tool.repl.switched", targetBlock.getBlockType().getRichName()));
         }
 
         return true;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BrushTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BrushTool.java
@@ -33,7 +33,7 @@ import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.mask.MaskIntersection;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.util.Location;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 
 import javax.annotation.Nullable;
 
@@ -197,7 +197,7 @@ public class BrushTool implements TraceTool {
         Location target = player.getBlockTrace(getRange(), true, traceMask);
 
         if (target == null) {
-            player.printError(TranslatableComponent.of("worldedit.tool.no-block"));
+            player.printError(Component.translatable("worldedit.tool.no-block"));
             return true;
         }
 
@@ -221,7 +221,7 @@ public class BrushTool implements TraceTool {
             try {
                 brush.build(editSession, target.toVector().toBlockPoint(), material, size);
             } catch (MaxChangedBlocksException e) {
-                player.printError(TranslatableComponent.of("worldedit.tool.max-block-changes"));
+                player.printError(Component.translatable("worldedit.tool.max-block-changes"));
             } finally {
                 session.remember(editSession);
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/DistanceWand.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/DistanceWand.java
@@ -28,7 +28,7 @@ import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.RegionSelector;
 import com.sk89q.worldedit.util.Location;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 
 /**
  * A wand that can be used at a distance.
@@ -79,7 +79,7 @@ public class DistanceWand extends BrushTool implements DoubleActionTraceTool {
         }
 
         if (target == null) {
-            player.printError(TranslatableComponent.of("worldedit.tool.no-block"));
+            player.printError(Component.translatable("worldedit.tool.no-block"));
             return null;
         }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/FloatingTreeRemover.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/FloatingTreeRemover.java
@@ -29,7 +29,7 @@ import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.Location;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BlockCategories;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -75,7 +75,7 @@ public class FloatingTreeRemover implements BlockTool {
         final BlockState state = world.getBlock(clicked.toVector().toBlockPoint());
 
         if (!isTreeBlock(state.getBlockType())) {
-            player.printError(TranslatableComponent.of("worldedit.tool.deltree.not-tree"));
+            player.printError(Component.translatable("worldedit.tool.deltree.not-tree"));
             return true;
         }
 
@@ -83,7 +83,7 @@ public class FloatingTreeRemover implements BlockTool {
             try {
                 final Set<BlockVector3> blockSet = bfs(world, clicked.toVector().toBlockPoint());
                 if (blockSet == null) {
-                    player.printError(TranslatableComponent.of("worldedit.tool.deltree.not-floating"));
+                    player.printError(Component.translatable("worldedit.tool.deltree.not-floating"));
                     return true;
                 }
 
@@ -94,7 +94,7 @@ public class FloatingTreeRemover implements BlockTool {
                     }
                 }
             } catch (MaxChangedBlocksException e) {
-                player.printError(TranslatableComponent.of("worldedit.tool.max-block-changes"));
+                player.printError(Component.translatable("worldedit.tool.max-block-changes"));
             } finally {
                 session.remember(editSession);
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/FloodFillTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/FloodFillTool.java
@@ -30,7 +30,7 @@ import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.Location;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
@@ -76,7 +76,7 @@ public class FloodFillTool implements BlockTool {
             try {
                 recurse(editSession, origin, origin, range, initialType, new HashSet<>());
             } catch (MaxChangedBlocksException e) {
-                player.printError(TranslatableComponent.of("worldedit.tool.max-block-changes"));
+                player.printError(Component.translatable("worldedit.tool.max-block-changes"));
             } finally {
                 session.remember(editSession);
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/LongRangeBuildTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/LongRangeBuildTool.java
@@ -31,7 +31,7 @@ import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Location;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.block.BaseBlock;
 
 /**
@@ -123,7 +123,7 @@ public class LongRangeBuildTool extends BrushTool implements DoubleActionTraceTo
         }
 
         if (target == null) {
-            player.printError(TranslatableComponent.of("worldedit.tool.no-block"));
+            player.printError(Component.translatable("worldedit.tool.no-block"));
             return null;
         }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/NavigationWand.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/NavigationWand.java
@@ -25,7 +25,7 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.util.Location;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 
 public class NavigationWand implements DoubleActionTraceTool {
 
@@ -45,7 +45,7 @@ public class NavigationWand implements DoubleActionTraceTool {
         if (pos != null) {
             player.findFreePosition(pos);
         } else {
-            player.printError(TranslatableComponent.of("worldedit.jumpto.none"));
+            player.printError(Component.translatable("worldedit.jumpto.none"));
         }
         return true;
     }
@@ -61,7 +61,7 @@ public class NavigationWand implements DoubleActionTraceTool {
         }
 
         if (!player.passThroughForwardWall(Math.max(1, maxDist - 10))) {
-            player.printError(TranslatableComponent.of("worldedit.thru.obstructed"));
+            player.printError(Component.translatable("worldedit.thru.obstructed"));
         }
         return true;
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/QueryTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/QueryTool.java
@@ -28,10 +28,10 @@ import com.sk89q.worldedit.internal.block.BlockStateIdAccess;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.registry.LegacyMapper;
@@ -55,25 +55,25 @@ public class QueryTool implements BlockTool {
         BlockVector3 blockPoint = clicked.toVector().toBlockPoint();
         BaseBlock block = world.getFullBlock(blockPoint);
 
-        TextComponent.Builder builder = TextComponent.builder();
-        builder.append(TextComponent.of("@" + clicked.toVector().toBlockPoint() + ": ", TextColor.BLUE));
-        builder.append(block.getBlockType().getRichName().color(TextColor.YELLOW));
-        builder.append(TextComponent.of(" (" + block + ") ", TextColor.GRAY)
-            .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TranslatableComponent.of("worldedit.tool.info.blockstate.hover"))));
+        TextComponent.Builder builder = Component.text();
+        builder.append(Component.text("@" + clicked.toVector().toBlockPoint() + ": ", NamedTextColor.BLUE));
+        builder.append(block.getBlockType().getRichName().color(NamedTextColor.YELLOW));
+        builder.append(Component.text(" (" + block + ") ", NamedTextColor.GRAY)
+            .hoverEvent(HoverEvent.showText(Component.translatable("worldedit.tool.info.blockstate.hover"))));
         final int internalId = BlockStateIdAccess.getBlockStateId(block.toImmutableState());
         if (BlockStateIdAccess.isValidInternalId(internalId)) {
-            builder.append(TextComponent.of(" (" + internalId + ") ", TextColor.DARK_GRAY)
-                .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TranslatableComponent.of("worldedit.tool.info.internalid.hover"))));
+            builder.append(Component.text(" (" + internalId + ") ", NamedTextColor.DARK_GRAY)
+                .hoverEvent(HoverEvent.showText(Component.translatable("worldedit.tool.info.internalid.hover"))));
         }
         final int[] legacy = LegacyMapper.getInstance().getLegacyFromBlock(block.toImmutableState());
         if (legacy != null) {
-            builder.append(TextComponent.of(" (" + legacy[0] + ":" + legacy[1] + ") ", TextColor.DARK_GRAY)
-                .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TranslatableComponent.of("worldedit.tool.info.legacy.hover"))));
+            builder.append(Component.text(" (" + legacy[0] + ":" + legacy[1] + ") ", NamedTextColor.DARK_GRAY)
+                .hoverEvent(HoverEvent.showText(Component.translatable("worldedit.tool.info.legacy.hover"))));
         }
 
-        builder.append(TextComponent.of(" (" + world.getBlockLightLevel(blockPoint) + "/"
-            + world.getBlockLightLevel(blockPoint.add(0, 1, 0)) + ")", TextColor.WHITE)
-            .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TranslatableComponent.of("worldedit.tool.info.light.hover"))));
+        builder.append(Component.text(" (" + world.getBlockLightLevel(blockPoint) + "/"
+            + world.getBlockLightLevel(blockPoint.add(0, 1, 0)) + ")", NamedTextColor.WHITE)
+            .hoverEvent(HoverEvent.showText(Component.translatable("worldedit.tool.info.light.hover"))));
 
         player.print(builder.build());
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/RecursivePickaxe.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/RecursivePickaxe.java
@@ -29,7 +29,7 @@ import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.Location;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
@@ -77,7 +77,7 @@ public class RecursivePickaxe implements BlockTool {
                 recurse(server, editSession, world, clicked.toVector().toBlockPoint(),
                         clicked.toVector().toBlockPoint(), range, initialType, new HashSet<>());
             } catch (MaxChangedBlocksException e) {
-                player.printError(TranslatableComponent.of("worldedit.tool.max-block-changes"));
+                player.printError(Component.translatable("worldedit.tool.max-block-changes"));
             } finally {
                 session.remember(editSession);
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/SinglePickaxe.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/SinglePickaxe.java
@@ -29,7 +29,7 @@ import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.Location;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
@@ -59,7 +59,7 @@ public class SinglePickaxe implements BlockTool {
             editSession.getSurvivalExtent().setToolUse(config.superPickaxeDrop);
             editSession.setBlock(blockPoint, BlockTypes.AIR.getDefaultState());
         } catch (MaxChangedBlocksException e) {
-            player.printError(TranslatableComponent.of("worldedit.tool.max-block-changes"));
+            player.printError(Component.translatable("worldedit.tool.max-block-changes"));
         }
 
         return true;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/TreePlanter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/TreePlanter.java
@@ -30,7 +30,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.TreeGenerator;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 
 import javax.annotation.Nullable;
 
@@ -66,10 +66,10 @@ public class TreePlanter implements BlockTool {
                 }
 
                 if (!successful) {
-                    player.printError(TranslatableComponent.of("worldedit.tool.tree.obstructed"));
+                    player.printError(Component.translatable("worldedit.tool.tree.obstructed"));
                 }
             } catch (MaxChangedBlocksException e) {
-                player.printError(TranslatableComponent.of("worldedit.tool.max-block-changes"));
+                player.printError(Component.translatable("worldedit.tool.max-block-changes"));
             } finally {
                 session.remember(editSession);
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/util/AsyncCommandBuilder.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/util/AsyncCommandBuilder.java
@@ -28,8 +28,7 @@ import com.sk89q.worldedit.internal.command.exception.ExceptionConverter;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.util.formatting.component.ErrorFormat;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 import com.sk89q.worldedit.util.task.FutureForwardingTask;
 import com.sk89q.worldedit.util.task.Supervisor;
 import org.apache.logging.log4j.Logger;
@@ -88,7 +87,7 @@ public final class AsyncCommandBuilder<T> {
 
     @Deprecated
     public AsyncCommandBuilder<T> sendMessageAfterDelay(String message) {
-        return sendMessageAfterDelay(TextComponent.of(checkNotNull(message)));
+        return sendMessageAfterDelay(Component.text(checkNotNull(message)));
     }
 
     @Deprecated
@@ -116,7 +115,7 @@ public final class AsyncCommandBuilder<T> {
 
     public AsyncCommandBuilder<T> onSuccess(@Nullable String message, @Nullable Consumer<T> consumer) {
         checkArgument(message != null || consumer != null, "Can't have null message AND consumer");
-        this.successMessage = message == null ? null : TextComponent.of(message, TextColor.LIGHT_PURPLE);
+        this.successMessage = message == null ? null : Component.text(message, NamedTextColor.LIGHT_PURPLE);
         this.consumer = consumer;
         return this;
     }
@@ -163,7 +162,7 @@ public final class AsyncCommandBuilder<T> {
                 sender.print(successMessage);
             }
         } catch (Throwable orig) {
-            Component failure = failureMessage != null ? failureMessage : TextComponent.of("An error occurred");
+            Component failure = failureMessage != null ? failureMessage : Component.text("An error occurred");
             try {
                 if (exceptionConverter != null) {
                     try {
@@ -180,18 +179,18 @@ public final class AsyncCommandBuilder<T> {
 
                         if (message == null) {
                             if (Strings.isNullOrEmpty(converted.getMessage())) {
-                                message = TextComponent.of("Unknown error.");
+                                message = Component.text("Unknown error.");
                             } else {
                                 message = converted.getRichMessage();
                             }
                         }
-                        sender.printError(failure.append(TextComponent.of(": ")).append(message));
+                        sender.printError(failure.append(Component.text(": ")).append(message));
                     }
                 } else {
                     throw orig;
                 }
             } catch (Throwable unknown) {
-                sender.printError(failure.append(TextComponent.of(": Unknown error. Please see console.")));
+                sender.printError(failure.append(Component.text(": Unknown error. Please see console.")));
                 LOGGER.error("Uncaught exception occurred in task: " + description, orig);
             }
         }
@@ -211,7 +210,7 @@ public final class AsyncCommandBuilder<T> {
                 if (parentCause instanceof com.sk89q.minecraft.util.commands.CommandException) {
                     final String msg = parentCause.getMessage();
                     if (!Strings.isNullOrEmpty(msg)) {
-                        message = TextComponent.of(msg);
+                        message = Component.text(msg);
                     }
                     break;
                 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/util/FutureProgressListener.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/util/FutureProgressListener.java
@@ -23,7 +23,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
 
 import java.util.Timer;
 import javax.annotation.Nullable;
@@ -40,7 +39,7 @@ public class FutureProgressListener implements Runnable {
 
     @Deprecated
     public FutureProgressListener(Actor sender, String message) {
-        this(sender, TextComponent.of(message));
+        this(sender, Component.text(message));
     }
 
     public FutureProgressListener(Actor sender, Component message) {
@@ -62,7 +61,7 @@ public class FutureProgressListener implements Runnable {
 
     @Deprecated
     public static void addProgressListener(ListenableFuture<?> future, Actor sender, String message) {
-        addProgressListener(future, sender, TextComponent.of(message));
+        addProgressListener(future, sender, Component.text(message));
     }
 
     public static void addProgressListener(ListenableFuture<?> future, Actor sender, Component message) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/util/MessageTimerTask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/util/MessageTimerTask.java
@@ -21,7 +21,6 @@ package com.sk89q.worldedit.command.util;
 
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
 
 import java.util.TimerTask;
 import javax.annotation.Nullable;
@@ -39,7 +38,7 @@ public class MessageTimerTask extends TimerTask {
 
     @Deprecated
     MessageTimerTask(Actor sender, String message) {
-        this(sender, TextComponent.of(message), null);
+        this(sender, Component.text(message), null);
     }
 
     MessageTimerTask(Actor sender, Component message, @Nullable Component workingMessage) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/util/PrintCommandHelp.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/util/PrintCommandHelp.java
@@ -26,8 +26,7 @@ import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.util.formatting.component.CommandListBox;
 import com.sk89q.worldedit.util.formatting.component.CommandUsageBox;
 import com.sk89q.worldedit.util.formatting.component.InvalidComponentException;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import org.enginehub.piston.Command;
 import org.enginehub.piston.CommandManager;
 import org.enginehub.piston.inject.InjectedValueStore;
@@ -82,7 +81,7 @@ public class PrintCommandHelp {
         List<Command> visited = new ArrayList<>();
         Command currentCommand = detectCommand(manager, commandPath.get(0));
         if (currentCommand == null) {
-            actor.printError(TranslatableComponent.of("worldedit.help.command-not-found", TextComponent.of(commandPath.get(0))));
+            actor.printError(Component.translatable("worldedit.help.command-not-found", Component.text(commandPath.get(0))));
             return;
         }
         visited.add(currentCommand);
@@ -93,8 +92,8 @@ public class PrintCommandHelp {
             Map<String, Command> subCommands = getSubCommands(currentCommand);
 
             if (subCommands.isEmpty()) {
-                actor.printError(TranslatableComponent.of("worldedit.help.no-subcommands",
-                    TextComponent.of(toCommandString(visited)), TextComponent.of(subCommand)));
+                actor.printError(Component.translatable("worldedit.help.no-subcommands",
+                    Component.text(toCommandString(visited)), Component.text(subCommand)));
                 // full help for single command
                 CommandUsageBox box = new CommandUsageBox(visited, visited.stream()
                         .map(Command::getName).collect(Collectors.joining(" ")), helpRootCommand);
@@ -106,8 +105,8 @@ public class PrintCommandHelp {
                 currentCommand = subCommands.get(subCommand);
                 visited.add(currentCommand);
             } else {
-                actor.printError(TranslatableComponent.of("worldedit.help.subcommand-not-found",
-                    TextComponent.of(subCommand), TextComponent.of(toCommandString(visited))));
+                actor.printError(Component.translatable("worldedit.help.subcommand-not-found",
+                    Component.text(subCommand), Component.text(toCommandString(visited))));
                 // list subcommands for currentCommand
                 printCommands(page, getSubCommands(Iterables.getLast(visited)).values().stream(), actor, visited, helpRootCommand);
                 return;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/util/WorldEditAsyncCommandBuilder.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/util/WorldEditAsyncCommandBuilder.java
@@ -22,7 +22,6 @@ package com.sk89q.worldedit.command.util;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
 
 import java.util.concurrent.Callable;
 import javax.annotation.Nullable;
@@ -36,7 +35,7 @@ public final class WorldEditAsyncCommandBuilder {
 
     @Deprecated
     public static void createAndSendMessage(Actor actor, Callable<Component> task, @Nullable String desc) {
-        createAndSendMessage(actor, task, desc != null ? TextComponent.of(desc) : null);
+        createAndSendMessage(actor, task, desc != null ? Component.text(desc) : null);
     }
 
     public static void createAndSendMessage(Actor actor, Callable<Component> task, @Nullable Component desc) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/MaskFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/MaskFactory.java
@@ -41,8 +41,7 @@ import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.mask.MaskIntersection;
 import com.sk89q.worldedit.internal.registry.AbstractFactory;
 import com.sk89q.worldedit.internal.registry.InputParser;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -111,14 +110,14 @@ public final class MaskFactory extends AbstractFactory<Mask> {
                 }
             }
             if (match == null) {
-                throw new NoMatchException(TranslatableComponent.of("worldedit.error.no-match", TextComponent.of(component)));
+                throw new NoMatchException(Component.translatable("worldedit.error.no-match", Component.text(component)));
             }
             masks.add(match);
         }
 
         switch (masks.size()) {
             case 0:
-                throw new NoMatchException(TranslatableComponent.of("worldedit.error.no-match", TextComponent.of(input)));
+                throw new NoMatchException(Component.translatable("worldedit.error.no-match", Component.text(input)));
             case 1:
                 return masks.get(0);
             default:

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultBlockParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultBlockParser.java
@@ -42,8 +42,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.util.HandSide;
 import com.sk89q.worldedit.util.concurrency.LazyReference;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -78,12 +77,12 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
             } catch (NotABlockException e) {
                 throw new InputParseException(e.getRichMessage());
             } catch (WorldEditException e) {
-                throw new InputParseException(TranslatableComponent.of("worldedit.error.unknown", e.getRichMessage()), e);
+                throw new InputParseException(Component.translatable("worldedit.error.unknown", e.getRichMessage()), e);
             }
         } else {
-            throw new InputParseException(TranslatableComponent.of(
+            throw new InputParseException(Component.translatable(
                     "worldedit.error.parser.player-only",
-                    TextComponent.of(handSide == HandSide.MAIN_HAND ? "hand" : "offhand")
+                    Component.text(handSide == HandSide.MAIN_HAND ? "hand" : "offhand")
             ));
         }
     }
@@ -152,8 +151,8 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
                 String[] parts = parseableData.split("=");
                 if (parts.length != 2) {
                     throw new InputParseException(
-                            TranslatableComponent.of("worldedit.error.parser.bad-state-format",
-                            TextComponent.of(parseableData))
+                            Component.translatable("worldedit.error.parser.bad-state-format",
+                            Component.text(parseableData))
                     );
                 }
 
@@ -161,10 +160,10 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
                 Property<Object> propertyKey = (Property<Object>) type.getPropertyMap().get(parts[0]);
                 if (propertyKey == null) {
                     if (context.getActor() != null) {
-                        throw new NoMatchException(TranslatableComponent.of(
+                        throw new NoMatchException(Component.translatable(
                                 "worldedit.error.parser.unknown-property",
-                                TextComponent.of(parts[0]),
-                                TextComponent.of(type.getId())
+                                Component.text(parts[0]),
+                                Component.text(type.getId())
                         ));
                     } else {
                         WorldEdit.logger.debug("Unknown property " + parts[0] + " for block " + type.getId());
@@ -172,19 +171,19 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
                     return Map.of();
                 }
                 if (blockStates.containsKey(propertyKey)) {
-                    throw new InputParseException(TranslatableComponent.of(
+                    throw new InputParseException(Component.translatable(
                             "worldedit.error.parser.duplicate-property",
-                            TextComponent.of(parts[0])
+                            Component.text(parts[0])
                     ));
                 }
                 Object value;
                 try {
                     value = propertyKey.getValueFor(parts[1]);
                 } catch (IllegalArgumentException e) {
-                    throw new NoMatchException(TranslatableComponent.of(
+                    throw new NoMatchException(Component.translatable(
                             "worldedit.error.parser.unknown-value",
-                            TextComponent.of(parts[1]),
-                            TextComponent.of(propertyKey.getName())
+                            Component.text(parts[1]),
+                            Component.text(propertyKey.getName())
                     ));
                 }
 
@@ -192,9 +191,9 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
             } catch (InputParseException e) {
                 throw e; // Pass-through
             } catch (Exception e) {
-                throw new InputParseException(TranslatableComponent.of(
+                throw new InputParseException(Component.translatable(
                         "worldedit.error.parser.bad-state-format",
-                        TextComponent.of(parseableData)
+                        Component.text(parseableData)
                 ));
             }
         }
@@ -256,7 +255,7 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
         Map<Property<?>, Object> blockStates = new HashMap<>();
         String[] blockAndExtraData = input.trim().split("\\|");
         if (blockAndExtraData.length == 0) {
-            throw new NoMatchException(TranslatableComponent.of("worldedit.error.unknown-block", TextComponent.of(input)));
+            throw new NoMatchException(Component.translatable("worldedit.error.unknown-block", Component.text(input)));
         }
         if (context.isTryingLegacy()) {
             // Perform a legacy wool colour mapping
@@ -271,7 +270,7 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
             try {
                 String[] split = blockAndExtraData[0].split(":", 2);
                 if (split.length == 0) {
-                    throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.invalid-colon"));
+                    throw new InputParseException(Component.translatable("worldedit.error.parser.invalid-colon"));
                 } else if (split.length == 1) {
                     state = LegacyMapper.getInstance().getBlockFromLegacy(Integer.parseInt(split[0]));
                 } else {
@@ -300,11 +299,11 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
             String stateString = null;
             if (stateStart != -1 && (nbtStart == -1 || stateStart < nbtStart)) {
                 if (stateStart + 1 >= blockAndExtraData[0].length()) {
-                    throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.hanging-lbracket", TextComponent.of(stateStart)));
+                    throw new InputParseException(Component.translatable("worldedit.error.parser.hanging-lbracket", Component.text(stateStart)));
                 }
                 int stateEnd = blockAndExtraData[0].indexOf(']');
                 if (stateEnd < 0) {
-                    throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.missing-rbracket"));
+                    throw new InputParseException(Component.translatable("worldedit.error.parser.missing-rbracket"));
                 }
                 stateString = blockAndExtraData[0].substring(stateStart + 1, stateEnd);
             }
@@ -312,19 +311,19 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
             String nbtString = null;
             if (nbtStart != -1) {
                 if (nbtStart + 1 >= blockAndExtraData[0].length()) {
-                    throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.hanging-lbrace", TextComponent.of(nbtStart)));
+                    throw new InputParseException(Component.translatable("worldedit.error.parser.hanging-lbrace", Component.text(nbtStart)));
                 }
                 int nbtEnd = blockAndExtraData[0].lastIndexOf('}');
                 if (nbtEnd < 0) {
-                    throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.missing-rbrace"));
+                    throw new InputParseException(Component.translatable("worldedit.error.parser.missing-rbrace"));
                 }
                 nbtString = blockAndExtraData[0].substring(nbtStart, nbtEnd + 1);
             }
 
             if (typeString.isEmpty()) {
-                throw new InputParseException(TranslatableComponent.of(
+                throw new InputParseException(Component.translatable(
                         "worldedit.error.parser.bad-state-format",
-                        TextComponent.of(blockAndExtraData[0])
+                        Component.text(blockAndExtraData[0])
                 ));
             }
             String[] stateProperties = EMPTY_STRING_ARRAY;
@@ -359,7 +358,7 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
                 try {
                     primaryPosition = context.requireSession().getRegionSelector(world).getPrimaryPosition();
                 } catch (IncompleteRegionException e) {
-                    throw new InputParseException(TranslatableComponent.of("worldedit.error.incomplete-region"));
+                    throw new InputParseException(Component.translatable("worldedit.error.incomplete-region"));
                 }
                 final BaseBlock blockInHand = world.getFullBlock(primaryPosition);
 
@@ -372,7 +371,7 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
             }
 
             if (blockType == null) {
-                throw new NoMatchException(TranslatableComponent.of("worldedit.error.unknown-block", TextComponent.of(input)));
+                throw new NoMatchException(Component.translatable("worldedit.error.unknown-block", Component.text(input)));
             }
 
             blockStates.putAll(parseProperties(blockType, stateProperties, context));
@@ -401,10 +400,10 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
                 try {
                     otherTag = LinStringIO.readFromStringUsing(nbtString, LinCompoundTag::readFrom);
                 } catch (NbtParseException e) {
-                    throw new NoMatchException(TranslatableComponent.of(
+                    throw new NoMatchException(Component.translatable(
                         "worldedit.error.parser.invalid-nbt",
-                        TextComponent.of(input),
-                        TextComponent.of(e.getMessage())
+                        Component.text(input),
+                        Component.text(e.getMessage())
                     ));
                 }
                 if (blockNbtData == null) {
@@ -416,7 +415,7 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
         }
         // this should be impossible but IntelliJ isn't that smart
         if (blockType == null) {
-            throw new NoMatchException(TranslatableComponent.of("worldedit.error.unknown-block", TextComponent.of(input)));
+            throw new NoMatchException(Component.translatable("worldedit.error.unknown-block", Component.text(input)));
         }
 
         // Check if the item is allowed
@@ -424,7 +423,7 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
             Actor actor = context.requireActor();
             if (actor != null && !actor.hasPermission("worldedit.anyblock")
                     && worldEdit.getConfiguration().disallowedBlocks.contains(blockType.getId())) {
-                throw new DisallowedUsageException(TranslatableComponent.of("worldedit.error.disallowed-block", TextComponent.of(input)));
+                throw new DisallowedUsageException(Component.translatable("worldedit.error.disallowed-block", Component.text(input)));
             }
         }
 
@@ -451,11 +450,11 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
                 mobName = blockAndExtraData[1];
                 EntityType ent = EntityTypes.get(mobName.toLowerCase(Locale.ROOT));
                 if (ent == null) {
-                    throw new NoMatchException(TranslatableComponent.of("worldedit.error.unknown-entity", TextComponent.of(mobName)));
+                    throw new NoMatchException(Component.translatable("worldedit.error.unknown-entity", Component.text(mobName)));
                 }
                 mobName = ent.getId();
                 if (!worldEdit.getPlatformManager().queryCapability(Capability.USER_COMMANDS).isValidMobType(mobName)) {
-                    throw new NoMatchException(TranslatableComponent.of("worldedit.error.unknown-mob", TextComponent.of(mobName)));
+                    throw new NoMatchException(Component.translatable("worldedit.error.unknown-mob", Component.text(mobName)));
                 }
             } else {
                 mobName = EntityTypes.PIG.getId();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultItemParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultItemParser.java
@@ -31,8 +31,7 @@ import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.internal.registry.InputParser;
 import com.sk89q.worldedit.util.HandSide;
 import com.sk89q.worldedit.util.concurrency.LazyReference;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.item.ItemTypes;
 import com.sk89q.worldedit.world.registry.LegacyMapper;
@@ -66,7 +65,7 @@ public class DefaultItemParser extends InputParser<BaseItem> {
             try {
                 String[] split = input.split(":");
                 if (split.length == 0) {
-                    throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.invalid-colon"));
+                    throw new InputParseException(Component.translatable("worldedit.error.parser.invalid-colon"));
                 } else if (split.length == 1) {
                     itemType = LegacyMapper.getInstance().getItemFromLegacy(Integer.parseInt(split[0]));
                 } else {
@@ -89,11 +88,11 @@ public class DefaultItemParser extends InputParser<BaseItem> {
             } else {
                 typeString = input.substring(0, nbtStart);
                 if (nbtStart + 1 >= input.length()) {
-                    throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.hanging-lbrace", TextComponent.of(nbtStart)));
+                    throw new InputParseException(Component.translatable("worldedit.error.parser.hanging-lbrace", Component.text(nbtStart)));
                 }
                 int stateEnd = input.lastIndexOf('}');
                 if (stateEnd < 0) {
-                    throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.missing-rbrace"));
+                    throw new InputParseException(Component.translatable("worldedit.error.parser.missing-rbrace"));
                 }
                 nbtString = input.substring(nbtStart);
             }
@@ -111,7 +110,7 @@ public class DefaultItemParser extends InputParser<BaseItem> {
             }
 
             if (itemType == null) {
-                throw new NoMatchException(TranslatableComponent.of("worldedit.error.unknown-item", TextComponent.of(input)));
+                throw new NoMatchException(Component.translatable("worldedit.error.unknown-item", Component.text(input)));
             }
 
             if (nbtString != null) {
@@ -119,10 +118,10 @@ public class DefaultItemParser extends InputParser<BaseItem> {
                 try {
                     otherTag = LinStringIO.readFromStringUsing(nbtString, LinCompoundTag::readFrom);
                 } catch (NbtParseException e) {
-                    throw new NoMatchException(TranslatableComponent.of(
+                    throw new NoMatchException(Component.translatable(
                         "worldedit.error.invalid-nbt",
-                        TextComponent.of(input),
-                        TextComponent.of(e.getMessage())
+                        Component.text(input),
+                        Component.text(e.getMessage())
                     ));
                 }
                 if (itemNbtData == null) {
@@ -142,9 +141,9 @@ public class DefaultItemParser extends InputParser<BaseItem> {
         if (actor instanceof Player) {
             return ((Player) actor).getItemInHand(handSide);
         } else {
-            throw new InputParseException(TranslatableComponent.of(
+            throw new InputParseException(Component.translatable(
                     "worldedit.error.parser.player-only",
-                    TextComponent.of(handSide == HandSide.MAIN_HAND ? "hand" : "offhand")
+                    Component.text(handSide == HandSide.MAIN_HAND ? "hand" : "offhand")
             ));
         }
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BiomeMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BiomeMaskParser.java
@@ -28,8 +28,7 @@ import com.sk89q.worldedit.extension.input.ParserContext;
 import com.sk89q.worldedit.function.mask.BiomeMask;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.internal.registry.InputParser;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.biome.BiomeType;
 
 import java.util.Arrays;
@@ -74,7 +73,7 @@ public class BiomeMaskParser extends InputParser<Mask> {
         for (String biomeName : Splitter.on(",").split(input.substring(1))) {
             BiomeType biome = BiomeType.REGISTRY.get(biomeName);
             if (biome == null) {
-                throw new NoMatchException(TranslatableComponent.of("worldedit.error.unknown-biome", TextComponent.of(biomeName)));
+                throw new NoMatchException(Component.translatable("worldedit.error.unknown-biome", Component.text(biomeName)));
             }
             biomes.add(biome);
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlockCategoryMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlockCategoryMaskParser.java
@@ -27,8 +27,7 @@ import com.sk89q.worldedit.extension.input.ParserContext;
 import com.sk89q.worldedit.function.mask.BlockCategoryMask;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.internal.registry.InputParser;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.block.BlockCategory;
 
 import java.util.Locale;
@@ -54,7 +53,7 @@ public class BlockCategoryMaskParser extends InputParser<Mask> {
         // This means it's a tag mask.
         BlockCategory category = BlockCategory.REGISTRY.get(input.substring(2).toLowerCase(Locale.ROOT));
         if (category == null) {
-            throw new NoMatchException(TranslatableComponent.of("worldedit.error.unknown-tag", TextComponent.of(input.substring(2))));
+            throw new NoMatchException(Component.translatable("worldedit.error.unknown-tag", Component.text(input.substring(2))));
         } else {
             return new BlockCategoryMask(context.requireExtent(), category);
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlockStateMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlockStateMaskParser.java
@@ -26,8 +26,7 @@ import com.sk89q.worldedit.extension.input.ParserContext;
 import com.sk89q.worldedit.function.mask.BlockStateMask;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.internal.registry.InputParser;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 
 import java.util.stream.Stream;
 
@@ -58,7 +57,7 @@ public class BlockStateMaskParser extends InputParser<Mask> {
                     Splitter.on(',').omitEmptyStrings().trimResults().withKeyValueSeparator('=').split(states),
                     strict);
         } catch (Exception e) {
-            throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.bad-state-format", TextComponent.of(states)), e);
+            throw new InputParseException(Component.translatable("worldedit.error.parser.bad-state-format", Component.text(states)), e);
         }
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/ExpressionMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/ExpressionMaskParser.java
@@ -30,7 +30,7 @@ import com.sk89q.worldedit.internal.registry.InputParser;
 import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.regions.shape.WorldEditExpressionEnvironment;
 import com.sk89q.worldedit.session.SessionOwner;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 
 import java.util.function.IntSupplier;
 import java.util.stream.Stream;
@@ -67,7 +67,7 @@ public class ExpressionMaskParser extends InputParser<Mask> {
             }
             return new ExpressionMask(exp);
         } catch (ExpressionException e) {
-            throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.invalid-expression"));
+            throw new InputParseException(Component.translatable("worldedit.error.parser.invalid-expression"));
         }
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/NegateMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/NegateMaskParser.java
@@ -25,7 +25,7 @@ import com.sk89q.worldedit.extension.input.ParserContext;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.mask.Masks;
 import com.sk89q.worldedit.internal.registry.InputParser;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 
 import java.util.stream.Stream;
 
@@ -55,7 +55,7 @@ public class NegateMaskParser extends InputParser<Mask> {
         if (input.length() > 1) {
             return Masks.negate(worldEdit.getMaskFactory().parseFromInput(input.substring(1), context));
         } else {
-            throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.negate-nothing"));
+            throw new InputParseException(Component.translatable("worldedit.error.parser.negate-nothing"));
         }
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/RegionMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/RegionMaskParser.java
@@ -27,7 +27,7 @@ import com.sk89q.worldedit.extension.input.ParserContext;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.mask.RegionMask;
 import com.sk89q.worldedit.internal.registry.SimpleInputParser;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 
 import java.util.List;
 
@@ -49,7 +49,7 @@ public class RegionMaskParser extends SimpleInputParser<Mask> {
         try {
             return new RegionMask(context.requireSession().getSelection(context.requireWorld()).clone());
         } catch (IncompleteRegionException e) {
-            throw new InputParseException(TranslatableComponent.of("worldedit.error.incomplete-region"));
+            throw new InputParseException(Component.translatable("worldedit.error.incomplete-region"));
         }
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/BlockCategoryPatternParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/BlockCategoryPatternParser.java
@@ -27,8 +27,7 @@ import com.sk89q.worldedit.extension.input.ParserContext;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.function.pattern.RandomPattern;
 import com.sk89q.worldedit.internal.registry.InputParser;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.block.BlockCategory;
 import com.sk89q.worldedit.world.block.BlockType;
 
@@ -61,13 +60,13 @@ public class BlockCategoryPatternParser extends InputParser<Pattern> {
 
         BlockCategory category = BlockCategory.REGISTRY.get(tag);
         if (category == null) {
-            throw new NoMatchException(TranslatableComponent.of("worldedit.error.unknown-tag", TextComponent.of(tag)));
+            throw new NoMatchException(Component.translatable("worldedit.error.unknown-tag", Component.text(tag)));
         }
         RandomPattern randomPattern = new RandomPattern();
 
         Set<BlockType> blocks = category.getAll();
         if (blocks.isEmpty()) {
-            throw new InputParseException(TranslatableComponent.of("worldedit.error.empty-tag", TextComponent.of(category.getId())));
+            throw new InputParseException(Component.translatable("worldedit.error.empty-tag", Component.text(category.getId())));
         }
 
         if (anyState) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/ClipboardPatternParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/ClipboardPatternParser.java
@@ -30,7 +30,7 @@ import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.internal.registry.InputParser;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.session.ClipboardHolder;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 
 import java.util.Locale;
 import java.util.stream.Stream;
@@ -79,11 +79,11 @@ public class ClipboardPatternParser extends InputParser<Pattern> {
             String coords = offsetParts[1];
             if (coords.length() < 7  // min length of `[x,y,z]`
                 || coords.charAt(0) != '[' || coords.charAt(coords.length() - 1) != ']') {
-                throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.clipboard.missing-offset"));
+                throw new InputParseException(Component.translatable("worldedit.error.parser.clipboard.missing-offset"));
             }
             String[] offsetSplit = coords.substring(1, coords.length() - 1).split(",");
             if (offsetSplit.length != 3) {
-                throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.clipboard.missing-coordinates"));
+                throw new InputParseException(Component.translatable("worldedit.error.parser.clipboard.missing-coordinates"));
             }
             offset = BlockVector3.at(
                     Integer.parseInt(offsetSplit[0]),
@@ -98,10 +98,10 @@ public class ClipboardPatternParser extends InputParser<Pattern> {
                 Clipboard clipboard = holder.getClipboard();
                 return new ClipboardPattern(clipboard, offset);
             } catch (EmptyClipboardException e) {
-                throw new InputParseException(TranslatableComponent.of("worldedit.error.empty-clipboard"));
+                throw new InputParseException(Component.translatable("worldedit.error.empty-clipboard"));
             }
         } else {
-            throw new InputParseException(TranslatableComponent.of("worldedit.error.missing-session"));
+            throw new InputParseException(Component.translatable("worldedit.error.missing-session"));
         }
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/RandomPatternParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/RandomPatternParser.java
@@ -26,8 +26,7 @@ import com.sk89q.worldedit.extension.input.ParserContext;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.function.pattern.RandomPattern;
 import com.sk89q.worldedit.internal.registry.InputParser;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -78,7 +77,7 @@ public class RandomPatternParser extends InputParser<Pattern> {
                 String[] p = token.split("%");
 
                 if (p.length < 2) {
-                    throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.missing-random-type", TextComponent.of(input)));
+                    throw new InputParseException(Component.translatable("worldedit.error.parser.missing-random-type", Component.text(input)));
                 } else {
                     chance = Double.parseDouble(p[0]);
                     innerPattern = worldEdit.getPatternFactory().parseFromInput(p[1], context);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/TypeOrStateApplyingPatternParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/TypeOrStateApplyingPatternParser.java
@@ -30,8 +30,7 @@ import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.function.pattern.StateApplyingPattern;
 import com.sk89q.worldedit.function.pattern.TypeApplyingPattern;
 import com.sk89q.worldedit.internal.registry.InputParser;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
 
@@ -89,28 +88,28 @@ public class TypeOrStateApplyingPatternParser extends InputParser<Pattern> {
         } else {
             // states given
             if (!parts[1].endsWith("]")) {
-                throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.missing-rbracket"));
+                throw new InputParseException(Component.translatable("worldedit.error.parser.missing-rbracket"));
             }
             final String[] states = parts[1].substring(0, parts[1].length() - 1).split(",");
             Map<String, String> statesToSet = new HashMap<>();
             for (String state : states) {
                 if (state.isEmpty()) {
-                    throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.empty-state"));
+                    throw new InputParseException(Component.translatable("worldedit.error.parser.empty-state"));
                 }
                 String[] propVal = state.split("=", 2);
                 if (propVal.length != 2) {
-                    throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.missing-equals-separator"));
+                    throw new InputParseException(Component.translatable("worldedit.error.parser.missing-equals-separator"));
                 }
                 final String prop = propVal[0];
                 if (prop.isEmpty()) {
-                    throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.empty-property"));
+                    throw new InputParseException(Component.translatable("worldedit.error.parser.empty-property"));
                 }
                 final String value = propVal[1];
                 if (value.isEmpty()) {
-                    throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.empty-value"));
+                    throw new InputParseException(Component.translatable("worldedit.error.parser.empty-value"));
                 }
                 if (statesToSet.put(prop, value) != null) {
-                    throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.duplicate-property", TextComponent.of(prop)));
+                    throw new InputParseException(Component.translatable("worldedit.error.parser.duplicate-property", Component.text(prop)));
                 }
             }
             if (type.isEmpty()) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/input/ParserContext.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/input/ParserContext.java
@@ -23,7 +23,7 @@ import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.extension.factory.MaskFactory;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extent.Extent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.World;
 
 import javax.annotation.Nullable;
@@ -147,7 +147,7 @@ public class ParserContext {
     public Extent requireExtent() throws InputParseException {
         Extent extent = getExtent();
         if (extent == null) {
-            throw new InputParseException(TranslatableComponent.of("worldedit.error.missing-extent"));
+            throw new InputParseException(Component.translatable("worldedit.error.missing-extent"));
         }
         return extent;
     }
@@ -161,7 +161,7 @@ public class ParserContext {
     public LocalSession requireSession() throws InputParseException {
         LocalSession session = getSession();
         if (session == null) {
-            throw new InputParseException(TranslatableComponent.of("worldedit.error.missing-session"));
+            throw new InputParseException(Component.translatable("worldedit.error.missing-session"));
         }
         return session;
     }
@@ -175,7 +175,7 @@ public class ParserContext {
     public World requireWorld() throws InputParseException {
         World world = getWorld();
         if (world == null) {
-            throw new InputParseException(TranslatableComponent.of("worldedit.error.missing-world"));
+            throw new InputParseException(Component.translatable("worldedit.error.missing-world"));
         }
         return world;
     }
@@ -189,7 +189,7 @@ public class ParserContext {
     public Actor requireActor() throws InputParseException {
         Actor actor = getActor();
         if (actor == null) {
-            throw new InputParseException(TranslatableComponent.of("worldedit.error.missing-actor"));
+            throw new InputParseException(Component.translatable("worldedit.error.missing-actor"));
         }
         return actor;
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
@@ -35,7 +35,7 @@ import com.sk89q.worldedit.util.HandSide;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.TargetBlock;
 import com.sk89q.worldedit.util.auth.AuthorizationException;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockCategories;
@@ -498,13 +498,13 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
 
     @Override
     public File openFileOpenDialog(String[] extensions) {
-        printError(TranslatableComponent.of("worldedit.platform.no-file-dialog"));
+        printError(Component.translatable("worldedit.platform.no-file-dialog"));
         return null;
     }
 
     @Override
     public File openFileSaveDialog(String[] extensions) {
-        printError(TranslatableComponent.of("worldedit.platform.no-file-dialog"));
+        printError(Component.translatable("worldedit.platform.no-file-dialog"));
         return null;
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/Actor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/Actor.java
@@ -24,7 +24,7 @@ import com.sk89q.worldedit.session.SessionOwner;
 import com.sk89q.worldedit.util.Identifiable;
 import com.sk89q.worldedit.util.auth.Subject;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 
 import java.io.File;
 import java.util.Locale;
@@ -92,7 +92,7 @@ public interface Actor extends Identifiable, SessionOwner, Subject {
      * @param component The component to print
      */
     default void printError(Component component) {
-        print(component.color(TextColor.RED));
+        print(component.color(NamedTextColor.RED));
     }
 
     /**
@@ -101,7 +101,7 @@ public interface Actor extends Identifiable, SessionOwner, Subject {
      * @param component The component to print
      */
     default void printInfo(Component component) {
-        print(component.color(TextColor.LIGHT_PURPLE));
+        print(component.color(NamedTextColor.LIGHT_PURPLE));
     }
 
     /**
@@ -110,7 +110,7 @@ public interface Actor extends Identifiable, SessionOwner, Subject {
      * @param component The component to print
      */
     default void printDebug(Component component) {
-        print(component.color(TextColor.GRAY));
+        print(component.color(NamedTextColor.GRAY));
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
@@ -108,9 +108,8 @@ import com.sk89q.worldedit.internal.util.Substring;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.session.request.Request;
 import com.sk89q.worldedit.util.eventbus.Subscribe;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.Component;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 import com.sk89q.worldedit.util.logging.DynamicStreamHandler;
 import com.sk89q.worldedit.util.logging.LogFormat;
 import com.sk89q.worldedit.world.World;
@@ -296,7 +295,7 @@ public final class PlatformCommandManager {
                                           Consumer<CommandManager> additionalConfig) {
         commandManager.register(name, cmd -> {
             cmd.aliases(aliases);
-            cmd.description(TextComponent.of(desc));
+            cmd.description(Component.text(desc));
             cmd.action(Command.Action.NULL_ACTION);
 
             CommandManager manager = commandManagerService.newCommandManager();
@@ -308,8 +307,8 @@ public final class PlatformCommandManager {
             additionalConfig.accept(manager);
 
             final List<Command> subCommands = manager.getAllCommands().collect(Collectors.toList());
-            cmd.addPart(SubCommandPart.builder(TranslatableComponent.of("worldedit.argument.action"),
-                TextComponent.of("Sub-command to run."))
+            cmd.addPart(SubCommandPart.builder(Component.translatable("worldedit.argument.action"),
+                Component.text("Sub-command to run."))
                 .withCommands(subCommands)
                 .required()
                 .build());
@@ -517,19 +516,19 @@ public final class PlatformCommandManager {
             }
         } catch (ConditionFailedException e) {
             if (e.getCondition() instanceof PermissionCondition) {
-                actor.printError(TranslatableComponent.of("worldedit.command.permissions"));
+                actor.printError(Component.translatable("worldedit.command.permissions"));
             } else {
                 actor.print(e.getRichMessage());
             }
         } catch (UsageException e) {
-            actor.print(TextComponent.builder("")
-                .color(TextColor.RED)
+            actor.print(Component.text()
+                .color(NamedTextColor.RED)
                 .append(e.getRichMessage())
                 .build());
             ImmutableList<Command> cmd = e.getCommands();
             if (!cmd.isEmpty()) {
                 actor.printError(
-                        TranslatableComponent.of("worldedit.error.incorrect-usage",
+                        Component.translatable("worldedit.error.incorrect-usage",
                         HelpGenerator.create(e.getCommandParseResult()).getUsage())
                 );
             }
@@ -553,11 +552,11 @@ public final class PlatformCommandManager {
                     double timeS = (time / 1000.0);
                     int changed = editSession.getBlockChangeCount();
                     double throughput = timeS == 0 ? changed : changed / timeS;
-                    actor.printDebug(TranslatableComponent.of(
+                    actor.printDebug(Component.translatable(
                             "worldedit.command.time-elapsed",
-                            TextComponent.of(timeS),
-                            TextComponent.of(changed),
-                            TextComponent.of(Math.round(throughput))
+                            Component.text(timeS),
+                            Component.text(changed),
+                            Component.text(Math.round(throughput))
                     ));
                 }
 
@@ -577,7 +576,7 @@ public final class PlatformCommandManager {
             store.injectValue(Key.of(Player.class, OptionalArg.class), ValueProvider.constant((Player) actor));
         } else {
             store.injectValue(Key.of(Player.class), context -> {
-                throw new CommandException(TranslatableComponent.of("worldedit.command.player-only"), ImmutableList.of());
+                throw new CommandException(Component.translatable("worldedit.command.player-only"), ImmutableList.of());
             });
         }
         store.injectValue(Key.of(Arguments.class), ValueProvider.constant(arguments));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlayerProxy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlayerProxy.java
@@ -30,7 +30,6 @@ import com.sk89q.worldedit.session.SessionKey;
 import com.sk89q.worldedit.util.HandSide;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.gamemode.GameMode;
@@ -117,25 +116,25 @@ class PlayerProxy extends AbstractPlayerActor {
     @Override
     @Deprecated
     public void printRaw(String msg) {
-        basePlayer.print(TextComponent.of(msg));
+        basePlayer.print(Component.text(msg));
     }
 
     @Override
     @Deprecated
     public void printDebug(String msg) {
-        basePlayer.printDebug(TextComponent.of(msg));
+        basePlayer.printDebug(Component.text(msg));
     }
 
     @Override
     @Deprecated
     public void print(String msg) {
-        basePlayer.printInfo(TextComponent.of(msg));
+        basePlayer.printInfo(Component.text(msg));
     }
 
     @Override
     @Deprecated
     public void printError(String msg) {
-        basePlayer.printError(TextComponent.of(msg));
+        basePlayer.printError(Component.text(msg));
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/BlockArrayClipboard.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/BlockArrayClipboard.java
@@ -19,7 +19,6 @@
 
 package com.sk89q.worldedit.extent.clipboard;
 
-import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.entity.Entity;
 import com.sk89q.worldedit.function.operation.Operation;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/share/BuiltInClipboardShareDestinations.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/share/BuiltInClipboardShareDestinations.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extent.clipboard.io.BuiltInClipboardFormat;
 import com.sk89q.worldedit.extent.clipboard.io.ClipboardFormat;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
 import com.sk89q.worldedit.util.paste.EngineHubPaste;
 import com.sk89q.worldedit.util.paste.PasteMetadata;
@@ -62,7 +62,7 @@ public enum BuiltInClipboardShareDestinations implements ClipboardShareDestinati
 
             URL url = pasteService.paste(new String(Base64.getEncoder().encode(outputStream.toByteArray()), StandardCharsets.UTF_8), pasteMetadata).call();
             String urlString = url.toExternalForm() + ".schem";
-            return actor -> actor.printInfo(TextComponent.of(urlString).clickEvent(ClickEvent.openUrl(urlString)));
+            return actor -> actor.printInfo(Component.text(urlString).clickEvent(ClickEvent.openUrl(urlString)));
         }
 
         @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/factory/Deform.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/factory/Deform.java
@@ -36,9 +36,7 @@ import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.regions.NullRegion;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.sk89q.worldedit.util.GuavaUtil.firstNonNull;
@@ -192,8 +190,8 @@ public class Deform implements Contextual<Operation> {
 
         @Override
         public Iterable<Component> getStatusMessages() {
-            return ImmutableList.of(TranslatableComponent.of("worldedit.operation.deform.expression",
-                    TextComponent.of(expression.getSource()).color(TextColor.LIGHT_PURPLE)));
+            return ImmutableList.of(Component.translatable("worldedit.operation.deform.expression",
+                    Component.text(expression.getSource()).color(NamedTextColor.LIGHT_PURPLE)));
         }
 
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/operation/ForwardExtentCopy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/operation/ForwardExtentCopy.java
@@ -40,9 +40,7 @@ import com.sk89q.worldedit.math.transform.Identity;
 import com.sk89q.worldedit.math.transform.Transform;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 
 import java.util.List;
 
@@ -335,12 +333,12 @@ public class ForwardExtentCopy implements Operation {
     @Override
     public Iterable<Component> getStatusMessages() {
         return ImmutableList.of(
-            TranslatableComponent.of("worldedit.operation.affected.block",
-                    TextComponent.of(affectedBlocks)).color(TextColor.LIGHT_PURPLE),
-            TranslatableComponent.of("worldedit.operation.affected.biome",
-                    TextComponent.of(affectedBiomeCols)).color(TextColor.LIGHT_PURPLE),
-            TranslatableComponent.of("worldedit.operation.affected.entity",
-                    TextComponent.of(affectedEntities)).color(TextColor.LIGHT_PURPLE)
+            Component.translatable("worldedit.operation.affected.block",
+                    Component.text(affectedBlocks)).color(NamedTextColor.LIGHT_PURPLE),
+            Component.translatable("worldedit.operation.affected.biome",
+                    Component.text(affectedBiomeCols)).color(NamedTextColor.LIGHT_PURPLE),
+            Component.translatable("worldedit.operation.affected.entity",
+                    Component.text(affectedEntities)).color(NamedTextColor.LIGHT_PURPLE)
         );
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/operation/Operation.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/operation/Operation.java
@@ -22,7 +22,6 @@ package com.sk89q.worldedit.function.operation;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -91,6 +90,6 @@ public interface Operation {
                 warnedDeprecatedClasses.add(className);
             }
         }
-        return oldMessages.stream().map(TextComponent::of).collect(Collectors.toList());
+        return oldMessages.stream().map(Component::text).collect(Collectors.toList());
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/visitor/BreadthFirstSearch.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/visitor/BreadthFirstSearch.java
@@ -27,9 +27,7 @@ import com.sk89q.worldedit.function.operation.RunContext;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -187,10 +185,10 @@ public abstract class BreadthFirstSearch implements Operation {
 
     @Override
     public Iterable<Component> getStatusMessages() {
-        return ImmutableList.of(TranslatableComponent.of(
+        return ImmutableList.of(Component.translatable(
                 "worldedit.operation.affected.block",
-                TextComponent.of(getAffected())
-        ).color(TextColor.LIGHT_PURPLE));
+                Component.text(getAffected())
+        ).color(NamedTextColor.LIGHT_PURPLE));
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/visitor/EntityVisitor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/visitor/EntityVisitor.java
@@ -26,9 +26,7 @@ import com.sk89q.worldedit.function.EntityFunction;
 import com.sk89q.worldedit.function.operation.Operation;
 import com.sk89q.worldedit.function.operation.RunContext;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 
 import java.util.Iterator;
 
@@ -82,10 +80,10 @@ public class EntityVisitor implements Operation {
 
     @Override
     public Iterable<Component> getStatusMessages() {
-        return ImmutableList.of(TranslatableComponent.of(
+        return ImmutableList.of(Component.translatable(
                 "worldedit.operation.affected.entity",
-                TextComponent.of(getAffected())
-        ).color(TextColor.LIGHT_PURPLE));
+                Component.text(getAffected())
+        ).color(NamedTextColor.LIGHT_PURPLE));
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/visitor/FlatRegionVisitor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/visitor/FlatRegionVisitor.java
@@ -27,9 +27,7 @@ import com.sk89q.worldedit.function.operation.RunContext;
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.regions.FlatRegion;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -82,10 +80,10 @@ public class FlatRegionVisitor implements Operation {
 
     @Override
     public Iterable<Component> getStatusMessages() {
-        return ImmutableList.of(TranslatableComponent.of(
+        return ImmutableList.of(Component.translatable(
                 "worldedit.operation.affected.column",
-                TextComponent.of(getAffected())
-        ).color(TextColor.LIGHT_PURPLE));
+                Component.text(getAffected())
+        ).color(NamedTextColor.LIGHT_PURPLE));
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/visitor/RegionVisitor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/visitor/RegionVisitor.java
@@ -27,9 +27,7 @@ import com.sk89q.worldedit.function.operation.RunContext;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 
 /**
  * Utility class to apply region functions to {@link com.sk89q.worldedit.regions.Region}.
@@ -71,10 +69,10 @@ public class RegionVisitor implements Operation {
 
     @Override
     public Iterable<Component> getStatusMessages() {
-        return ImmutableList.of(TranslatableComponent.of(
+        return ImmutableList.of(Component.translatable(
                 "worldedit.operation.affected.block",
-                TextComponent.of(getAffected())
-        ).color(TextColor.LIGHT_PURPLE));
+                Component.text(getAffected())
+        ).color(NamedTextColor.LIGHT_PURPLE));
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/command/CommandUtil.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/command/CommandUtil.java
@@ -25,9 +25,8 @@ import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extension.platform.PlatformCommandManager;
 import com.sk89q.worldedit.internal.util.Substring;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 import com.sk89q.worldedit.util.formatting.text.format.TextDecoration;
 import org.enginehub.piston.Command;
 import org.enginehub.piston.CommandParameters;
@@ -50,14 +49,14 @@ import static java.util.stream.Collectors.toList;
 
 public class CommandUtil {
 
-    private static final Component DEPRECATION_MARKER = TextComponent.of("This command is deprecated.");
+    private static final Component DEPRECATION_MARKER = Component.text("This command is deprecated.");
 
     private static Component makeDeprecatedFooter(String reason, Component replacement) {
-        return TextComponent.builder()
+        return Component.text()
             .append(DEPRECATION_MARKER)
-            .append(" " + reason + ".")
-            .append(TextComponent.newline())
-            .append(replacement.color(TextColor.GOLD))
+            .append(Component.text(" " + reason + "."))
+            .append(Component.newline())
+            .append(replacement.color(NamedTextColor.GOLD))
             .build();
     }
 
@@ -85,12 +84,11 @@ public class CommandUtil {
     }
 
     public static Component createNewCommandReplacementText(String suggestedCommand) {
-        return TextComponent.builder("Please use ", TextColor.GOLD)
-            .append(TextComponent.of(suggestedCommand)
+        return Component.text("Please use ", NamedTextColor.GOLD)
+            .append(Component.text(suggestedCommand)
                 .decoration(TextDecoration.UNDERLINED, true)
                 .clickEvent(ClickEvent.suggestCommand(suggestedCommand)))
-            .append(" instead.")
-            .build();
+            .append(Component.text(" instead."));
     }
 
     public static Command deprecate(Command command, String reason,
@@ -107,7 +105,7 @@ public class CommandUtil {
                 deprecatedCommandWarning(parameters, command, reason, replacementMessageGenerator))
             .footer(command.getFooter()
                 .map(existingFooter -> existingFooter
-                    .append(TextComponent.newline())
+                    .append(Component.newline())
                     .append(deprecatedWarning))
                 .orElse(deprecatedWarning))
             .build();
@@ -141,7 +139,7 @@ public class CommandUtil {
 
     private static Component replaceDeprecation(Component component) {
         if (component.children().stream().anyMatch(Predicate.isEqual(DEPRECATION_MARKER))) {
-            return TextComponent.empty();
+            return Component.empty();
         }
         return component.children(
             component.children().stream()
@@ -183,9 +181,7 @@ public class CommandUtil {
     ) {
         Component replacement = generator.getReplacement(command, parameters);
         actor.print(
-            TextComponent.builder(reason + ". ", TextColor.GOLD)
-                .append(replacement)
-                .build()
+            Component.text(reason + ". ", NamedTextColor.GOLD).append(replacement)
         );
     }
 
@@ -269,7 +265,7 @@ public class CommandUtil {
      * @param message the message for failure
      */
     public static void checkCommandArgument(boolean condition, String message) {
-        checkCommandArgument(condition, TextComponent.of(message));
+        checkCommandArgument(condition, Component.text(message));
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/command/exception/WorldEditExceptionConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/command/exception/WorldEditExceptionConverter.java
@@ -37,8 +37,6 @@ import com.sk89q.worldedit.extension.input.NoMatchException;
 import com.sk89q.worldedit.internal.expression.ExpressionException;
 import com.sk89q.worldedit.regions.RegionOperationException;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.io.file.FileSelectionAbortedException;
 import com.sk89q.worldedit.util.io.file.FilenameResolutionException;
 import com.sk89q.worldedit.util.io.file.InvalidFilenameException;
@@ -64,7 +62,7 @@ public class WorldEditExceptionConverter extends ExceptionConverterHelper {
     }
 
     private CommandException newCommandException(String message, Throwable cause) {
-        return newCommandException(TextComponent.of(String.valueOf(message)), cause);
+        return newCommandException(Component.text(String.valueOf(message)), cause);
     }
 
     private CommandException newCommandException(Component message, Throwable cause) {
@@ -76,15 +74,15 @@ public class WorldEditExceptionConverter extends ExceptionConverterHelper {
         final Matcher matcher = numberFormat.matcher(e.getMessage());
 
         if (matcher.matches()) {
-            throw newCommandException(TranslatableComponent.of("worldedit.error.invalid-number.matches", TextComponent.of(matcher.group(1))), e);
+            throw newCommandException(Component.translatable("worldedit.error.invalid-number.matches", Component.text(matcher.group(1))), e);
         } else {
-            throw newCommandException(TranslatableComponent.of("worldedit.error.invalid-number"), e);
+            throw newCommandException(Component.translatable("worldedit.error.invalid-number"), e);
         }
     }
 
     @ExceptionMatch
     public void convert(IncompleteRegionException e) throws CommandException {
-        throw newCommandException(TranslatableComponent.of("worldedit.error.incomplete-region"), e);
+        throw newCommandException(Component.translatable("worldedit.error.incomplete-region"), e);
     }
 
     @ExceptionMatch
@@ -110,13 +108,13 @@ public class WorldEditExceptionConverter extends ExceptionConverterHelper {
 
     @ExceptionMatch
     public void convert(MaxChangedBlocksException e) throws CommandException {
-        throw newCommandException(TranslatableComponent.of("worldedit.error.max-changes", TextComponent.of(e.getBlockLimit())), e);
+        throw newCommandException(Component.translatable("worldedit.error.max-changes", Component.text(e.getBlockLimit())), e);
     }
 
     @ExceptionMatch
     public void convert(MaxBrushRadiusException e) throws CommandException {
         throw newCommandException(
-                TranslatableComponent.of("worldedit.error.max-brush-radius", TextComponent.of(worldEdit.getConfiguration().maxBrushRadius)),
+                Component.translatable("worldedit.error.max-brush-radius", Component.text(worldEdit.getConfiguration().maxBrushRadius)),
                 e
         );
     }
@@ -124,7 +122,7 @@ public class WorldEditExceptionConverter extends ExceptionConverterHelper {
     @ExceptionMatch
     public void convert(MaxRadiusException e) throws CommandException {
         throw newCommandException(
-                TranslatableComponent.of("worldedit.error.max-radius", TextComponent.of(worldEdit.getConfiguration().maxRadius)),
+                Component.translatable("worldedit.error.max-radius", Component.text(worldEdit.getConfiguration().maxRadius)),
                 e
         );
     }
@@ -151,13 +149,13 @@ public class WorldEditExceptionConverter extends ExceptionConverterHelper {
 
     @ExceptionMatch
     public void convert(EmptyClipboardException e) throws CommandException {
-        throw newCommandException(TranslatableComponent.of("worldedit.error.empty-clipboard"), e);
+        throw newCommandException(Component.translatable("worldedit.error.empty-clipboard"), e);
     }
 
     @ExceptionMatch
     public void convert(InvalidFilenameException e) throws CommandException {
         throw newCommandException(
-                TranslatableComponent.of("worldedit.error.invalid-filename", TextComponent.of(e.getFilename()), e.getRichMessage()),
+                Component.translatable("worldedit.error.invalid-filename", Component.text(e.getFilename()), e.getRichMessage()),
                 e
         );
     }
@@ -165,7 +163,7 @@ public class WorldEditExceptionConverter extends ExceptionConverterHelper {
     @ExceptionMatch
     public void convert(FilenameResolutionException e) throws CommandException {
         throw newCommandException(
-                TranslatableComponent.of("worldedit.error.file-resolution", TextComponent.of(e.getFilename()), e.getRichMessage()),
+                Component.translatable("worldedit.error.file-resolution", Component.text(e.getFilename()), e.getRichMessage()),
                 e
         );
     }
@@ -173,14 +171,14 @@ public class WorldEditExceptionConverter extends ExceptionConverterHelper {
     @ExceptionMatch
     public void convert(InvalidToolBindException e) throws CommandException {
         throw newCommandException(
-                TranslatableComponent.of("worldedit.tool.error.cannot-bind", e.getItemType().getRichName(), e.getRichMessage()),
+                Component.translatable("worldedit.tool.error.cannot-bind", e.getItemType().getRichName(), e.getRichMessage()),
                 e
         );
     }
 
     @ExceptionMatch
     public void convert(FileSelectionAbortedException e) throws CommandException {
-        throw newCommandException(TranslatableComponent.of("worldedit.error.file-aborted"), e);
+        throw newCommandException(Component.translatable("worldedit.error.file-aborted"), e);
     }
 
     @ExceptionMatch

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/registry/AbstractFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/registry/AbstractFactory.java
@@ -23,8 +23,7 @@ import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.NoMatchException;
 import com.sk89q.worldedit.extension.input.ParserContext;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -81,7 +80,7 @@ public abstract class AbstractFactory<E> {
             }
         }
 
-        throw new NoMatchException(TranslatableComponent.of("worldedit.error.no-match", TextComponent.of(input)));
+        throw new NoMatchException(Component.translatable("worldedit.error.no-match", Component.text(input)));
     }
 
     @Deprecated

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/ErrorReporting.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/ErrorReporting.java
@@ -21,8 +21,7 @@ package com.sk89q.worldedit.internal.util;
 
 import com.google.common.base.Throwables;
 import com.sk89q.worldedit.extension.platform.Actor;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
 
 /**
@@ -30,12 +29,12 @@ import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
  */
 public class ErrorReporting {
     public static void trigger(Actor actor, Throwable error) {
-        actor.printError(TranslatableComponent.of("worldedit.command.error.report"));
-        TextComponent.Builder errorBuilder = TextComponent.builder(error.getClass().getName() + ": " + error.getMessage());
+        actor.printError(Component.translatable("worldedit.command.error.report"));
+        Component errorBuilder = Component.text(error.getClass().getName() + ": " + error.getMessage());
         if (actor.hasPermission("worldedit.error.detailed")) {
-            errorBuilder = errorBuilder.hoverEvent(HoverEvent.showText(TextComponent.of(Throwables.getStackTraceAsString(error))));
+            errorBuilder = errorBuilder.hoverEvent(HoverEvent.showText(Component.text(Throwables.getStackTraceAsString(error))));
         }
-        actor.print(errorBuilder.build());
+        actor.print(errorBuilder);
     }
 
     private ErrorReporting() {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CylinderRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CylinderRegion.java
@@ -27,7 +27,7 @@ import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.math.geom.Polygons;
 import com.sk89q.worldedit.regions.iterator.FlatRegion3DIterator;
 import com.sk89q.worldedit.regions.iterator.FlatRegionIterator;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.World;
 
 import java.math.BigDecimal;
@@ -220,7 +220,7 @@ public class CylinderRegion extends AbstractRegion implements FlatRegion {
         }
 
         if ((diff.getBlockX() & 1) + (diff.getBlockZ() & 1) != 0) {
-            throw new RegionOperationException(TranslatableComponent.of("worldedit.selection.cylinder.error.even-horizontal"));
+            throw new RegionOperationException(Component.translatable("worldedit.selection.cylinder.error.even-horizontal"));
         }
 
         return diff.divide(2).floor();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/EllipsoidRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/EllipsoidRegion.java
@@ -22,7 +22,7 @@ package com.sk89q.worldedit.regions;
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.storage.ChunkStore;
 
@@ -114,7 +114,7 @@ public class EllipsoidRegion extends AbstractRegion {
         BlockVector3 diff = BlockVector3.ZERO.add(changes);
 
         if ((diff.getBlockX() & 1) + (diff.getBlockY() & 1) + (diff.getBlockZ() & 1) != 0) {
-            throw new RegionOperationException(TranslatableComponent.of("worldedit.selection.ellipsoid.error.even-horizontal"));
+            throw new RegionOperationException(Component.translatable("worldedit.selection.ellipsoid.error.even-horizontal"));
         }
 
         return diff.divide(2).floor();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/NullRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/NullRegion.java
@@ -22,7 +22,7 @@ package com.sk89q.worldedit.regions;
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.World;
 
 import java.util.Collections;
@@ -75,17 +75,17 @@ public class NullRegion implements Region {
 
     @Override
     public void expand(BlockVector3... changes) throws RegionOperationException {
-        throw new RegionOperationException(TranslatableComponent.of("worldedit.selection.null.error.immutable"));
+        throw new RegionOperationException(Component.translatable("worldedit.selection.null.error.immutable"));
     }
 
     @Override
     public void contract(BlockVector3... changes) throws RegionOperationException {
-        throw new RegionOperationException(TranslatableComponent.of("worldedit.selection.null.error.immutable"));
+        throw new RegionOperationException(Component.translatable("worldedit.selection.null.error.immutable"));
     }
 
     @Override
     public void shift(BlockVector3 change) throws RegionOperationException {
-        throw new RegionOperationException(TranslatableComponent.of("worldedit.selection.null.error.immutable"));
+        throw new RegionOperationException(Component.translatable("worldedit.selection.null.error.immutable"));
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegion.java
@@ -23,7 +23,7 @@ import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.iterator.FlatRegion3DIterator;
 import com.sk89q.worldedit.regions.iterator.FlatRegionIterator;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.World;
 
 import java.math.BigDecimal;
@@ -246,7 +246,7 @@ public class Polygonal2DRegion extends AbstractRegion implements FlatRegion {
     public void expand(BlockVector3... changes) throws RegionOperationException {
         for (BlockVector3 change : changes) {
             if (change.getBlockX() != 0 || change.getBlockZ() != 0) {
-                throw new RegionOperationException(TranslatableComponent.of("worldedit.selection.polygon2d.error.expand-only-vertical"));
+                throw new RegionOperationException(Component.translatable("worldedit.selection.polygon2d.error.expand-only-vertical"));
             }
             int changeY = change.getBlockY();
             if (changeY > 0) {
@@ -262,7 +262,7 @@ public class Polygonal2DRegion extends AbstractRegion implements FlatRegion {
     public void contract(BlockVector3... changes) throws RegionOperationException {
         for (BlockVector3 change : changes) {
             if (change.getBlockX() != 0 || change.getBlockZ() != 0) {
-                throw new RegionOperationException(TranslatableComponent.of("worldedit.selection.polygon2d.error.contract-only-vertical"));
+                throw new RegionOperationException(Component.translatable("worldedit.selection.polygon2d.error.contract-only-vertical"));
             }
             int changeY = change.getBlockY();
             if (changeY > 0) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/RegionIntersection.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/RegionIntersection.java
@@ -21,7 +21,7 @@ package com.sk89q.worldedit.regions;
 
 import com.google.common.collect.Iterators;
 import com.sk89q.worldedit.math.BlockVector3;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.World;
 
 import java.util.ArrayList;
@@ -110,13 +110,13 @@ public class RegionIntersection extends AbstractRegion {
     @Override
     public void expand(BlockVector3... changes) throws RegionOperationException {
         checkNotNull(changes);
-        throw new RegionOperationException(TranslatableComponent.of("worldedit.selection.intersection.error.cannot-expand"));
+        throw new RegionOperationException(Component.translatable("worldedit.selection.intersection.error.cannot-expand"));
     }
 
     @Override
     public void contract(BlockVector3... changes) throws RegionOperationException {
         checkNotNull(changes);
-        throw new RegionOperationException(TranslatableComponent.of("worldedit.selection.intersection.error.cannot-contract"));
+        throw new RegionOperationException(Component.translatable("worldedit.selection.intersection.error.cannot-contract"));
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/RegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/RegionSelector.java
@@ -28,8 +28,7 @@ import com.sk89q.worldedit.internal.util.NonAbstractForCompatibility;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.selector.limit.SelectorLimits;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 import com.sk89q.worldedit.world.World;
 
 import java.util.List;
@@ -193,7 +192,7 @@ public interface RegionSelector {
      */
     default List<Component> getSelectionInfoLines() {
         return getInformationLines().stream()
-                .map(line -> TextComponent.of(line, TextColor.LIGHT_PURPLE))
+                .map(line -> Component.text(line, NamedTextColor.LIGHT_PURPLE))
                 .collect(Collectors.toList());
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/TransformRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/TransformRegion.java
@@ -24,7 +24,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.math.transform.Identity;
 import com.sk89q.worldedit.math.transform.Transform;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.World;
 
 import java.util.ArrayList;
@@ -134,17 +134,17 @@ public class TransformRegion extends AbstractRegion {
 
     @Override
     public void expand(BlockVector3... changes) throws RegionOperationException {
-        throw new RegionOperationException(TranslatableComponent.of("worldedit.selection.transform.error.cannot-expand"));
+        throw new RegionOperationException(Component.translatable("worldedit.selection.transform.error.cannot-expand"));
     }
 
     @Override
     public void contract(BlockVector3... changes) throws RegionOperationException {
-        throw new RegionOperationException(TranslatableComponent.of("worldedit.selection.transform.error.cannot-contract"));
+        throw new RegionOperationException(Component.translatable("worldedit.selection.transform.error.cannot-contract"));
     }
 
     @Override
     public void shift(BlockVector3 change) throws RegionOperationException {
-        throw new RegionOperationException(TranslatableComponent.of("worldedit.selection.transform.error.cannot-change"));
+        throw new RegionOperationException(Component.translatable("worldedit.selection.transform.error.cannot-change"));
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/ConvexPolyhedralRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/ConvexPolyhedralRegionSelector.java
@@ -34,8 +34,6 @@ import com.sk89q.worldedit.regions.RegionSelector;
 import com.sk89q.worldedit.regions.polyhedron.Triangle;
 import com.sk89q.worldedit.regions.selector.limit.SelectorLimits;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.World;
 
 import java.util.ArrayList;
@@ -188,8 +186,8 @@ public class ConvexPolyhedralRegionSelector implements RegionSelector, CUIRegion
     public List<Component> getSelectionInfoLines() {
         List<Component> ret = new ArrayList<>();
 
-        ret.add(TranslatableComponent.of("worldedit.selection.convex.info.vertices", TextComponent.of(region.getVertices().size())));
-        ret.add(TranslatableComponent.of("worldedit.selection.convex.info.triangles", TextComponent.of(region.getTriangles().size())));
+        ret.add(Component.translatable("worldedit.selection.convex.info.vertices", Component.text(region.getVertices().size())));
+        ret.add(Component.translatable("worldedit.selection.convex.info.triangles", Component.text(region.getTriangles().size())));
 
         return ret;
     }
@@ -203,7 +201,7 @@ public class ConvexPolyhedralRegionSelector implements RegionSelector, CUIRegion
         session.dispatchCUIEvent(player, new SelectionShapeEvent(getTypeID()));
         session.describeCUI(player);
 
-        player.printInfo(TranslatableComponent.of("worldedit.selection.convex.explain.primary", TextComponent.of(pos.toString())));
+        player.printInfo(Component.translatable("worldedit.selection.convex.explain.primary", Component.text(pos.toString())));
     }
 
     @Override
@@ -214,7 +212,7 @@ public class ConvexPolyhedralRegionSelector implements RegionSelector, CUIRegion
 
         session.describeCUI(player);
 
-        player.printInfo(TranslatableComponent.of("worldedit.selection.convex.explain.secondary", TextComponent.of(pos.toString())));
+        player.printInfo(Component.translatable("worldedit.selection.convex.explain.secondary", Component.text(pos.toString())));
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/CuboidRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/CuboidRegionSelector.java
@@ -31,8 +31,6 @@ import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionSelector;
 import com.sk89q.worldedit.regions.selector.limit.SelectorLimits;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
 import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
 import com.sk89q.worldedit.world.World;
@@ -158,13 +156,13 @@ public class CuboidRegionSelector implements RegionSelector, CUIRegion {
         checkNotNull(pos);
 
         if (position1 != null && position2 != null) {
-            player.printInfo(TranslatableComponent.of(
+            player.printInfo(Component.translatable(
                     "worldedit.selection.cuboid.explain.primary-area",
-                    TextComponent.of(position1.toString()),
-                    TextComponent.of(region.getVolume())
+                    Component.text(position1.toString()),
+                    Component.text(region.getVolume())
             ));
         } else if (position1 != null) {
-            player.printInfo(TranslatableComponent.of("worldedit.selection.cuboid.explain.primary", TextComponent.of(position1.toString())));
+            player.printInfo(Component.translatable("worldedit.selection.cuboid.explain.primary", Component.text(position1.toString())));
         }
 
         session.dispatchCUIEvent(player, new SelectionPointEvent(0, pos, getVolume()));
@@ -177,13 +175,13 @@ public class CuboidRegionSelector implements RegionSelector, CUIRegion {
         checkNotNull(pos);
 
         if (position1 != null && position2 != null) {
-            player.printInfo(TranslatableComponent.of(
+            player.printInfo(Component.translatable(
                     "worldedit.selection.cuboid.explain.secondary-area",
-                    TextComponent.of(position2.toString()),
-                    TextComponent.of(region.getVolume())
+                    Component.text(position2.toString()),
+                    Component.text(region.getVolume())
             ));
         } else if (position2 != null) {
-            player.printInfo(TranslatableComponent.of("worldedit.selection.cuboid.explain.secondary", TextComponent.of(position2.toString())));
+            player.printInfo(Component.translatable("worldedit.selection.cuboid.explain.secondary", Component.text(position2.toString())));
         }
 
         session.dispatchCUIEvent(player, new SelectionPointEvent(1, pos, getVolume()));
@@ -257,15 +255,15 @@ public class CuboidRegionSelector implements RegionSelector, CUIRegion {
         final List<Component> lines = new ArrayList<>();
 
         if (position1 != null) {
-            lines.add(TranslatableComponent.of("worldedit.selection.cuboid.info.pos1", TextComponent.of(position1.toString())
-                    .clickEvent(ClickEvent.of(ClickEvent.Action.COPY_TO_CLIPBOARD, position1.toParserString()))
-                    .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TextComponent.of("Click to copy")))));
+            lines.add(Component.translatable("worldedit.selection.cuboid.info.pos1", Component.text(position1.toString())
+                    .clickEvent(ClickEvent.copyToClipboard(position1.toParserString()))
+                    .hoverEvent(HoverEvent.showText(Component.text("Click to copy")))));
         }
 
         if (position2 != null) {
-            lines.add(TranslatableComponent.of("worldedit.selection.cuboid.info.pos2", TextComponent.of(position2.toString())
-                    .clickEvent(ClickEvent.of(ClickEvent.Action.COPY_TO_CLIPBOARD, position2.toParserString()))
-                    .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TextComponent.of("Click to copy")))));
+            lines.add(Component.translatable("worldedit.selection.cuboid.info.pos2", Component.text(position2.toString())
+                    .clickEvent(ClickEvent.copyToClipboard(position2.toParserString()))
+                    .hoverEvent(HoverEvent.showText(Component.text("Click to copy")))));
         }
 
         return lines;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/CylinderRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/CylinderRegionSelector.java
@@ -35,8 +35,6 @@ import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionSelector;
 import com.sk89q.worldedit.regions.selector.limit.SelectorLimits;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
 import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
 import com.sk89q.worldedit.world.World;
@@ -184,7 +182,7 @@ public class CylinderRegionSelector implements RegionSelector, CUIRegion {
 
     @Override
     public void explainPrimarySelection(Actor player, LocalSession session, BlockVector3 pos) {
-        player.printInfo(TranslatableComponent.of("worldedit.selection.cylinder.explain.primary", TextComponent.of(pos.toString())));
+        player.printInfo(Component.translatable("worldedit.selection.cylinder.explain.primary", Component.text(pos.toString())));
 
         session.describeCUI(player);
     }
@@ -192,14 +190,14 @@ public class CylinderRegionSelector implements RegionSelector, CUIRegion {
     @Override
     public void explainSecondarySelection(Actor player, LocalSession session, BlockVector3 pos) {
         if (selectedCenter) {
-            player.printInfo(TranslatableComponent.of(
+            player.printInfo(Component.translatable(
                     "worldedit.selection.cylinder.explain.secondary",
-                    TextComponent.of(NUMBER_FORMAT.format(region.getRadius().getX())),
-                    TextComponent.of(NUMBER_FORMAT.format(region.getRadius().getZ())),
-                    TextComponent.of(region.getVolume())
+                    Component.text(NUMBER_FORMAT.format(region.getRadius().getX())),
+                    Component.text(NUMBER_FORMAT.format(region.getRadius().getZ())),
+                    Component.text(region.getVolume())
             ));
         } else {
-            player.printError(TranslatableComponent.of("worldedit.selection.cylinder.explain.secondary-missing"));
+            player.printError(Component.translatable("worldedit.selection.cylinder.explain.secondary-missing"));
             return;
         }
 
@@ -260,12 +258,12 @@ public class CylinderRegionSelector implements RegionSelector, CUIRegion {
 
         if (!region.getCenter().equals(Vector3.ZERO)) {
             Vector3 center = region.getCenter();
-            lines.add(TranslatableComponent.of("worldedit.selection.cylinder.info.center", TextComponent.of(center.toString())
-                    .clickEvent(ClickEvent.of(ClickEvent.Action.COPY_TO_CLIPBOARD, center.toParserString()))
-                    .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TextComponent.of("Click to copy")))));
+            lines.add(Component.translatable("worldedit.selection.cylinder.info.center", Component.text(center.toString())
+                    .clickEvent(ClickEvent.copyToClipboard(center.toParserString()))
+                    .hoverEvent(HoverEvent.showText(Component.text("Click to copy")))));
         }
         if (!region.getRadius().equals(Vector2.ZERO)) {
-            lines.add(TranslatableComponent.of("worldedit.selection.cylinder.info.radius", TextComponent.of(region.getRadius().toString())));
+            lines.add(Component.translatable("worldedit.selection.cylinder.info.radius", Component.text(region.getRadius().toString())));
         }
 
         return lines;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/EllipsoidRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/EllipsoidRegionSelector.java
@@ -32,8 +32,6 @@ import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionSelector;
 import com.sk89q.worldedit.regions.selector.limit.SelectorLimits;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
 import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
 import com.sk89q.worldedit.world.World;
@@ -161,15 +159,15 @@ public class EllipsoidRegionSelector implements RegionSelector, CUIRegion {
     @Override
     public void explainPrimarySelection(Actor player, LocalSession session, BlockVector3 pos) {
         if (isDefined()) {
-            player.printInfo(TranslatableComponent.of(
+            player.printInfo(Component.translatable(
                     "worldedit.selection.ellipsoid.explain.primary-area",
-                    TextComponent.of(region.getCenter().toString()),
-                    TextComponent.of(region.getVolume())
+                    Component.text(region.getCenter().toString()),
+                    Component.text(region.getVolume())
             ));
         } else {
-            player.printInfo(TranslatableComponent.of(
+            player.printInfo(Component.translatable(
                     "worldedit.selection.ellipsoid.explain.primary",
-                    TextComponent.of(region.getCenter().toString())
+                    Component.text(region.getCenter().toString())
             ));
         }
 
@@ -179,15 +177,15 @@ public class EllipsoidRegionSelector implements RegionSelector, CUIRegion {
     @Override
     public void explainSecondarySelection(Actor player, LocalSession session, BlockVector3 pos) {
         if (isDefined()) {
-            player.printInfo(TranslatableComponent.of(
+            player.printInfo(Component.translatable(
                     "worldedit.selection.ellipsoid.explain.secondary-area",
-                    TextComponent.of(region.getRadius().toString()),
-                    TextComponent.of(region.getVolume())
+                    Component.text(region.getRadius().toString()),
+                    Component.text(region.getVolume())
             ));
         } else {
-            player.printInfo(TranslatableComponent.of(
+            player.printInfo(Component.translatable(
                     "worldedit.selection.ellipsoid.explain.secondary",
-                    TextComponent.of(region.getRadius().toString())
+                    Component.text(region.getRadius().toString())
             ));
         }
 
@@ -240,14 +238,14 @@ public class EllipsoidRegionSelector implements RegionSelector, CUIRegion {
 
         final Vector3 center = region.getCenter();
         if (center.lengthSq() > 0) {
-            lines.add(TranslatableComponent.of("worldedit.selection.ellipsoid.info.center", TextComponent.of(center.toString())
-                    .clickEvent(ClickEvent.of(ClickEvent.Action.COPY_TO_CLIPBOARD, center.toParserString()))
-                    .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TextComponent.of("Click to copy")))));
+            lines.add(Component.translatable("worldedit.selection.ellipsoid.info.center", Component.text(center.toString())
+                    .clickEvent(ClickEvent.copyToClipboard(center.toParserString()))
+                    .hoverEvent(HoverEvent.showText(Component.text("Click to copy")))));
         }
 
         final Vector3 radius = region.getRadius();
         if (radius.lengthSq() > 0) {
-            lines.add(TranslatableComponent.of("worldedit.selection.ellipsoid.info.radius", TextComponent.of(radius.toString())));
+            lines.add(Component.translatable("worldedit.selection.ellipsoid.info.radius", Component.text(radius.toString())));
         }
 
         return lines;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/ExtendingCuboidRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/ExtendingCuboidRegionSelector.java
@@ -24,8 +24,7 @@ import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.RegionSelector;
 import com.sk89q.worldedit.regions.selector.limit.SelectorLimits;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.World;
 
 import javax.annotation.Nullable;
@@ -131,10 +130,10 @@ public class ExtendingCuboidRegionSelector extends CuboidRegionSelector {
 
     @Override
     public void explainPrimarySelection(Actor player, LocalSession session, BlockVector3 pos) {
-        player.printInfo(TranslatableComponent.of(
+        player.printInfo(Component.translatable(
                 "worldedit.selection.extend.explain.primary",
-                TextComponent.of(pos.toString()),
-                TextComponent.of(region.getVolume())
+                Component.text(pos.toString()),
+                Component.text(region.getVolume())
         ));
 
         explainRegionAdjust(player, session);
@@ -142,10 +141,10 @@ public class ExtendingCuboidRegionSelector extends CuboidRegionSelector {
 
     @Override
     public void explainSecondarySelection(Actor player, LocalSession session, BlockVector3 pos) {
-        player.printInfo(TranslatableComponent.of(
+        player.printInfo(Component.translatable(
                 "worldedit.selection.extend.explain.secondary",
-                TextComponent.of(pos.toString()),
-                TextComponent.of(region.getVolume())
+                Component.text(pos.toString()),
+                Component.text(region.getVolume())
         ));
 
         explainRegionAdjust(player, session);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/Polygonal2DRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/Polygonal2DRegionSelector.java
@@ -33,8 +33,6 @@ import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionSelector;
 import com.sk89q.worldedit.regions.selector.limit.SelectorLimits;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.World;
 
 import java.util.Collections;
@@ -165,7 +163,7 @@ public class Polygonal2DRegionSelector implements RegionSelector, CUIRegion {
 
     @Override
     public void explainPrimarySelection(Actor player, LocalSession session, BlockVector3 pos) {
-        player.printInfo(TranslatableComponent.of("worldedit.selection.polygon2d.explain.primary", TextComponent.of(pos.toString())));
+        player.printInfo(Component.translatable("worldedit.selection.polygon2d.explain.primary", Component.text(pos.toString())));
 
         session.dispatchCUIEvent(player, new SelectionShapeEvent(getTypeID()));
         session.dispatchCUIEvent(player, new SelectionPoint2DEvent(0, pos, getVolume()));
@@ -174,10 +172,10 @@ public class Polygonal2DRegionSelector implements RegionSelector, CUIRegion {
 
     @Override
     public void explainSecondarySelection(Actor player, LocalSession session, BlockVector3 pos) {
-        player.printInfo(TranslatableComponent.of(
+        player.printInfo(Component.translatable(
                 "worldedit.selection.polygon2d.explain.secondary",
-                TextComponent.of(region.size()),
-                TextComponent.of(pos.toString())
+                Component.text(region.size()),
+                Component.text(pos.toString())
         ));
 
         session.dispatchCUIEvent(player, new SelectionPoint2DEvent(region.size() - 1, pos, getVolume()));
@@ -237,7 +235,7 @@ public class Polygonal2DRegionSelector implements RegionSelector, CUIRegion {
 
     @Override
     public List<Component> getSelectionInfoLines() {
-        return Collections.singletonList(TranslatableComponent.of("worldedit.selection.polygon2d.info", TextComponent.of(region.size())));
+        return Collections.singletonList(Component.translatable("worldedit.selection.polygon2d.info", Component.text(region.size())));
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/SphereRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/SphereRegionSelector.java
@@ -25,8 +25,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.regions.RegionSelector;
 import com.sk89q.worldedit.regions.selector.limit.SelectorLimits;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.World;
 
 import javax.annotation.Nullable;
@@ -94,13 +93,13 @@ public class SphereRegionSelector extends EllipsoidRegionSelector {
     @Override
     public void explainSecondarySelection(Actor player, LocalSession session, BlockVector3 pos) {
         if (isDefined()) {
-            player.printInfo(TranslatableComponent.of(
+            player.printInfo(Component.translatable(
                     "worldedit.selection.sphere.explain.secondary-defined",
-                    TextComponent.of(region.getRadius().getX()),
-                    TextComponent.of(region.getVolume())
+                    Component.text(region.getRadius().getX()),
+                    Component.text(region.getVolume())
             ));
         } else {
-            player.printInfo(TranslatableComponent.of("worldedit.selection.sphere.explain.secondary", TextComponent.of(region.getRadius().getX())));
+            player.printInfo(Component.translatable("worldedit.selection.sphere.explain.secondary", Component.text(region.getRadius().getX())));
         }
 
         session.describeCUI(player);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/scripting/CraftScriptContext.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/scripting/CraftScriptContext.java
@@ -33,8 +33,7 @@ import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.internal.expression.invoke.ReturnException;
 import com.sk89q.worldedit.session.request.Request;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.io.file.FilenameException;
 import com.sk89q.worldedit.world.block.BaseBlock;
 
@@ -119,7 +118,7 @@ public class CraftScriptContext extends CraftScriptEnvironment {
      * @param message a message
      */
     public void print(String message) {
-        player.printInfo(TextComponent.of(message));
+        player.printInfo(Component.text(message));
     }
 
     /**
@@ -128,7 +127,7 @@ public class CraftScriptContext extends CraftScriptEnvironment {
      * @param message a message
      */
     public void error(String message) {
-        player.printError(TextComponent.of(message));
+        player.printError(Component.text(message));
     }
 
     /**
@@ -137,7 +136,7 @@ public class CraftScriptContext extends CraftScriptEnvironment {
      * @param message a message
      */
     public void printRaw(String message) {
-        player.print(TextComponent.of(message));
+        player.print(Component.text(message));
     }
 
     /**
@@ -151,7 +150,7 @@ public class CraftScriptContext extends CraftScriptEnvironment {
     public void checkArgs(int min, int max, String usage)
             throws InsufficientArgumentsException {
         if (args.length <= min || (max != -1 && args.length - 1 > max)) {
-            throw new InsufficientArgumentsException(TranslatableComponent.of("worldedit.error.incorrect-usage", TextComponent.of(usage)));
+            throw new InsufficientArgumentsException(Component.translatable("worldedit.error.incorrect-usage", Component.text(usage)));
         }
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/Placement.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/Placement.java
@@ -24,8 +24,6 @@ import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.RegionSelector;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 
 public class Placement {
     private final PlacementType placementType;
@@ -55,13 +53,13 @@ public class Placement {
 
     public Component getInfo() {
         if (offset.equals(BlockVector3.ZERO)) {
-            return TranslatableComponent.of(placementType.getTranslationKey());
+            return Component.translatable(placementType.getTranslationKey());
         } else {
-            return TranslatableComponent.of(
+            return Component.translatable(
                     placementType.getTranslationKeyWithOffset(),
-                    TextComponent.of(offset.getX()),
-                    TextComponent.of(offset.getY()),
-                    TextComponent.of(offset.getZ())
+                    Component.text(offset.getX()),
+                    Component.text(offset.getY()),
+                    Component.text(offset.getZ())
             );
         }
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/CodeFormat.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/CodeFormat.java
@@ -20,7 +20,7 @@
 package com.sk89q.worldedit.util.formatting.component;
 
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 
 /**
  * Represents a fragment representing a command that is to be typed.
@@ -28,7 +28,7 @@ import com.sk89q.worldedit.util.formatting.text.format.TextColor;
 public class CodeFormat extends TextComponentProducer {
 
     private CodeFormat() {
-        getBuilder().content("").color(TextColor.AQUA);
+        getBuilder().color(NamedTextColor.AQUA);
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/CommandListBox.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/CommandListBox.java
@@ -24,7 +24,7 @@ import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
 import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 
 import java.util.List;
 
@@ -60,7 +60,7 @@ public class CommandListBox extends PaginationBox {
 
     @Deprecated
     public void appendCommand(String alias, String description, String insertion) {
-        appendCommand(alias, TextComponent.of(description), insertion);
+        appendCommand(alias, Component.text(description), insertion);
     }
 
     public void appendCommand(String alias, Component description, String insertion) {
@@ -90,18 +90,18 @@ public class CommandListBox extends PaginationBox {
             TextComponentProducer line = new TextComponentProducer();
             if (!hideHelp) {
                 line.append(SubtleFormat.wrap("? ")
-                        .clickEvent(ClickEvent.of(ClickEvent.Action.RUN_COMMAND, CommandListBox.this.helpCommand + " " + insertion))
-                        .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TextComponent.of("Additional Help"))));
+                        .clickEvent(ClickEvent.runCommand(CommandListBox.this.helpCommand + " " + insertion))
+                        .hoverEvent(HoverEvent.showText(Component.text("Additional Help"))));
             }
-            TextComponent command = TextComponent.of(alias, TextColor.GOLD);
+            TextComponent command = Component.text(alias, NamedTextColor.GOLD);
             if (insertion == null) {
                 line.append(command);
             } else {
                 line.append(command
-                        .clickEvent(ClickEvent.of(ClickEvent.Action.SUGGEST_COMMAND, insertion))
-                        .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TextComponent.of("Click to select"))));
+                        .clickEvent(ClickEvent.suggestCommand(insertion))
+                        .hoverEvent(HoverEvent.showText(Component.text("Click to select"))));
             }
-            return line.append(TextComponent.of(": ")).append(description).create();
+            return line.append(Component.text(": ")).append(description).create();
         }
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/CommandUsageBox.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/CommandUsageBox.java
@@ -20,7 +20,7 @@
 package com.sk89q.worldedit.util.formatting.component;
 
 import com.google.common.collect.Iterables;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
 import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
 import com.sk89q.worldedit.util.formatting.text.format.TextDecoration;
@@ -71,14 +71,14 @@ public class CommandUsageBox extends TextComponentProducer {
         TextComponentProducer boxContent = new TextComponentProducer()
             .append(HelpGenerator.create(commands).getFullHelp());
         if (getSubCommands(Iterables.getLast(commands)).size() > 0) {
-            boxContent.append(TextComponent.newline())
-                .append(ColorConfig.helpText().wrap(TextComponent.builder("> ")
-                    .append(ColorConfig.mainText().wrap(TextComponent.builder("List Subcommands")
+            boxContent.append(Component.newline())
+                .append(ColorConfig.helpText().wrap(Component.text("> ")
+                    .append(ColorConfig.mainText().wrap(Component.text("List Subcommands")
                         .decoration(TextDecoration.ITALIC, true)
                         .clickEvent(ClickEvent.runCommand(helpRootCommand + " -s " + commandString))
-                        .hoverEvent(HoverEvent.showText(TextComponent.of("List all subcommands of this command")))
-                        .build()))
-                    .build()));
+                        .hoverEvent(HoverEvent.showText(Component.text("List all subcommands of this command")))
+                    ))
+                ));
         }
         MessageBox box = new MessageBox("Help for " + commandString,
             boxContent);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/ErrorFormat.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/ErrorFormat.java
@@ -20,7 +20,7 @@
 package com.sk89q.worldedit.util.formatting.component;
 
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 
 /**
  * Represents a fragment representing an error.
@@ -31,7 +31,7 @@ public class ErrorFormat extends TextComponentProducer {
      * Create a new instance.
      */
     private ErrorFormat() {
-        getBuilder().content("").color(TextColor.RED);
+        getBuilder().color(NamedTextColor.RED);
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/LabelFormat.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/LabelFormat.java
@@ -20,7 +20,7 @@
 package com.sk89q.worldedit.util.formatting.component;
 
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 
 /**
  * Represents a fragment representing a label.
@@ -31,7 +31,7 @@ public class LabelFormat extends TextComponentProducer {
      * Create a new instance.
      */
     private LabelFormat() {
-        getBuilder().content("").color(TextColor.YELLOW);
+        getBuilder().content("").color(NamedTextColor.YELLOW);
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/MessageBox.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/MessageBox.java
@@ -23,8 +23,10 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 import com.sk89q.worldedit.util.formatting.text.format.TextColor;
 import com.sk89q.worldedit.util.formatting.text.format.TextDecoration;
+import com.sk89q.worldedit.util.formatting.text.serializer.plain.PlainTextComponentSerializer;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -42,7 +44,7 @@ public class MessageBox extends TextComponentProducer {
      * Create a new box.
      */
     public MessageBox(String title, TextComponentProducer contents) {
-        this(title, contents, TextColor.YELLOW);
+        this(title, contents, NamedTextColor.YELLOW);
     }
 
     /**
@@ -52,7 +54,7 @@ public class MessageBox extends TextComponentProducer {
         checkNotNull(title);
 
         this.borderColor = borderColor;
-        append(centerAndBorder(TextComponent.of(title))).newline();
+        append(centerAndBorder(Component.text(title))).newline();
         this.contents = contents;
     }
 
@@ -64,11 +66,11 @@ public class MessageBox extends TextComponentProducer {
             if (side > 1) {
                 line.append(createBorder(side - 1));
             }
-            line.append(TextComponent.space());
+            line.append(Component.space());
         }
         line.append(text);
         if (side > 0) {
-            line.append(TextComponent.space());
+            line.append(Component.space());
             if (side > 1) {
                 line.append(createBorder(side - 1));
             }
@@ -77,12 +79,11 @@ public class MessageBox extends TextComponentProducer {
     }
 
     private static int getLength(TextComponent text) {
-        return text.content().length() + text.children().stream().filter(c -> c instanceof TextComponent)
-                .mapToInt(c -> getLength((TextComponent) c)).sum();
+        return PlainTextComponentSerializer.plainText().serialize(text).length();
     }
 
     private TextComponent createBorder(int count) {
-        return TextComponent.of(Strings.repeat("-", count),
+        return Component.text(Strings.repeat("-", count),
                 borderColor, Sets.newHashSet(TextDecoration.STRIKETHROUGH));
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/PaginationBox.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/PaginationBox.java
@@ -21,10 +21,9 @@ package com.sk89q.worldedit.util.formatting.component;
 
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
 import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -85,7 +84,7 @@ public abstract class PaginationBox extends MessageBox {
         }
         int pageCount = (int) Math.ceil(getComponentsSize() / (double) componentsPerPage);
         if (page < 1 || page > pageCount) {
-            throw new InvalidComponentException(TranslatableComponent.of("worldedit.error.invalid-page"));
+            throw new InvalidComponentException(Component.translatable("worldedit.error.invalid-page"));
         }
         currentPage = page;
         final int lastComp = Math.min(page * componentsPerPage, getComponentsSize());
@@ -99,23 +98,23 @@ public abstract class PaginationBox extends MessageBox {
             return super.create();
         }
         getContents().newline();
-        TextComponent pageNumberComponent = TextComponent.of("Page ", TextColor.YELLOW)
-                .append(TextComponent.of(String.valueOf(page), TextColor.GOLD))
-                .append(TextComponent.of(" of "))
-                .append(TextComponent.of(String.valueOf(pageCount), TextColor.GOLD));
+        TextComponent pageNumberComponent = Component.text("Page ", NamedTextColor.YELLOW)
+                .append(Component.text(String.valueOf(page), NamedTextColor.GOLD))
+                .append(Component.text(" of "))
+                .append(Component.text(String.valueOf(pageCount), NamedTextColor.GOLD));
         if (pageCommand != null) {
             TextComponentProducer navProducer = new TextComponentProducer();
             if (page > 1) {
-                TextComponent prevComponent = TextComponent.of("<<< ", TextColor.GOLD)
-                        .clickEvent(ClickEvent.of(ClickEvent.Action.RUN_COMMAND, pageCommand.replace("%page%", String.valueOf(page - 1))))
-                        .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TextComponent.of("Click to navigate")));
+                TextComponent prevComponent = Component.text("<<< ", NamedTextColor.GOLD)
+                        .clickEvent(ClickEvent.runCommand(pageCommand.replace("%page%", String.valueOf(page - 1))))
+                        .hoverEvent(HoverEvent.showText(Component.text("Click to navigate")));
                 navProducer.append(prevComponent);
             }
             navProducer.append(pageNumberComponent);
             if (page < pageCount) {
-                TextComponent nextComponent = TextComponent.of(" >>>", TextColor.GOLD)
-                        .clickEvent(ClickEvent.of(ClickEvent.Action.RUN_COMMAND, pageCommand.replace("%page%", String.valueOf(page + 1))))
-                        .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TextComponent.of("Click to navigate")));
+                TextComponent nextComponent = Component.text(" >>>", NamedTextColor.GOLD)
+                        .clickEvent(ClickEvent.runCommand(pageCommand.replace("%page%", String.valueOf(page + 1))))
+                        .hoverEvent(HoverEvent.showText(Component.text("Click to navigate")));
                 navProducer.append(nextComponent);
             }
             getContents().append(centerAndBorder(navProducer.create()));
@@ -132,7 +131,7 @@ public abstract class PaginationBox extends MessageBox {
 
     public static PaginationBox fromStrings(String header, @Nullable String pageCommand, List<String> lines) {
         return fromComponents(header, pageCommand, lines.stream()
-            .map(TextComponent::of)
+            .map(Component::text)
             .collect(Collectors.toList()));
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/SideEffectBox.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/SideEffectBox.java
@@ -26,15 +26,13 @@ import com.sk89q.worldedit.util.concurrency.LazyReference;
 import com.sk89q.worldedit.util.formatting.WorldEditText;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
 import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
-import java.util.stream.Collectors;
 
 public class SideEffectBox extends PaginationBox {
 
@@ -44,7 +42,7 @@ public class SideEffectBox extends PaginationBox {
             .filter(SideEffect::isExposed)
             .sorted(Comparator.comparing(effect ->
                 WorldEditText.reduceToText(
-                    TranslatableComponent.of(effect.getDisplayName()),
+                    Component.translatable(effect.getDisplayName()),
                     Locale.US
                 )
             ))
@@ -70,16 +68,16 @@ public class SideEffectBox extends PaginationBox {
         SideEffect effect = getSideEffects().get(number);
         SideEffect.State state = this.sideEffectSet.getState(effect);
 
-        TextComponent.Builder builder = TextComponent.builder();
-        builder = builder.append(TranslatableComponent.of(effect.getDisplayName(), TextColor.YELLOW)
-                .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TranslatableComponent.of(effect.getDescription()))));
+        TextComponent.Builder builder = Component.text();
+        builder.append(Component.translatable(effect.getDisplayName(), NamedTextColor.YELLOW)
+                .hoverEvent(HoverEvent.showText(Component.translatable(effect.getDescription()))));
         for (SideEffect.State uiState : SHOWN_VALUES) {
-            builder = builder.append(TextComponent.space());
-            builder = builder.append(TranslatableComponent.of(uiState.getDisplayName(), uiState == state ? TextColor.WHITE : TextColor.GRAY)
+            builder.append(Component.space());
+            builder.append(Component.translatable(uiState.getDisplayName(), uiState == state ? NamedTextColor.WHITE : NamedTextColor.GRAY)
                     .clickEvent(ClickEvent.runCommand("//perf -h " + effect.name().toLowerCase(Locale.US) + " " + uiState.name().toLowerCase(Locale.US)))
                     .hoverEvent(HoverEvent.showText(uiState == state
-                            ? TranslatableComponent.of("worldedit.sideeffect.box.current")
-                            : TranslatableComponent.of("worldedit.sideeffect.box.change-to", TranslatableComponent.of(uiState.getDisplayName()))
+                            ? Component.translatable("worldedit.sideeffect.box.current")
+                            : Component.translatable("worldedit.sideeffect.box.change-to", Component.translatable(uiState.getDisplayName()))
                     ))
             );
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/SubtleFormat.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/SubtleFormat.java
@@ -20,7 +20,7 @@
 package com.sk89q.worldedit.util.formatting.component;
 
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 
 /**
  * Represents a subtle part of the message.
@@ -31,7 +31,7 @@ public class SubtleFormat extends TextComponentProducer {
      * Create a new instance.
      */
     private SubtleFormat() {
-        getBuilder().content("").color(TextColor.GRAY);
+        getBuilder().color(NamedTextColor.GRAY);
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/TextComponentProducer.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/TextComponentProducer.java
@@ -22,9 +22,13 @@ package com.sk89q.worldedit.util.formatting.component;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
 
+/**
+ * @deprecated do not use anymore, use adventure directly
+ */
+@Deprecated
 public class TextComponentProducer {
 
-    private TextComponent.Builder builder = TextComponent.builder().content("");
+    private TextComponent.Builder builder = Component.text();
 
     public TextComponent.Builder getBuilder() {
         return builder;
@@ -48,7 +52,7 @@ public class TextComponentProducer {
      * @return The producer, for chaining
      */
     public TextComponentProducer append(String string) {
-        getBuilder().append(TextComponent.of(string));
+        getBuilder().append(Component.text(string));
         return this;
     }
 
@@ -58,7 +62,7 @@ public class TextComponentProducer {
      * @return The producer, for chaining
      */
     public TextComponentProducer newline() {
-        getBuilder().append(TextComponent.newline());
+        getBuilder().append(Component.newline());
         return this;
     }
 
@@ -77,7 +81,7 @@ public class TextComponentProducer {
      * @return The producer, for chaining
      */
     public TextComponentProducer reset() {
-        builder = TextComponent.builder().content("");
+        builder = Component.text();
         return this;
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/TextUtils.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/TextUtils.java
@@ -38,7 +38,7 @@ public class TextUtils {
      * @return The joined component
      */
     public static Component join(List<Component> components, Component joiner) {
-        TextComponent.Builder builder = TextComponent.builder();
+        TextComponent.Builder builder = Component.text();
         for (int i = 0; i < components.size(); i++) {
             builder.append(components.get(i));
             if (i < components.size() - 1) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/paste/ActorCallbackPaste.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/paste/ActorCallbackPaste.java
@@ -21,7 +21,7 @@ package com.sk89q.worldedit.util.paste;
 
 import com.sk89q.worldedit.command.util.AsyncCommandBuilder;
 import com.sk89q.worldedit.extension.platform.Actor;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.task.Supervisor;
 
@@ -71,8 +71,8 @@ public final class ActorCallbackPaste {
 
         AsyncCommandBuilder.wrap(task, sender)
                 .registerWithSupervisor(supervisor, "Submitting content to a pastebin service.")
-                .setDelayMessage(TranslatableComponent.of("worldedit.pastebin.uploading"))
-                .onSuccess((String) null, url -> sender.printInfo(successMessage.args(TextComponent.of(url.toString())).build()))
+                .setDelayMessage(Component.translatable("worldedit.pastebin.uploading"))
+                .onSuccess((String) null, url -> sender.printInfo(successMessage.args(Component.text(url.toString())).build()))
                 .onFailure("Failed to submit paste", null)
                 .buildAndExec(Pasters.getExecutor());
     }
@@ -88,13 +88,13 @@ public final class ActorCallbackPaste {
      * @param pasteMetadata The paste metadata
      * @param successMessage The message builder, given the URL as an arg
      */
-    public static void pastebin(Supervisor supervisor, final Actor sender, String content, PasteMetadata pasteMetadata, final TranslatableComponent.Builder successMessage) {
+    public static void pastebin(Supervisor supervisor, final Actor sender, String content, PasteMetadata pasteMetadata, final TranslatableComponent successMessage) {
         Callable<URL> task = paster.paste(content, pasteMetadata);
 
         AsyncCommandBuilder.wrap(task, sender)
             .registerWithSupervisor(supervisor, "Submitting content to a pastebin service.")
-            .setDelayMessage(TranslatableComponent.of("worldedit.pastebin.uploading"))
-            .onSuccess((String) null, url -> sender.printInfo(successMessage.args(TextComponent.of(url.toString())).build()))
+            .setDelayMessage(Component.translatable("worldedit.pastebin.uploading"))
+            .onSuccess((String) null, url -> sender.printInfo(successMessage.args(Component.text(url.toString()))))
             .onFailure("Failed to submit paste", null)
             .buildAndExec(Pasters.getExecutor());
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/translation/TranslationManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/translation/TranslationManager.java
@@ -85,9 +85,11 @@ public class TranslationManager {
         return type + '.' + parts[0] + '.' + parts[1].replace('/', '.');
     }
 
-    private final TranslatableComponentRenderer<Locale> friendlyComponentRenderer = TranslatableComponentRenderer.from(
-        this::getTranslation
-    );
+    private final TranslatableComponentRenderer<Locale> friendlyComponentRenderer = new TranslatableComponentRenderer<>() {
+        protected @Nullable MessageFormat translate(final String key, final Locale context) {
+            return getTranslation(context, key);
+        }
+    };
     private final Table<Locale, String, MessageFormat> translationTable = Tables.newCustomTable(
         new ConcurrentHashMap<>(), ConcurrentHashMap::new
     );

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/WorldUnloadedException.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/WorldUnloadedException.java
@@ -20,7 +20,7 @@
 package com.sk89q.worldedit.world;
 
 import com.sk89q.worldedit.WorldEditException;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.Component;
 
 /**
  * Thrown if the world has been unloaded.
@@ -31,6 +31,6 @@ public class WorldUnloadedException extends WorldEditException {
      * Create a new instance.
      */
     public WorldUnloadedException() {
-        super(TranslatableComponent.of("worldedit.error.world-unloaded"));
+        super(Component.translatable("worldedit.error.world-unloaded"));
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BaseBlock.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BaseBlock.java
@@ -20,12 +20,10 @@
 package com.sk89q.worldedit.world.block;
 
 import com.sk89q.jnbt.CompoundTag;
-import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.blocks.TileEntityBlock;
 import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.util.concurrency.LazyReference;
 import org.enginehub.linbus.format.snbt.LinStringIO;
-import org.enginehub.linbus.stream.exception.NbtWriteException;
 import org.enginehub.linbus.tree.LinCompoundTag;
 import org.enginehub.linbus.tree.LinStringTag;
 import org.enginehub.linbus.tree.LinTagType;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledBlockRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledBlockRegistry.java
@@ -21,8 +21,6 @@ package com.sk89q.worldedit.world.registry;
 
 import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.translation.TranslationManager;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
@@ -46,9 +44,9 @@ public class BundledBlockRegistry implements BlockRegistry {
             // Some vanilla MC blocks have overrides so we need this name here
             // Most platforms should be overriding this anyways, so it likely doesn't matter
             // too much!
-            return TextComponent.of(blockEntry.localizedName);
+            return Component.text(blockEntry.localizedName);
         }
-        return TranslatableComponent.of(
+        return Component.translatable(
             TranslationManager.makeTranslationKey("block", blockType.getId())
         );
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledItemRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledItemRegistry.java
@@ -20,8 +20,6 @@
 package com.sk89q.worldedit.world.registry;
 
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.translation.TranslationManager;
 import com.sk89q.worldedit.world.item.ItemType;
 
@@ -45,9 +43,9 @@ public class BundledItemRegistry implements ItemRegistry {
             // Some vanilla MC items have overrides so we need this name here
             // Most platforms should be overriding this anyways, so it likely doesn't matter
             // too much!
-            return TextComponent.of(itemEntry.localizedName);
+            return Component.text(itemEntry.localizedName);
         }
-        return TranslatableComponent.of(
+        return Component.translatable(
             TranslationManager.makeTranslationKey("item", itemType.getId())
         );
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/ItemRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/ItemRegistry.java
@@ -20,8 +20,8 @@
 package com.sk89q.worldedit.world.registry;
 
 import com.sk89q.worldedit.blocks.BaseItemStack;
-import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.item.ItemType;
+import com.sk89q.worldedit.util.formatting.text.Component;
 
 import javax.annotation.Nullable;
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/NullBiomeRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/NullBiomeRegistry.java
@@ -20,7 +20,6 @@
 package com.sk89q.worldedit.world.registry;
 
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.translation.TranslationManager;
 import com.sk89q.worldedit.world.biome.BiomeData;
 import com.sk89q.worldedit.world.biome.BiomeType;
@@ -40,7 +39,7 @@ public class NullBiomeRegistry implements BiomeRegistry {
 
     @Override
     public Component getRichName(BiomeType biomeType) {
-        return TranslatableComponent.of(
+        return Component.translatable(
             TranslationManager.makeTranslationKey("biome", biomeType.getId())
         );
     }

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricBiomeRegistry.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricBiomeRegistry.java
@@ -20,7 +20,6 @@
 package com.sk89q.worldedit.fabric;
 
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.biome.BiomeData;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.registry.BiomeRegistry;
@@ -34,7 +33,7 @@ class FabricBiomeRegistry implements BiomeRegistry {
 
     @Override
     public Component getRichName(BiomeType biomeType) {
-        return TranslatableComponent.of(Util.makeDescriptionId("biome", new ResourceLocation(biomeType.getId())));
+        return Component.translatable(Util.makeDescriptionId("biome", new ResourceLocation(biomeType.getId())));
     }
 
     @Deprecated

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricBlockCommandSender.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricBlockCommandSender.java
@@ -85,7 +85,7 @@ public class FabricBlockCommandSender extends AbstractCommandBlockActor {
     @Override
     public void print(Component component) {
         sendMessage(net.minecraft.network.chat.Component.Serializer.fromJson(
-            GsonComponentSerializer.INSTANCE.serialize(WorldEditText.format(component, getLocale()))
+            GsonComponentSerializer.gson().serialize(WorldEditText.format(component, getLocale()))
         ));
     }
 

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricBlockRegistry.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricBlockRegistry.java
@@ -22,7 +22,6 @@ package com.sk89q.worldedit.fabric;
 import com.sk89q.worldedit.fabric.internal.FabricTransmogrifier;
 import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
@@ -41,7 +40,7 @@ public class FabricBlockRegistry extends BundledBlockRegistry {
 
     @Override
     public Component getRichName(BlockType blockType) {
-        return TranslatableComponent.of(FabricAdapter.adapt(blockType).getDescriptionId());
+        return Component.translatable(FabricAdapter.adapt(blockType).getDescriptionId());
     }
 
     @Override

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricCommandSender.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricCommandSender.java
@@ -90,7 +90,7 @@ public class FabricCommandSender extends AbstractNonPlayerActor {
     @Override
     public void print(Component component) {
         sendMessage(net.minecraft.network.chat.Component.Serializer.fromJson(
-            GsonComponentSerializer.INSTANCE.serialize(WorldEditText.format(component, getLocale()))
+            GsonComponentSerializer.gson().serialize(WorldEditText.format(component, getLocale()))
         ));
     }
 

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricItemRegistry.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricItemRegistry.java
@@ -21,7 +21,6 @@ package com.sk89q.worldedit.fabric;
 
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BundledItemRegistry;
 
@@ -29,14 +28,14 @@ public class FabricItemRegistry extends BundledItemRegistry {
 
     @Override
     public Component getRichName(ItemType itemType) {
-        return TranslatableComponent.of(
+        return Component.translatable(
             FabricAdapter.adapt(itemType).getDescriptionId()
         );
     }
 
     @Override
     public Component getRichName(BaseItemStack itemStack) {
-        return TranslatableComponent.of(
+        return Component.translatable(
             FabricAdapter.adapt(itemStack).getDescriptionId()
         );
     }

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricPlayer.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricPlayer.java
@@ -173,7 +173,9 @@ public class FabricPlayer extends AbstractPlayerActor {
 
     @Override
     public void print(Component component) {
-        this.player.sendSystemMessage(net.minecraft.network.chat.Component.Serializer.fromJson(GsonComponentSerializer.INSTANCE.serialize(WorldEditText.format(component, getLocale()))));
+        this.player.sendSystemMessage(net.minecraft.network.chat.Component.Serializer.fromJson(
+                GsonComponentSerializer.gson().serialize(WorldEditText.format(component, getLocale()))
+        ));
     }
 
     private void sendColorized(String msg, ChatFormatting formatting) {

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/internal/FabricEntity.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/internal/FabricEntity.java
@@ -26,7 +26,6 @@ import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.fabric.FabricAdapter;
 import com.sk89q.worldedit.fabric.FabricEntityProperties;
 import com.sk89q.worldedit.fabric.FabricWorldEdit;
-import com.sk89q.worldedit.fabric.internal.NBTConverter;
 import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.concurrency.LazyReference;

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeBiomeRegistry.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeBiomeRegistry.java
@@ -20,7 +20,6 @@
 package com.sk89q.worldedit.forge;
 
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.biome.BiomeData;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.registry.BiomeRegistry;
@@ -34,7 +33,7 @@ class ForgeBiomeRegistry implements BiomeRegistry {
 
     @Override
     public Component getRichName(BiomeType biomeType) {
-        return TranslatableComponent.of(Util.makeDescriptionId("biome", new ResourceLocation(biomeType.getId())));
+        return Component.translatable(Util.makeDescriptionId("biome", new ResourceLocation(biomeType.getId())));
     }
 
     @Deprecated

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeBlockCommandSender.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeBlockCommandSender.java
@@ -87,7 +87,7 @@ public class ForgeBlockCommandSender extends AbstractCommandBlockActor {
     @Override
     public void print(Component component) {
         sendMessage(net.minecraft.network.chat.Component.Serializer.fromJson(
-            GsonComponentSerializer.INSTANCE.serialize(WorldEditText.format(component, getLocale()))
+            GsonComponentSerializer.gson().serialize(WorldEditText.format(component, getLocale()))
         ));
     }
 

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeBlockRegistry.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeBlockRegistry.java
@@ -22,7 +22,6 @@ package com.sk89q.worldedit.forge;
 import com.sk89q.worldedit.forge.internal.ForgeTransmogrifier;
 import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
@@ -41,7 +40,7 @@ public class ForgeBlockRegistry extends BundledBlockRegistry {
 
     @Override
     public Component getRichName(BlockType blockType) {
-        return TranslatableComponent.of(ForgeAdapter.adapt(blockType).getDescriptionId());
+        return Component.translatable(ForgeAdapter.adapt(blockType).getDescriptionId());
     }
 
     @Override

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeCommandSender.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeCommandSender.java
@@ -90,7 +90,7 @@ public class ForgeCommandSender extends AbstractNonPlayerActor {
     @Override
     public void print(Component component) {
         sendMessage(net.minecraft.network.chat.Component.Serializer.fromJson(
-            GsonComponentSerializer.INSTANCE.serialize(WorldEditText.format(component, getLocale()))
+            GsonComponentSerializer.gson().serialize(WorldEditText.format(component, getLocale()))
         ));
     }
 

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeItemRegistry.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeItemRegistry.java
@@ -21,7 +21,6 @@ package com.sk89q.worldedit.forge;
 
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BundledItemRegistry;
 
@@ -29,14 +28,14 @@ public class ForgeItemRegistry extends BundledItemRegistry {
 
     @Override
     public Component getRichName(ItemType itemType) {
-        return TranslatableComponent.of(
+        return Component.translatable(
             ForgeAdapter.adapt(itemType).getDescriptionId()
         );
     }
 
     @Override
     public Component getRichName(BaseItemStack itemStack) {
-        return TranslatableComponent.of(
+        return Component.translatable(
             ForgeAdapter.adapt(itemStack).getDescriptionId()
         );
     }

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePlayer.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePlayer.java
@@ -168,7 +168,7 @@ public class ForgePlayer extends AbstractPlayerActor {
     @Override
     public void print(Component component) {
         sendMessage(net.minecraft.network.chat.Component.Serializer.fromJson(
-            GsonComponentSerializer.INSTANCE.serialize(WorldEditText.format(component, getLocale()))
+            GsonComponentSerializer.gson().serialize(WorldEditText.format(component, getLocale()))
         ));
     }
 

--- a/worldedit-libs/bukkit/build.gradle.kts
+++ b/worldedit-libs/bukkit/build.gradle.kts
@@ -9,5 +9,5 @@ repositories {
 }
 
 dependencies {
-    "shade"("net.kyori:text-adapter-bukkit:${Versions.TEXT_EXTRAS}")
+    "shade"("net.kyori:adventure-platform-bukkit:${Versions.KYORI_PLATFORM_BUKKIT}")
 }

--- a/worldedit-libs/core/ap/build.gradle.kts
+++ b/worldedit-libs/core/ap/build.gradle.kts
@@ -1,7 +1,10 @@
 applyLibrariesConfiguration()
 
+repositories {
+    mavenLocal()
+}
 dependencies {
-    // These are here because they use net.kyori:text-api -- so they need to be relocated too
+    // These are here because they use net.kyori:adventure -- so they need to be relocated too
     "shade"("org.enginehub.piston.core-ap:annotations:${Versions.PISTON}")
     "shade"("org.enginehub.piston.core-ap:processor:${Versions.PISTON}")
 }

--- a/worldedit-libs/core/build.gradle.kts
+++ b/worldedit-libs/core/build.gradle.kts
@@ -1,11 +1,15 @@
 applyLibrariesConfiguration()
 
+repositories {
+    mavenLocal()
+}
+
 dependencies {
-    "shade"("net.kyori:text-api:${Versions.TEXT}")
-    "shade"("net.kyori:text-serializer-gson:${Versions.TEXT}")
-    "shade"("net.kyori:text-serializer-legacy:${Versions.TEXT}")
-    "shade"("net.kyori:text-serializer-plain:${Versions.TEXT}")
-    // These are here because they use net.kyori:text-api -- so they need to be relocated too
+    "shade"("net.kyori:adventure-api:${Versions.KYORI_ADVENTURE}")
+    "shade"("net.kyori:adventure-text-serializer-gson:${Versions.KYORI_ADVENTURE}")
+    "shade"("net.kyori:adventure-text-serializer-legacy:${Versions.KYORI_ADVENTURE}")
+    "shade"("net.kyori:adventure-text-serializer-plain:${Versions.KYORI_ADVENTURE}")
+    // These are here because they use net.kyori:adventure -- so they need to be relocated too
     "shade"("org.enginehub.piston:core:${Versions.PISTON}")
     "shade"("org.enginehub.piston.core-ap:runtime:${Versions.PISTON}")
     "shade"("org.enginehub.piston:default-impl:${Versions.PISTON}")

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeBiomeRegistry.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeBiomeRegistry.java
@@ -20,7 +20,6 @@
 package com.sk89q.worldedit.sponge;
 
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.translation.TranslationManager;
 import com.sk89q.worldedit.world.biome.BiomeData;
 import com.sk89q.worldedit.world.registry.BiomeRegistry;
@@ -36,7 +35,7 @@ class SpongeBiomeRegistry implements BiomeRegistry {
 
     @Override
     public Component getRichName(com.sk89q.worldedit.world.biome.BiomeType biomeType) {
-        return TranslatableComponent.of(
+        return Component.translatable(
             TranslationManager.makeTranslationKey("biome", biomeType.getId())
         );
     }

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeBlockCommandSender.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeBlockCommandSender.java
@@ -24,8 +24,7 @@ import com.sk89q.worldedit.extension.platform.AbstractCommandBlockActor;
 import com.sk89q.worldedit.session.SessionKey;
 import com.sk89q.worldedit.util.auth.AuthorizationException;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.NamedTextColor;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
@@ -73,7 +72,7 @@ public class SpongeBlockCommandSender extends AbstractCommandBlockActor {
     @Deprecated
     public void print(String msg) {
         for (String part : msg.split("\n")) {
-            print(TextComponent.of(part, TextColor.LIGHT_PURPLE));
+            print(Component.text(part, NamedTextColor.LIGHT_PURPLE));
         }
     }
 
@@ -81,7 +80,7 @@ public class SpongeBlockCommandSender extends AbstractCommandBlockActor {
     @Deprecated
     public void printDebug(String msg) {
         for (String part : msg.split("\n")) {
-            print(TextComponent.of(part, TextColor.GRAY));
+            print(Component.text(part, NamedTextColor.GRAY));
         }
     }
 
@@ -89,7 +88,7 @@ public class SpongeBlockCommandSender extends AbstractCommandBlockActor {
     @Deprecated
     public void printError(String msg) {
         for (String part : msg.split("\n")) {
-            print(TextComponent.of(part, TextColor.RED));
+            print(Component.text(part, NamedTextColor.RED));
         }
     }
 

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeCommandSender.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeCommandSender.java
@@ -23,10 +23,9 @@ import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.internal.cui.CUIEvent;
 import com.sk89q.worldedit.session.SessionKey;
-import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
-import com.sk89q.worldedit.util.formatting.text.format.TextColor;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.spongepowered.api.entity.living.player.Player;
 
 import java.io.File;
@@ -69,7 +68,7 @@ public class SpongeCommandSender implements Actor {
     @Deprecated
     public void printRaw(String msg) {
         for (String part : msg.split("\n")) {
-            sender.sendMessage(net.kyori.adventure.text.Component.text(part));
+            sender.sendMessage(Component.text(part));
         }
     }
 
@@ -77,7 +76,7 @@ public class SpongeCommandSender implements Actor {
     @Deprecated
     public void print(String msg) {
         for (String part : msg.split("\n")) {
-            print(TextComponent.of(part, TextColor.LIGHT_PURPLE));
+            sender.sendMessage(Component.text(part, NamedTextColor.LIGHT_PURPLE));
         }
     }
 
@@ -85,7 +84,7 @@ public class SpongeCommandSender implements Actor {
     @Deprecated
     public void printDebug(String msg) {
         for (String part : msg.split("\n")) {
-            print(TextComponent.of(part, TextColor.GRAY));
+            sender.sendMessage(Component.text(part, NamedTextColor.GRAY));
         }
     }
 
@@ -93,12 +92,12 @@ public class SpongeCommandSender implements Actor {
     @Deprecated
     public void printError(String msg) {
         for (String part : msg.split("\n")) {
-            print(TextComponent.of(part, TextColor.RED));
+            sender.sendMessage(Component.text(part, NamedTextColor.RED));
         }
     }
 
     @Override
-    public void print(Component component) {
+    public void print(com.sk89q.worldedit.util.formatting.text.Component component) {
         sender.sendMessage(SpongeTextAdapter.convert(component, getLocale()));
     }
 

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeItemRegistry.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeItemRegistry.java
@@ -21,7 +21,6 @@ package com.sk89q.worldedit.sponge;
 
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BundledItemRegistry;
 import net.minecraft.world.item.ItemStack;
@@ -39,7 +38,7 @@ public class SpongeItemRegistry extends BundledItemRegistry {
 
     @Override
     public Component getRichName(BaseItemStack itemStack) {
-        return TranslatableComponent.of(
+        return Component.translatable(
             ((ItemStack) (Object) SpongeAdapter.adapt(itemStack)).getDescriptionId()
         );
     }

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeTextAdapter.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeTextAdapter.java
@@ -30,11 +30,11 @@ public class SpongeTextAdapter {
     public static net.kyori.adventure.text.Component convert(Component component, Locale locale) {
         component = WorldEditText.format(component, locale);
         return net.kyori.adventure.text.serializer.gson.GsonComponentSerializer.gson()
-            .deserialize(GsonComponentSerializer.INSTANCE.serialize(component));
+            .deserialize(GsonComponentSerializer.gson().serialize(component));
     }
 
     public static Component convert(net.kyori.adventure.text.Component component) {
-        return GsonComponentSerializer.INSTANCE.deserialize(
+        return GsonComponentSerializer.gson().deserialize(
             net.kyori.adventure.text.serializer.gson.GsonComponentSerializer.gson()
                 .serialize(component)
         );


### PR DESCRIPTION
I started a new adventure after I was able to make the changes for https://github.com/EngineHub/Piston/pull/40

I applied the piston version with adventure 4.14.0 to worldedit and fixed many compilation errors and improved the usage of adventure at some points.

I tested the changes on paper but it should work fine on fabric, forge and sponge too.

## However

This is a breaking change. WorldGuard uses the relocated text serializers from WorldEdit to send messages and initialize flags by using the LegacyComponentSerializer. I'm confident to replace kyori-text by shading adventure in WorldGuard or by introducing the breaking change into WG 7.1.x.

