### PR TITLE
Fix EditSession initialisation without a World

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -372,6 +372,10 @@ public class EditSession implements Extent, AutoCloseable {
      */
     @Deprecated
     public void setReorderMode(ReorderMode reorderMode) {
+        if (world == null && reorderMode == ReorderMode.FAST) {
+            // Fast requires a world, for now we can fallback to multi stage, but use "none" in the future.
+            reorderMode = ReorderMode.MULTI_STAGE;
+        }
         if (reorderMode == ReorderMode.FAST && sideEffectExtent == null) {
             throw new IllegalArgumentException("An EditSession without a fast mode tried to use it for reordering!");
         }


### PR DESCRIPTION
Semi hacky fix, but done this way due to the deprecation of the reorder system. Once it's stripped out, we can just not have reordering for worldless EditSessions