### PR TITLE
Limit //line thickness by max-radius

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.LocalSession;
+import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.command.util.CommandPermissions;
 import com.sk89q.worldedit.command.util.CommandPermissionsConditionGenerator;
@@ -134,7 +135,7 @@ public class RegionCommands {
             return 0;
         }
         checkCommandArgument(thickness >= 0, "Thickness must be >= 0");
-
+        WorldEdit.getInstance().checkMaxRadius(thickness);
 
         List<BlockVector3> vectors;
 


### PR DESCRIPTION
Fixes https://github.com/EngineHub/WorldEdit/issues/2415.

I doubt this actually fixes the issue mentioned in the issue, but logically this is a radius and therefore does make sense to have limited by this setting.