### PR TITLE
Concatenate AffineTransforms with less allocations

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/transform/AffineTransform.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/transform/AffineTransform.java
@@ -146,28 +146,44 @@ public record AffineTransform(
 
     /**
      * Returns the affine transform created by applying first the affine
+     * transform given by the parameters, then this affine transform.
+     *
+     * @return the composition this * that
+     */
+    public AffineTransform concatenate(double o00, double o01, double o02, double o03,
+                                       double o10, double o11, double o12, double o13,
+                                       double o20, double o21, double o22, double o23) {
+        double n00 = m00 * o00 + m01 * o10 + m02 * o20;
+        double n01 = m00 * o01 + m01 * o11 + m02 * o21;
+        double n02 = m00 * o02 + m01 * o12 + m02 * o22;
+        double n03 = m00 * o03 + m01 * o13 + m02 * o23 + m03;
+        double n10 = m10 * o00 + m11 * o10 + m12 * o20;
+        double n11 = m10 * o01 + m11 * o11 + m12 * o21;
+        double n12 = m10 * o02 + m11 * o12 + m12 * o22;
+        double n13 = m10 * o03 + m11 * o13 + m12 * o23 + m13;
+        double n20 = m20 * o00 + m21 * o10 + m22 * o20;
+        double n21 = m20 * o01 + m21 * o11 + m22 * o21;
+        double n22 = m20 * o02 + m21 * o12 + m22 * o22;
+        double n23 = m20 * o03 + m21 * o13 + m22 * o23 + m23;
+        return new AffineTransform(
+            n00, n01, n02, n03,
+            n10, n11, n12, n13,
+            n20, n21, n22, n23);
+    }
+
+    /**
+     * Returns the affine transform created by applying first the affine
      * transform given by {@code that}, then this affine transform.
      *
      * @param that the transform to apply first
      * @return the composition this * that
      */
     public AffineTransform concatenate(AffineTransform that) {
-        double n00 = m00 * that.m00 + m01 * that.m10 + m02 * that.m20;
-        double n01 = m00 * that.m01 + m01 * that.m11 + m02 * that.m21;
-        double n02 = m00 * that.m02 + m01 * that.m12 + m02 * that.m22;
-        double n03 = m00 * that.m03 + m01 * that.m13 + m02 * that.m23 + m03;
-        double n10 = m10 * that.m00 + m11 * that.m10 + m12 * that.m20;
-        double n11 = m10 * that.m01 + m11 * that.m11 + m12 * that.m21;
-        double n12 = m10 * that.m02 + m11 * that.m12 + m12 * that.m22;
-        double n13 = m10 * that.m03 + m11 * that.m13 + m12 * that.m23 + m13;
-        double n20 = m20 * that.m00 + m21 * that.m10 + m22 * that.m20;
-        double n21 = m20 * that.m01 + m21 * that.m11 + m22 * that.m21;
-        double n22 = m20 * that.m02 + m21 * that.m12 + m22 * that.m22;
-        double n23 = m20 * that.m03 + m21 * that.m13 + m22 * that.m23 + m23;
-        return new AffineTransform(
-                n00, n01, n02, n03,
-                n10, n11, n12, n13,
-                n20, n21, n22, n23);
+        return concatenate(
+            that.m00, that.m01, that.m02, that.m03,
+            that.m10, that.m11, that.m12, that.m13,
+            that.m20, that.m21, that.m22, that.m23
+        );
     }
 
     /**
@@ -205,37 +221,37 @@ public record AffineTransform(
     }
 
     public AffineTransform translate(double x, double y, double z) {
-        return concatenate(new AffineTransform(1, 0, 0, x, 0, 1, 0, y, 0, 0, 1, z));
+        return concatenate(1, 0, 0, x, 0, 1, 0, y, 0, 0, 1, z);
     }
 
     public AffineTransform rotateX(double theta) {
         double cot = MathUtils.dCos(theta);
         double sit = MathUtils.dSin(theta);
         return concatenate(
-                new AffineTransform(
-                        1, 0, 0, 0,
-                        0, cot, -sit, 0,
-                        0, sit, cot, 0));
+            1, 0, 0, 0,
+            0, cot, -sit, 0,
+            0, sit, cot, 0
+        );
     }
 
     public AffineTransform rotateY(double theta) {
         double cot = MathUtils.dCos(theta);
         double sit = MathUtils.dSin(theta);
         return concatenate(
-                new AffineTransform(
-                        cot, 0, sit, 0,
-                        0, 1, 0, 0,
-                        -sit, 0, cot, 0));
+            cot, 0, sit, 0,
+            0, 1, 0, 0,
+            -sit, 0, cot, 0
+        );
     }
 
     public AffineTransform rotateZ(double theta) {
         double cot = MathUtils.dCos(theta);
         double sit = MathUtils.dSin(theta);
         return concatenate(
-                new AffineTransform(
-                        cot, -sit, 0, 0,
-                        sit, cot, 0, 0,
-                        0, 0, 1, 0));
+            cot, -sit, 0, 0,
+            sit, cot, 0, 0,
+            0, 0, 1, 0
+        );
     }
 
     public AffineTransform scale(double s) {
@@ -243,7 +259,7 @@ public record AffineTransform(
     }
 
     public AffineTransform scale(double sx, double sy, double sz) {
-        return concatenate(new AffineTransform(sx, 0, 0, 0, 0, sy, 0, 0, 0, 0, sz, 0));
+        return concatenate(sx, 0, 0, 0, 0, sy, 0, 0, 0, 0, sz, 0);
     }
 
     public AffineTransform scale(Vector3 vec) {
@@ -264,8 +280,8 @@ public record AffineTransform(
 
     @Override
     public Transform combine(Transform other) {
-        if (other instanceof AffineTransform) {
-            return concatenate((AffineTransform) other);
+        if (other instanceof AffineTransform otherTransform) {
+            return concatenate(otherTransform);
         } else {
             return new CombinedTransform(this, other);
         }


### PR DESCRIPTION
Builds on https://github.com/EngineHub/WorldEdit/pull/2419, adds a new concatenate method that takes doubles, so the internal methods that do concatenations don't need to do two allocations