### PR TITLE
Send biome updates for chunks when possible

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1.19.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_19_R3/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.19.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_19_R3/PaperweightAdapter.java
@@ -23,7 +23,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
@@ -176,6 +175,7 @@ import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -975,7 +975,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     public void sendBiomeUpdates(World world, Iterable<BlockVector2> chunks) {
         ServerLevel originalWorld = ((CraftWorld) world).getHandle();
 
-        List<ChunkAccess> nativeChunks = Lists.newArrayListWithCapacity(Iterables.size(chunks));
+        List<ChunkAccess> nativeChunks = chunks instanceof Collection<BlockVector2> chunkCollection ? Lists.newArrayListWithCapacity(chunkCollection.size()) : Lists.newArrayList();
         for (BlockVector2 chunk : chunks) {
             nativeChunks.add(originalWorld.getChunk(chunk.getBlockX(), chunk.getBlockZ(), ChunkStatus.BIOMES, false));
         }

--- a/worldedit-bukkit/adapters/adapter-1.19.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_19_R3/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.19.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_19_R3/PaperweightAdapter.java
@@ -23,6 +23,8 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.mojang.datafixers.util.Either;
@@ -967,6 +969,17 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             ChunkPos.rangeClosed(min, max).forEach((chunkPosx) -> structureStart.placeInChunk(proxyLevel, originalWorld.structureManager(), chunkManager.getGenerator(), originalWorld.getRandom(), new BoundingBox(chunkPosx.getMinBlockX(), originalWorld.getMinBuildHeight(), chunkPosx.getMinBlockZ(), chunkPosx.getMaxBlockX(), originalWorld.getMaxBuildHeight(), chunkPosx.getMaxBlockZ()), chunkPosx));
             return true;
         }
+    }
+
+    @Override
+    public void sendBiomeUpdates(World world, Iterable<BlockVector2> chunks) {
+        ServerLevel originalWorld = ((CraftWorld) world).getHandle();
+
+        List<ChunkAccess> nativeChunks = Lists.newArrayListWithCapacity(Iterables.size(chunks));
+        for (BlockVector2 chunk : chunks) {
+            nativeChunks.add(originalWorld.getChunk(chunk.getBlockX(), chunk.getBlockZ(), ChunkStatus.BIOMES, false));
+        }
+        originalWorld.getChunkSource().chunkMap.resendBiomesForChunks(nativeChunks);
     }
 
     // ------------------------------------------------------------------------

--- a/worldedit-bukkit/adapters/adapter-1.20.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R2/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.20.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R2/PaperweightAdapter.java
@@ -23,6 +23,8 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.mojang.datafixers.util.Either;
@@ -968,6 +970,17 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             ChunkPos.rangeClosed(min, max).forEach((chunkPosx) -> structureStart.placeInChunk(proxyLevel, originalWorld.structureManager(), chunkManager.getGenerator(), originalWorld.getRandom(), new BoundingBox(chunkPosx.getMinBlockX(), originalWorld.getMinBuildHeight(), chunkPosx.getMinBlockZ(), chunkPosx.getMaxBlockX(), originalWorld.getMaxBuildHeight(), chunkPosx.getMaxBlockZ()), chunkPosx));
             return true;
         }
+    }
+
+    @Override
+    public void sendBiomeUpdates(World world, Iterable<BlockVector2> chunks) {
+        ServerLevel originalWorld = ((CraftWorld) world).getHandle();
+
+        List<ChunkAccess> nativeChunks = Lists.newArrayListWithCapacity(Iterables.size(chunks));
+        for (BlockVector2 chunk : chunks) {
+            nativeChunks.add(originalWorld.getChunk(chunk.getBlockX(), chunk.getBlockZ(), ChunkStatus.BIOMES, false));
+        }
+        originalWorld.getChunkSource().chunkMap.resendBiomesForChunks(nativeChunks);
     }
 
     // ------------------------------------------------------------------------

--- a/worldedit-bukkit/adapters/adapter-1.20.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R2/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.20.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R2/PaperweightAdapter.java
@@ -23,7 +23,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
@@ -176,6 +175,7 @@ import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -976,7 +976,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     public void sendBiomeUpdates(World world, Iterable<BlockVector2> chunks) {
         ServerLevel originalWorld = ((CraftWorld) world).getHandle();
 
-        List<ChunkAccess> nativeChunks = Lists.newArrayListWithCapacity(Iterables.size(chunks));
+        List<ChunkAccess> nativeChunks = chunks instanceof Collection<BlockVector2> chunkCollection ? Lists.newArrayListWithCapacity(chunkCollection.size()) : Lists.newArrayList();
         for (BlockVector2 chunk : chunks) {
             nativeChunks.add(originalWorld.getChunk(chunk.getBlockX(), chunk.getBlockZ(), ChunkStatus.BIOMES, false));
         }

--- a/worldedit-bukkit/adapters/adapter-1.20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R1/PaperweightAdapter.java
@@ -23,6 +23,8 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.mojang.datafixers.util.Either;
@@ -968,6 +970,17 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             ChunkPos.rangeClosed(min, max).forEach((chunkPosx) -> structureStart.placeInChunk(proxyLevel, originalWorld.structureManager(), chunkManager.getGenerator(), originalWorld.getRandom(), new BoundingBox(chunkPosx.getMinBlockX(), originalWorld.getMinBuildHeight(), chunkPosx.getMinBlockZ(), chunkPosx.getMaxBlockX(), originalWorld.getMaxBuildHeight(), chunkPosx.getMaxBlockZ()), chunkPosx));
             return true;
         }
+    }
+
+    @Override
+    public void sendBiomeUpdates(World world, Iterable<BlockVector2> chunks) {
+        ServerLevel originalWorld = ((CraftWorld) world).getHandle();
+
+        List<ChunkAccess> nativeChunks = Lists.newArrayListWithCapacity(Iterables.size(chunks));
+        for (BlockVector2 chunk : chunks) {
+            nativeChunks.add(originalWorld.getChunk(chunk.getBlockX(), chunk.getBlockZ(), ChunkStatus.BIOMES, false));
+        }
+        originalWorld.getChunkSource().chunkMap.resendBiomesForChunks(nativeChunks);
     }
 
     // ------------------------------------------------------------------------

--- a/worldedit-bukkit/adapters/adapter-1.20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R1/PaperweightAdapter.java
@@ -23,7 +23,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
@@ -176,6 +175,7 @@ import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -976,7 +976,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     public void sendBiomeUpdates(World world, Iterable<BlockVector2> chunks) {
         ServerLevel originalWorld = ((CraftWorld) world).getHandle();
 
-        List<ChunkAccess> nativeChunks = Lists.newArrayListWithCapacity(Iterables.size(chunks));
+        List<ChunkAccess> nativeChunks = chunks instanceof Collection<BlockVector2> chunkCollection ? Lists.newArrayListWithCapacity(chunkCollection.size()) : Lists.newArrayList();
         for (BlockVector2 chunk : chunks) {
             nativeChunks.add(originalWorld.getChunk(chunk.getBlockX(), chunk.getBlockZ(), ChunkStatus.BIOMES, false));
         }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
@@ -330,6 +330,14 @@ public class BukkitWorld extends AbstractWorld {
     }
 
     @Override
+    public void sendBiomeUpdates(Iterable<BlockVector2> chunks) {
+        BukkitImplAdapter adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
+        if (adapter != null) {
+            adapter.sendBiomeUpdates(getWorld(), chunks);
+        }
+    }
+
+    @Override
     public boolean playEffect(Vector3 position, int type, int data) {
         World world = getWorld();
 

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
@@ -25,6 +25,7 @@ import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.internal.wna.WorldNativeAccess;
+import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.registry.state.Property;
@@ -313,5 +314,18 @@ public interface BukkitImplAdapter {
      */
     default void initializeRegistries() {
 
+    }
+
+    /**
+     * Sends biome updates for the given chunks.
+     *
+     * <p>This doesn't modify biomes at all, it just sends the current state of the biomes
+     * in the world to all of the nearby players, updating the visual representation of the
+     * biomes on their clients.</p>
+     *
+     * @param world the world
+     * @param chunks a list of chunk coordinates to send biome updates for
+     */
+    default void sendBiomeUpdates(World world, Iterable<BlockVector2> chunks) {
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/AbstractWorld.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/AbstractWorld.java
@@ -95,6 +95,10 @@ public abstract class AbstractWorld implements World {
     }
 
     @Override
+    public void sendBiomeUpdates(Iterable<BlockVector2> chunks) {
+    }
+
+    @Override
     public void fixLighting(Iterable<BlockVector2> chunks) {
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
@@ -312,6 +312,17 @@ public interface World extends Extent, Keyed {
     void fixAfterFastMode(Iterable<BlockVector2> chunks);
 
     /**
+     * Sends biome updates for the given chunks.
+     *
+     * <p>This doesn't modify biomes at all, it just sends the current state of the biomes
+     * in the world to all of the nearby players, updating the visual representation of the
+     * biomes on their clients.</p>
+     *
+     * @param chunks a list of chunk coordinates to send biome updates for
+     */
+    void sendBiomeUpdates(Iterable<BlockVector2> chunks);
+
+    /**
      * Relight the given chunks if possible.
      *
      * @param chunks a list of chunk coordinates to fix

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorld.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorld.java
@@ -23,7 +23,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
@@ -117,6 +116,7 @@ import java.lang.ref.WeakReference;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -530,7 +530,7 @@ public class FabricWorld extends AbstractWorld {
 
     @Override
     public void sendBiomeUpdates(Iterable<BlockVector2> chunks) {
-        List<ChunkAccess> nativeChunks = Lists.newArrayListWithCapacity(Iterables.size(chunks));
+        List<ChunkAccess> nativeChunks = chunks instanceof Collection<BlockVector2> chunkCollection ? Lists.newArrayListWithCapacity(chunkCollection.size()) : Lists.newArrayList();
         for (BlockVector2 chunk : chunks) {
             nativeChunks.add(getWorld().getChunk(chunk.getBlockX(), chunk.getBlockZ(), ChunkStatus.BIOMES, false));
         }

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorld.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorld.java
@@ -23,6 +23,8 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import com.google.common.util.concurrent.Futures;
@@ -524,6 +526,15 @@ public class FabricWorld extends AbstractWorld {
     @Override
     public void fixAfterFastMode(Iterable<BlockVector2> chunks) {
         fixLighting(chunks);
+    }
+
+    @Override
+    public void sendBiomeUpdates(Iterable<BlockVector2> chunks) {
+        List<ChunkAccess> nativeChunks = Lists.newArrayListWithCapacity(Iterables.size(chunks));
+        for (BlockVector2 chunk : chunks) {
+            nativeChunks.add(getWorld().getChunk(chunk.getBlockX(), chunk.getBlockZ(), ChunkStatus.BIOMES, false));
+        }
+        ((ServerLevel) getWorld()).getChunkSource().chunkMap.resendBiomesForChunks(nativeChunks);
     }
 
     @Override

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java
@@ -23,6 +23,8 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import com.google.common.util.concurrent.Futures;
@@ -506,6 +508,15 @@ public class ForgeWorld extends AbstractWorld {
     @Override
     public void fixAfterFastMode(Iterable<BlockVector2> chunks) {
         fixLighting(chunks);
+    }
+
+    @Override
+    public void sendBiomeUpdates(Iterable<BlockVector2> chunks) {
+        List<ChunkAccess> nativeChunks = Lists.newArrayListWithCapacity(Iterables.size(chunks));
+        for (BlockVector2 chunk : chunks) {
+            nativeChunks.add(getWorld().getChunk(chunk.getBlockX(), chunk.getBlockZ(), ChunkStatus.BIOMES, false));
+        }
+        ((ServerLevel) getWorld()).getChunkSource().chunkMap.resendBiomesForChunks(nativeChunks);
     }
 
     @Override

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java
@@ -23,7 +23,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
@@ -115,6 +114,7 @@ import java.lang.ref.WeakReference;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -512,7 +512,7 @@ public class ForgeWorld extends AbstractWorld {
 
     @Override
     public void sendBiomeUpdates(Iterable<BlockVector2> chunks) {
-        List<ChunkAccess> nativeChunks = Lists.newArrayListWithCapacity(Iterables.size(chunks));
+        List<ChunkAccess> nativeChunks = chunks instanceof Collection<BlockVector2> chunkCollection ? Lists.newArrayListWithCapacity(chunkCollection.size()) : Lists.newArrayList();
         for (BlockVector2 chunk : chunks) {
             nativeChunks.add(getWorld().getChunk(chunk.getBlockX(), chunk.getBlockZ(), ChunkStatus.BIOMES, false));
         }


### PR DESCRIPTION
This is a WIP PR that uses the new packet in 1.19.4 to allow sending real-time biome updates when available.

It seems to cope fine at large volumes with just me on a local server (so no network latency etc), but I'm unsure how this'll go at higher volumes. Might make sense for us to add a side effect here?