### PR TITLE
Attempt fix for unreproducable biome error

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/validation/DataValidatorExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/validation/DataValidatorExtent.java
@@ -24,6 +24,7 @@ import com.sk89q.worldedit.extent.AbstractDelegateExtent;
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.World;
+import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockType;
 
@@ -64,4 +65,14 @@ public class DataValidatorExtent extends AbstractDelegateExtent {
         return super.setBlock(location, block);
     }
 
+    @Override
+    public boolean setBiome(BlockVector3 location, BiomeType biome) {
+        final int y = location.getBlockY();
+
+        if (y < world.getMinY() || y > world.getMaxY()) {
+            return false;
+        }
+
+        return super.setBiome(location, biome);
+    }
 }


### PR DESCRIPTION
Attempt to fix https://github.com/EngineHub/WorldEdit/issues/2411. I can't reproduce the issue, and from what I can tell the error is impossible using WorldEdit itself, but it's theoretically possible for a mod/plugin using the API to provide invalid data to an EditSession causing an error. This adds further data validation to prevent cases of invalid data being provided via the API causing issues