### PR TITLE
Fix ellipsoid and cylinder regions not fully clearing

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/CylinderRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/CylinderRegionSelector.java
@@ -247,6 +247,8 @@ public class CylinderRegionSelector implements RegionSelector, CUIRegion {
     @Override
     public void clear() {
         region = new CylinderRegion(region.getWorld());
+        selectedCenter = false;
+        selectedRadius = false;
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/EllipsoidRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/EllipsoidRegionSelector.java
@@ -227,6 +227,8 @@ public class EllipsoidRegionSelector implements RegionSelector, CUIRegion {
     public void clear() {
         region.setCenter(BlockVector3.ZERO);
         region.setRadius(Vector3.ZERO);
+        started = false;
+        selectedRadius = false;
     }
 
     @Override


### PR DESCRIPTION
When you clear (//sel) a region it should effectively remove your selection. For all selection types except for Ellipsoid/Sphere & Cylinder this is true, but for these two types it simply sets their radii to 0 and center to 0,0,0 whilst leaving them in a state to pass their isDefined() check.
This means if you //set 1 you will set 0,0,0 to stone.

The fix I've implemented sets the boolean used to check if the region selection is defined to false in the clear() method so the user will correctly receieve the "Make a region selection first" error should they try to operate on the region after clearing it.

Note: Redo of https://github.com/EngineHub/WorldEdit/pull/2412 - based off & targetting 7.2.x branch now