### PR TITLE
Deprecate the concept of bundled block data

### DIFF
--- a/verification/src/changes/accepted-fabric-public-api-changes.json
+++ b/verification/src/changes/accepted-fabric-public-api-changes.json
@@ -1,2 +1,11 @@
 {
+  "Removal of constructor in non-API class": [
+    {
+      "type": "com.sk89q.worldedit.fabric.FabricBlockMaterial",
+      "member": "Constructor com.sk89q.worldedit.fabric.FabricBlockMaterial(net.minecraft.class_2680,com.sk89q.worldedit.world.registry.BlockMaterial)",
+      "changes": [
+        "CONSTRUCTOR_REMOVED"
+      ]
+    }
+  ]
 }

--- a/verification/src/changes/accepted-neoforge-public-api-changes.json
+++ b/verification/src/changes/accepted-neoforge-public-api-changes.json
@@ -1,2 +1,11 @@
 {
+  "Removal of constructor in non-API class": [
+    {
+      "type": "com.sk89q.worldedit.neoforge.NeoForgeBlockMaterial",
+      "member": "Constructor com.sk89q.worldedit.neoforge.NeoForgeBlockMaterial(net.minecraft.world.level.block.state.BlockState,com.sk89q.worldedit.world.registry.BlockMaterial)",
+      "changes": [
+        "CONSTRUCTOR_REMOVED"
+      ]
+    }
+  ]
 }

--- a/worldedit-bukkit/adapters/adapter-1.20.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R2/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.20.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R2/PaperweightAdapter.java
@@ -69,6 +69,7 @@ import com.sk89q.worldedit.world.entity.EntityTypes;
 import com.sk89q.worldedit.world.generation.ConfiguredFeatureType;
 import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.item.ItemType;
+import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
@@ -576,6 +577,12 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     @Override
     public Component getRichItemName(BaseItemStack itemStack) {
         return TranslatableComponent.of(CraftItemStack.asNMSCopy(BukkitAdapter.adapt(itemStack)).getDescriptionId());
+    }
+
+    @Override
+    public BlockMaterial getBlockMaterial(BlockType blockType) {
+        net.minecraft.world.level.block.state.BlockState mcBlockState = getBlockFromType(blockType).defaultBlockState();
+        return new PaperweightBlockMaterial(mcBlockState);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/worldedit-bukkit/adapters/adapter-1.20.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R2/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.20.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R2/PaperweightBlockMaterial.java
@@ -1,0 +1,145 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.bukkit.adapter.impl.v1_20_R2;
+
+import com.sk89q.worldedit.world.registry.BlockMaterial;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.Clearable;
+import net.minecraft.world.level.EmptyBlockGetter;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.VoxelShape;
+
+public class PaperweightBlockMaterial implements BlockMaterial {
+
+    private static final AABB FULL_CUBE = AABB.unitCubeFromLowerCorner(Vec3.ZERO);
+
+    private final BlockState block;
+
+    public PaperweightBlockMaterial(BlockState block) {
+        this.block = block;
+    }
+
+    @Override
+    public boolean isAir() {
+        return block.isAir();
+    }
+
+    @Override
+    public boolean isFullCube() {
+        VoxelShape vs = block.getCollisionShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
+        return !vs.isEmpty() && vs.bounds().equals(FULL_CUBE);
+    }
+
+    @Override
+    public boolean isOpaque() {
+        return block.canOcclude();
+    }
+
+    @Override
+    public boolean isPowerSource() {
+        return block.isSignalSource();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isLiquid() {
+        return block.liquid();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isSolid() {
+        return block.isSolid();
+    }
+
+    @Override
+    public float getHardness() {
+        return block.getDestroySpeed(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public float getResistance() {
+        return block.getBlock().getExplosionResistance();
+    }
+
+    @Override
+    public float getSlipperiness() {
+        return block.getBlock().getFriction();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public int getLightValue() {
+        return block.getLightEmission();
+    }
+
+    @Override
+    public boolean isFragileWhenPushed() {
+        return block.getPistonPushReaction() == PushReaction.DESTROY;
+    }
+
+    @Override
+    public boolean isUnpushable() {
+        return block.getPistonPushReaction() == PushReaction.BLOCK;
+    }
+
+    @Override
+    public boolean isTicksRandomly() {
+        return block.isRandomlyTicking();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isMovementBlocker() {
+        return block.blocksMotion();
+    }
+
+    @Override
+    public boolean isBurnable() {
+        return block.ignitedByLava();
+    }
+
+    @Override
+    public boolean isToolRequired() {
+        return block.requiresCorrectToolForDrops();
+    }
+
+    @Override
+    public boolean isReplacedDuringPlacement() {
+        return block.canBeReplaced();
+    }
+
+    @Override
+    public boolean isTranslucent() {
+        return !block.canOcclude();
+    }
+
+    @Override
+    public boolean hasContainer() {
+        return block.getBlock() instanceof EntityBlock entityBlock
+                && entityBlock.newBlockEntity(BlockPos.ZERO, block) instanceof Clearable;
+    }
+
+}

--- a/worldedit-bukkit/adapters/adapter-1.20.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R2/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.20.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R2/PaperweightBlockMaterial.java
@@ -23,16 +23,12 @@ import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
-import net.minecraft.world.phys.AABB;
-import net.minecraft.world.phys.Vec3;
-import net.minecraft.world.phys.shapes.VoxelShape;
 
 public class PaperweightBlockMaterial implements BlockMaterial {
-
-    private static final AABB FULL_CUBE = AABB.unitCubeFromLowerCorner(Vec3.ZERO);
 
     private final BlockState block;
 
@@ -47,8 +43,7 @@ public class PaperweightBlockMaterial implements BlockMaterial {
 
     @Override
     public boolean isFullCube() {
-        VoxelShape vs = block.getCollisionShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
-        return !vs.isEmpty() && vs.bounds().equals(FULL_CUBE);
+        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.20.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R3/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.20.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R3/PaperweightAdapter.java
@@ -69,6 +69,7 @@ import com.sk89q.worldedit.world.entity.EntityTypes;
 import com.sk89q.worldedit.world.generation.ConfiguredFeatureType;
 import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.item.ItemType;
+import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
@@ -575,6 +576,12 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     @Override
     public Component getRichItemName(BaseItemStack itemStack) {
         return TranslatableComponent.of(CraftItemStack.asNMSCopy(BukkitAdapter.adapt(itemStack)).getDescriptionId());
+    }
+
+    @Override
+    public BlockMaterial getBlockMaterial(BlockType blockType) {
+        net.minecraft.world.level.block.state.BlockState mcBlockState = getBlockFromType(blockType).defaultBlockState();
+        return new PaperweightBlockMaterial(mcBlockState);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/worldedit-bukkit/adapters/adapter-1.20.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R3/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.20.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R3/PaperweightBlockMaterial.java
@@ -1,0 +1,145 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.bukkit.adapter.impl.v1_20_R3;
+
+import com.sk89q.worldedit.world.registry.BlockMaterial;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.Clearable;
+import net.minecraft.world.level.EmptyBlockGetter;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.VoxelShape;
+
+public class PaperweightBlockMaterial implements BlockMaterial {
+
+    private static final AABB FULL_CUBE = AABB.unitCubeFromLowerCorner(Vec3.ZERO);
+
+    private final BlockState block;
+
+    public PaperweightBlockMaterial(BlockState block) {
+        this.block = block;
+    }
+
+    @Override
+    public boolean isAir() {
+        return block.isAir();
+    }
+
+    @Override
+    public boolean isFullCube() {
+        VoxelShape vs = block.getCollisionShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
+        return !vs.isEmpty() && vs.bounds().equals(FULL_CUBE);
+    }
+
+    @Override
+    public boolean isOpaque() {
+        return block.canOcclude();
+    }
+
+    @Override
+    public boolean isPowerSource() {
+        return block.isSignalSource();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isLiquid() {
+        return block.liquid();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isSolid() {
+        return block.isSolid();
+    }
+
+    @Override
+    public float getHardness() {
+        return block.getDestroySpeed(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public float getResistance() {
+        return block.getBlock().getExplosionResistance();
+    }
+
+    @Override
+    public float getSlipperiness() {
+        return block.getBlock().getFriction();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public int getLightValue() {
+        return block.getLightEmission();
+    }
+
+    @Override
+    public boolean isFragileWhenPushed() {
+        return block.getPistonPushReaction() == PushReaction.DESTROY;
+    }
+
+    @Override
+    public boolean isUnpushable() {
+        return block.getPistonPushReaction() == PushReaction.BLOCK;
+    }
+
+    @Override
+    public boolean isTicksRandomly() {
+        return block.isRandomlyTicking();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isMovementBlocker() {
+        return block.blocksMotion();
+    }
+
+    @Override
+    public boolean isBurnable() {
+        return block.ignitedByLava();
+    }
+
+    @Override
+    public boolean isToolRequired() {
+        return block.requiresCorrectToolForDrops();
+    }
+
+    @Override
+    public boolean isReplacedDuringPlacement() {
+        return block.canBeReplaced();
+    }
+
+    @Override
+    public boolean isTranslucent() {
+        return !block.canOcclude();
+    }
+
+    @Override
+    public boolean hasContainer() {
+        return block.getBlock() instanceof EntityBlock entityBlock
+                && entityBlock.newBlockEntity(BlockPos.ZERO, block) instanceof Clearable;
+    }
+
+}

--- a/worldedit-bukkit/adapters/adapter-1.20.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R3/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.20.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R3/PaperweightBlockMaterial.java
@@ -23,16 +23,12 @@ import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
-import net.minecraft.world.phys.AABB;
-import net.minecraft.world.phys.Vec3;
-import net.minecraft.world.phys.shapes.VoxelShape;
 
 public class PaperweightBlockMaterial implements BlockMaterial {
-
-    private static final AABB FULL_CUBE = AABB.unitCubeFromLowerCorner(Vec3.ZERO);
 
     private final BlockState block;
 
@@ -47,8 +43,7 @@ public class PaperweightBlockMaterial implements BlockMaterial {
 
     @Override
     public boolean isFullCube() {
-        VoxelShape vs = block.getCollisionShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
-        return !vs.isEmpty() && vs.bounds().equals(FULL_CUBE);
+        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.20.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R4/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.20.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R4/PaperweightAdapter.java
@@ -69,6 +69,7 @@ import com.sk89q.worldedit.world.entity.EntityTypes;
 import com.sk89q.worldedit.world.generation.ConfiguredFeatureType;
 import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.item.ItemType;
+import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
@@ -577,6 +578,12 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     @Override
     public Component getRichItemName(BaseItemStack itemStack) {
         return TranslatableComponent.of(CraftItemStack.asNMSCopy(BukkitAdapter.adapt(itemStack)).getDescriptionId());
+    }
+
+    @Override
+    public BlockMaterial getBlockMaterial(BlockType blockType) {
+        net.minecraft.world.level.block.state.BlockState mcBlockState = getBlockFromType(blockType).defaultBlockState();
+        return new PaperweightBlockMaterial(mcBlockState);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/worldedit-bukkit/adapters/adapter-1.20.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R4/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.20.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R4/PaperweightBlockMaterial.java
@@ -1,0 +1,145 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.bukkit.adapter.impl.v1_20_R4;
+
+import com.sk89q.worldedit.world.registry.BlockMaterial;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.Clearable;
+import net.minecraft.world.level.EmptyBlockGetter;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.VoxelShape;
+
+public class PaperweightBlockMaterial implements BlockMaterial {
+
+    private static final AABB FULL_CUBE = AABB.unitCubeFromLowerCorner(Vec3.ZERO);
+
+    private final BlockState block;
+
+    public PaperweightBlockMaterial(BlockState block) {
+        this.block = block;
+    }
+
+    @Override
+    public boolean isAir() {
+        return block.isAir();
+    }
+
+    @Override
+    public boolean isFullCube() {
+        VoxelShape vs = block.getCollisionShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
+        return !vs.isEmpty() && vs.bounds().equals(FULL_CUBE);
+    }
+
+    @Override
+    public boolean isOpaque() {
+        return block.canOcclude();
+    }
+
+    @Override
+    public boolean isPowerSource() {
+        return block.isSignalSource();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isLiquid() {
+        return block.liquid();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isSolid() {
+        return block.isSolid();
+    }
+
+    @Override
+    public float getHardness() {
+        return block.getDestroySpeed(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public float getResistance() {
+        return block.getBlock().getExplosionResistance();
+    }
+
+    @Override
+    public float getSlipperiness() {
+        return block.getBlock().getFriction();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public int getLightValue() {
+        return block.getLightEmission();
+    }
+
+    @Override
+    public boolean isFragileWhenPushed() {
+        return block.getPistonPushReaction() == PushReaction.DESTROY;
+    }
+
+    @Override
+    public boolean isUnpushable() {
+        return block.getPistonPushReaction() == PushReaction.BLOCK;
+    }
+
+    @Override
+    public boolean isTicksRandomly() {
+        return block.isRandomlyTicking();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isMovementBlocker() {
+        return block.blocksMotion();
+    }
+
+    @Override
+    public boolean isBurnable() {
+        return block.ignitedByLava();
+    }
+
+    @Override
+    public boolean isToolRequired() {
+        return block.requiresCorrectToolForDrops();
+    }
+
+    @Override
+    public boolean isReplacedDuringPlacement() {
+        return block.canBeReplaced();
+    }
+
+    @Override
+    public boolean isTranslucent() {
+        return !block.canOcclude();
+    }
+
+    @Override
+    public boolean hasContainer() {
+        return block.getBlock() instanceof EntityBlock entityBlock
+                && entityBlock.newBlockEntity(BlockPos.ZERO, block) instanceof Clearable;
+    }
+
+}

--- a/worldedit-bukkit/adapters/adapter-1.20.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R4/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.20.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R4/PaperweightBlockMaterial.java
@@ -23,16 +23,12 @@ import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
-import net.minecraft.world.phys.AABB;
-import net.minecraft.world.phys.Vec3;
-import net.minecraft.world.phys.shapes.VoxelShape;
 
 public class PaperweightBlockMaterial implements BlockMaterial {
-
-    private static final AABB FULL_CUBE = AABB.unitCubeFromLowerCorner(Vec3.ZERO);
 
     private final BlockState block;
 
@@ -47,8 +43,7 @@ public class PaperweightBlockMaterial implements BlockMaterial {
 
     @Override
     public boolean isFullCube() {
-        VoxelShape vs = block.getCollisionShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
-        return !vs.isEmpty() && vs.bounds().equals(FULL_CUBE);
+        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_3/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_3/PaperweightAdapter.java
@@ -69,6 +69,7 @@ import com.sk89q.worldedit.world.entity.EntityTypes;
 import com.sk89q.worldedit.world.generation.ConfiguredFeatureType;
 import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.item.ItemType;
+import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.SharedConstants;
 import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
@@ -555,6 +556,12 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
                 ((CraftServer) Bukkit.getServer()).getServer().registryAccess()
             )
         );
+    }
+
+    @Override
+    public BlockMaterial getBlockMaterial(BlockType blockType) {
+        net.minecraft.world.level.block.state.BlockState mcBlockState = getBlockFromType(blockType).defaultBlockState();
+        return new PaperweightBlockMaterial(mcBlockState);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/worldedit-bukkit/adapters/adapter-1.21.3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_3/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_3/PaperweightBlockMaterial.java
@@ -1,0 +1,145 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.bukkit.adapter.impl.v1_21_3;
+
+import com.sk89q.worldedit.world.registry.BlockMaterial;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.Clearable;
+import net.minecraft.world.level.EmptyBlockGetter;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.VoxelShape;
+
+public class PaperweightBlockMaterial implements BlockMaterial {
+
+    private static final AABB FULL_CUBE = AABB.unitCubeFromLowerCorner(Vec3.ZERO);
+
+    private final BlockState block;
+
+    public PaperweightBlockMaterial(BlockState block) {
+        this.block = block;
+    }
+
+    @Override
+    public boolean isAir() {
+        return block.isAir();
+    }
+
+    @Override
+    public boolean isFullCube() {
+        VoxelShape vs = block.getCollisionShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
+        return !vs.isEmpty() && vs.bounds().equals(FULL_CUBE);
+    }
+
+    @Override
+    public boolean isOpaque() {
+        return block.canOcclude();
+    }
+
+    @Override
+    public boolean isPowerSource() {
+        return block.isSignalSource();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isLiquid() {
+        return block.liquid();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isSolid() {
+        return block.isSolid();
+    }
+
+    @Override
+    public float getHardness() {
+        return block.getDestroySpeed(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public float getResistance() {
+        return block.getBlock().getExplosionResistance();
+    }
+
+    @Override
+    public float getSlipperiness() {
+        return block.getBlock().getFriction();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public int getLightValue() {
+        return block.getLightEmission();
+    }
+
+    @Override
+    public boolean isFragileWhenPushed() {
+        return block.getPistonPushReaction() == PushReaction.DESTROY;
+    }
+
+    @Override
+    public boolean isUnpushable() {
+        return block.getPistonPushReaction() == PushReaction.BLOCK;
+    }
+
+    @Override
+    public boolean isTicksRandomly() {
+        return block.isRandomlyTicking();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isMovementBlocker() {
+        return block.blocksMotion();
+    }
+
+    @Override
+    public boolean isBurnable() {
+        return block.ignitedByLava();
+    }
+
+    @Override
+    public boolean isToolRequired() {
+        return block.requiresCorrectToolForDrops();
+    }
+
+    @Override
+    public boolean isReplacedDuringPlacement() {
+        return block.canBeReplaced();
+    }
+
+    @Override
+    public boolean isTranslucent() {
+        return !block.canOcclude();
+    }
+
+    @Override
+    public boolean hasContainer() {
+        return block.getBlock() instanceof EntityBlock entityBlock
+                && entityBlock.newBlockEntity(BlockPos.ZERO, block) instanceof Clearable;
+    }
+
+}

--- a/worldedit-bukkit/adapters/adapter-1.21.3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_3/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_3/PaperweightBlockMaterial.java
@@ -23,16 +23,12 @@ import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
-import net.minecraft.world.phys.AABB;
-import net.minecraft.world.phys.Vec3;
-import net.minecraft.world.phys.shapes.VoxelShape;
 
 public class PaperweightBlockMaterial implements BlockMaterial {
-
-    private static final AABB FULL_CUBE = AABB.unitCubeFromLowerCorner(Vec3.ZERO);
 
     private final BlockState block;
 
@@ -47,8 +43,7 @@ public class PaperweightBlockMaterial implements BlockMaterial {
 
     @Override
     public boolean isFullCube() {
-        VoxelShape vs = block.getCollisionShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
-        return !vs.isEmpty() && vs.bounds().equals(FULL_CUBE);
+        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
@@ -70,6 +70,7 @@ import com.sk89q.worldedit.world.entity.EntityTypes;
 import com.sk89q.worldedit.world.generation.ConfiguredFeatureType;
 import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.item.ItemType;
+import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.SharedConstants;
 import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
@@ -555,6 +556,12 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
                 ((CraftServer) Bukkit.getServer()).getServer().registryAccess()
             )
         );
+    }
+
+    @Override
+    public BlockMaterial getBlockMaterial(BlockType blockType) {
+        net.minecraft.world.level.block.state.BlockState mcBlockState = getBlockFromType(blockType).defaultBlockState();
+        return new PaperweightBlockMaterial(mcBlockState);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightBlockMaterial.java
@@ -23,16 +23,12 @@ import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
-import net.minecraft.world.phys.AABB;
-import net.minecraft.world.phys.Vec3;
-import net.minecraft.world.phys.shapes.VoxelShape;
 
 public class PaperweightBlockMaterial implements BlockMaterial {
-
-    private static final AABB FULL_CUBE = AABB.unitCubeFromLowerCorner(Vec3.ZERO);
 
     private final BlockState block;
 
@@ -47,8 +43,7 @@ public class PaperweightBlockMaterial implements BlockMaterial {
 
     @Override
     public boolean isFullCube() {
-        VoxelShape vs = block.getCollisionShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
-        return !vs.isEmpty() && vs.bounds().equals(FULL_CUBE);
+        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightBlockMaterial.java
@@ -1,0 +1,145 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.bukkit.adapter.impl.v1_21_4;
+
+import com.sk89q.worldedit.world.registry.BlockMaterial;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.Clearable;
+import net.minecraft.world.level.EmptyBlockGetter;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.VoxelShape;
+
+public class PaperweightBlockMaterial implements BlockMaterial {
+
+    private static final AABB FULL_CUBE = AABB.unitCubeFromLowerCorner(Vec3.ZERO);
+
+    private final BlockState block;
+
+    public PaperweightBlockMaterial(BlockState block) {
+        this.block = block;
+    }
+
+    @Override
+    public boolean isAir() {
+        return block.isAir();
+    }
+
+    @Override
+    public boolean isFullCube() {
+        VoxelShape vs = block.getCollisionShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
+        return !vs.isEmpty() && vs.bounds().equals(FULL_CUBE);
+    }
+
+    @Override
+    public boolean isOpaque() {
+        return block.canOcclude();
+    }
+
+    @Override
+    public boolean isPowerSource() {
+        return block.isSignalSource();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isLiquid() {
+        return block.liquid();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isSolid() {
+        return block.isSolid();
+    }
+
+    @Override
+    public float getHardness() {
+        return block.getDestroySpeed(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public float getResistance() {
+        return block.getBlock().getExplosionResistance();
+    }
+
+    @Override
+    public float getSlipperiness() {
+        return block.getBlock().getFriction();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public int getLightValue() {
+        return block.getLightEmission();
+    }
+
+    @Override
+    public boolean isFragileWhenPushed() {
+        return block.getPistonPushReaction() == PushReaction.DESTROY;
+    }
+
+    @Override
+    public boolean isUnpushable() {
+        return block.getPistonPushReaction() == PushReaction.BLOCK;
+    }
+
+    @Override
+    public boolean isTicksRandomly() {
+        return block.isRandomlyTicking();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isMovementBlocker() {
+        return block.blocksMotion();
+    }
+
+    @Override
+    public boolean isBurnable() {
+        return block.ignitedByLava();
+    }
+
+    @Override
+    public boolean isToolRequired() {
+        return block.requiresCorrectToolForDrops();
+    }
+
+    @Override
+    public boolean isReplacedDuringPlacement() {
+        return block.canBeReplaced();
+    }
+
+    @Override
+    public boolean isTranslucent() {
+        return !block.canOcclude();
+    }
+
+    @Override
+    public boolean hasContainer() {
+        return block.getBlock() instanceof EntityBlock entityBlock
+                && entityBlock.newBlockEntity(BlockPos.ZERO, block) instanceof Clearable;
+    }
+
+}

--- a/worldedit-bukkit/adapters/adapter-1.21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21/PaperweightAdapter.java
@@ -68,6 +68,7 @@ import com.sk89q.worldedit.world.entity.EntityTypes;
 import com.sk89q.worldedit.world.generation.ConfiguredFeatureType;
 import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.item.ItemType;
+import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.SharedConstants;
 import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
@@ -577,6 +578,12 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     @Override
     public Component getRichItemName(BaseItemStack itemStack) {
         return TranslatableComponent.of(CraftItemStack.asNMSCopy(BukkitAdapter.adapt(itemStack)).getDescriptionId());
+    }
+
+    @Override
+    public BlockMaterial getBlockMaterial(BlockType blockType) {
+        net.minecraft.world.level.block.state.BlockState mcBlockState = getBlockFromType(blockType).defaultBlockState();
+        return new PaperweightBlockMaterial(mcBlockState);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/worldedit-bukkit/adapters/adapter-1.21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21/PaperweightBlockMaterial.java
@@ -23,16 +23,12 @@ import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
-import net.minecraft.world.phys.AABB;
-import net.minecraft.world.phys.Vec3;
-import net.minecraft.world.phys.shapes.VoxelShape;
 
 public class PaperweightBlockMaterial implements BlockMaterial {
-
-    private static final AABB FULL_CUBE = AABB.unitCubeFromLowerCorner(Vec3.ZERO);
 
     private final BlockState block;
 
@@ -47,8 +43,7 @@ public class PaperweightBlockMaterial implements BlockMaterial {
 
     @Override
     public boolean isFullCube() {
-        VoxelShape vs = block.getCollisionShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
-        return !vs.isEmpty() && vs.bounds().equals(FULL_CUBE);
+        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21/PaperweightBlockMaterial.java
@@ -1,0 +1,145 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.bukkit.adapter.impl.v1_21;
+
+import com.sk89q.worldedit.world.registry.BlockMaterial;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.Clearable;
+import net.minecraft.world.level.EmptyBlockGetter;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.VoxelShape;
+
+public class PaperweightBlockMaterial implements BlockMaterial {
+
+    private static final AABB FULL_CUBE = AABB.unitCubeFromLowerCorner(Vec3.ZERO);
+
+    private final BlockState block;
+
+    public PaperweightBlockMaterial(BlockState block) {
+        this.block = block;
+    }
+
+    @Override
+    public boolean isAir() {
+        return block.isAir();
+    }
+
+    @Override
+    public boolean isFullCube() {
+        VoxelShape vs = block.getCollisionShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
+        return !vs.isEmpty() && vs.bounds().equals(FULL_CUBE);
+    }
+
+    @Override
+    public boolean isOpaque() {
+        return block.canOcclude();
+    }
+
+    @Override
+    public boolean isPowerSource() {
+        return block.isSignalSource();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isLiquid() {
+        return block.liquid();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isSolid() {
+        return block.isSolid();
+    }
+
+    @Override
+    public float getHardness() {
+        return block.getDestroySpeed(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public float getResistance() {
+        return block.getBlock().getExplosionResistance();
+    }
+
+    @Override
+    public float getSlipperiness() {
+        return block.getBlock().getFriction();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public int getLightValue() {
+        return block.getLightEmission();
+    }
+
+    @Override
+    public boolean isFragileWhenPushed() {
+        return block.getPistonPushReaction() == PushReaction.DESTROY;
+    }
+
+    @Override
+    public boolean isUnpushable() {
+        return block.getPistonPushReaction() == PushReaction.BLOCK;
+    }
+
+    @Override
+    public boolean isTicksRandomly() {
+        return block.isRandomlyTicking();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isMovementBlocker() {
+        return block.blocksMotion();
+    }
+
+    @Override
+    public boolean isBurnable() {
+        return block.ignitedByLava();
+    }
+
+    @Override
+    public boolean isToolRequired() {
+        return block.requiresCorrectToolForDrops();
+    }
+
+    @Override
+    public boolean isReplacedDuringPlacement() {
+        return block.canBeReplaced();
+    }
+
+    @Override
+    public boolean isTranslucent() {
+        return !block.canOcclude();
+    }
+
+    @Override
+    public boolean hasContainer() {
+        return block.getBlock() instanceof EntityBlock entityBlock
+                && entityBlock.newBlockEntity(BlockPos.ZERO, block) instanceof Clearable;
+    }
+
+}

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockRegistry.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockRegistry.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.OptionalInt;
 import javax.annotation.Nullable;
 
+@SuppressWarnings({ "removal", "deprecation" })
 public class BukkitBlockRegistry extends BundledBlockRegistry {
     private final Map<Material, BukkitBlockMaterial> materialMap = new HashMap<>();
 

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockRegistry.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockRegistry.java
@@ -21,10 +21,11 @@ package com.sk89q.worldedit.bukkit;
 
 import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.util.formatting.text.Component;
+import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
-import com.sk89q.worldedit.world.registry.BundledBlockRegistry;
+import com.sk89q.worldedit.world.registry.BlockRegistry;
 import com.sk89q.worldedit.world.registry.PassthroughBlockMaterial;
 import org.bukkit.Material;
 
@@ -33,8 +34,7 @@ import java.util.Map;
 import java.util.OptionalInt;
 import javax.annotation.Nullable;
 
-@SuppressWarnings({ "removal", "deprecation" })
-public class BukkitBlockRegistry extends BundledBlockRegistry {
+public class BukkitBlockRegistry implements BlockRegistry {
     private final Map<Material, BukkitBlockMaterial> materialMap = new HashMap<>();
 
     @Override
@@ -42,7 +42,7 @@ public class BukkitBlockRegistry extends BundledBlockRegistry {
         if (WorldEditPlugin.getInstance().getBukkitImplAdapter() != null) {
             return WorldEditPlugin.getInstance().getBukkitImplAdapter().getRichBlockName(blockType);
         }
-        return super.getRichName(blockType);
+        return TextComponent.of(blockType.id());
     }
 
     @Nullable
@@ -52,7 +52,13 @@ public class BukkitBlockRegistry extends BundledBlockRegistry {
         if (mat == null) {
             return null;
         }
-        return materialMap.computeIfAbsent(mat, material -> new BukkitBlockMaterial(BukkitBlockRegistry.super.getMaterial(blockType), material));
+        return materialMap.computeIfAbsent(mat, material -> {
+            BlockMaterial platformMaterial = null;
+            if (WorldEditPlugin.getInstance().getBukkitImplAdapter() != null) {
+                platformMaterial = WorldEditPlugin.getInstance().getBukkitImplAdapter().getBlockMaterial(blockType);
+            }
+            return new BukkitBlockMaterial(platformMaterial, material);
+        });
     }
 
     @Nullable
@@ -61,7 +67,7 @@ public class BukkitBlockRegistry extends BundledBlockRegistry {
         if (WorldEditPlugin.getInstance().getBukkitImplAdapter() != null) {
             return WorldEditPlugin.getInstance().getBukkitImplAdapter().getProperties(blockType);
         }
-        return super.getProperties(blockType);
+        return null;
     }
 
     @Override
@@ -83,14 +89,7 @@ public class BukkitBlockRegistry extends BundledBlockRegistry {
 
         @Override
         public boolean isAir() {
-            switch (material) {
-                case AIR:
-                case CAVE_AIR:
-                case VOID_AIR:
-                    return true;
-                default:
-                    return false;
-            }
+            return material.isAir();
         }
 
         @Override
@@ -106,7 +105,7 @@ public class BukkitBlockRegistry extends BundledBlockRegistry {
         @SuppressWarnings("deprecation")
         @Override
         public boolean isTranslucent() {
-            return material.isTransparent();
+            return super.isTranslucent() || material.isTransparent();
         }
     }
 }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
@@ -41,6 +41,7 @@ import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.generation.ConfiguredFeatureType;
 import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.item.ItemType;
+import com.sk89q.worldedit.world.registry.BlockMaterial;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.data.BlockData;
@@ -148,6 +149,15 @@ public interface BukkitImplAdapter {
      * @return The name
      */
     Component getRichItemName(BaseItemStack itemStack);
+
+    /**
+     * Gets the block material for the given block type.
+     *
+     * @param blockType the block type
+     * @return the material
+     */
+    @Nullable
+    BlockMaterial getBlockMaterial(BlockType blockType);
 
     /**
      * Get a map of {@code string -> property}.

--- a/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIBlockRegistry.java
+++ b/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIBlockRegistry.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
+@SuppressWarnings("removal")
 public class CLIBlockRegistry extends BundledBlockRegistry {
 
     private Property<?> createProperty(String type, String key, List<String> values) {

--- a/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIWorldEdit.java
+++ b/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIWorldEdit.java
@@ -48,7 +48,6 @@ import com.sk89q.worldedit.world.block.FuzzyBlockState;
 import com.sk89q.worldedit.world.entity.EntityType;
 import com.sk89q.worldedit.world.item.ItemCategory;
 import com.sk89q.worldedit.world.item.ItemType;
-import com.sk89q.worldedit.world.registry.BundledBlockData;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
@@ -93,9 +92,6 @@ public class CLIWorldEdit {
 
     @SuppressWarnings("removal")
     private void setupPlatform() {
-        // TODO Move this registry into the CLI data format
-        BundledBlockData.getInstance(); // Load block registry
-
         WorldEdit.getInstance().getPlatformManager().register(platform);
 
         registerCommands();

--- a/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIWorldEdit.java
+++ b/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIWorldEdit.java
@@ -48,6 +48,7 @@ import com.sk89q.worldedit.world.block.FuzzyBlockState;
 import com.sk89q.worldedit.world.entity.EntityType;
 import com.sk89q.worldedit.world.item.ItemCategory;
 import com.sk89q.worldedit.world.item.ItemType;
+import com.sk89q.worldedit.world.registry.BundledBlockData;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
@@ -90,7 +91,11 @@ public class CLIWorldEdit {
         inst = this;
     }
 
+    @SuppressWarnings("removal")
     private void setupPlatform() {
+        // TODO Move this registry into the CLI data format
+        BundledBlockData.getInstance(); // Load block registry
+
         WorldEdit.getInstance().getPlatformManager().register(platform);
 
         registerCommands();

--- a/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIWorldEdit.java
+++ b/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIWorldEdit.java
@@ -90,7 +90,6 @@ public class CLIWorldEdit {
         inst = this;
     }
 
-    @SuppressWarnings("removal")
     private void setupPlatform() {
         WorldEdit.getInstance().getPlatformManager().register(platform);
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -71,7 +71,6 @@ import com.sk89q.worldedit.util.translation.TranslationManager;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockType;
-import com.sk89q.worldedit.world.registry.BundledBlockData;
 import com.sk89q.worldedit.world.registry.LegacyMapper;
 import org.apache.logging.log4j.Logger;
 
@@ -403,9 +402,7 @@ public final class WorldEdit {
     /**
      * Load the bundled mappings.
      */
-    @SuppressWarnings("removal")
     public void loadMappings() {
-        BundledBlockData.getInstance(); // Load block registry
         LegacyMapper.getInstance(); // Load legacy mappings
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -403,6 +403,7 @@ public final class WorldEdit {
     /**
      * Load the bundled mappings.
      */
+    @SuppressWarnings("removal")
     public void loadMappings() {
         BundledBlockData.getInstance(); // Load block registry
         LegacyMapper.getInstance(); // Load legacy mappings

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledBlockData.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledBlockData.java
@@ -47,6 +47,7 @@ import javax.annotation.Nullable;
  * reading fails (which occurs when this class is first instantiated), then
  * the methods will return {@code null}s for all blocks.</p>
  */
+@Deprecated(forRemoval = true)
 public final class BundledBlockData {
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledBlockRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledBlockRegistry.java
@@ -36,6 +36,8 @@ import javax.annotation.Nullable;
  * A block registry that uses {@link BundledBlockData} to serve information
  * about blocks.
  */
+@SuppressWarnings({ "deprecation", "removal" })
+@Deprecated(forRemoval = true)
 public class BundledBlockRegistry implements BlockRegistry {
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledRegistries.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledRegistries.java
@@ -66,6 +66,7 @@ public class BundledRegistries implements Registries {
         return url;
     }
 
+    @SuppressWarnings("removal")
     private final BundledBlockRegistry blockRegistry = new BundledBlockRegistry();
     @SuppressWarnings("removal")
     private final BundledItemRegistry itemRegistry = new BundledItemRegistry();

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricBlockMaterial.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricBlockMaterial.java
@@ -23,12 +23,10 @@ import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
-import net.minecraft.world.phys.AABB;
-import net.minecraft.world.phys.Vec3;
-import net.minecraft.world.phys.shapes.VoxelShape;
 
 /**
  * Fabric block material that pulls as much info as possible from the Minecraft
@@ -36,8 +34,6 @@ import net.minecraft.world.phys.shapes.VoxelShape;
  * bundled block info.
  */
 public class FabricBlockMaterial implements BlockMaterial {
-
-    private static final AABB FULL_CUBE = AABB.unitCubeFromLowerCorner(Vec3.ZERO);
 
     private final BlockState block;
 
@@ -52,8 +48,7 @@ public class FabricBlockMaterial implements BlockMaterial {
 
     @Override
     public boolean isFullCube() {
-        VoxelShape vs = block.getCollisionShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
-        return !vs.isEmpty() && vs.bounds().equals(FULL_CUBE);
+        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
     }
 
     @Override

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricBlockMaterial.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricBlockMaterial.java
@@ -141,8 +141,8 @@ public class FabricBlockMaterial implements BlockMaterial {
 
     @Override
     public boolean hasContainer() {
-        return block.getBlock() instanceof EntityBlock entityBlock &&
-            entityBlock.newBlockEntity(BlockPos.ZERO, block) instanceof Clearable;
+        return block.getBlock() instanceof EntityBlock entityBlock
+                && entityBlock.newBlockEntity(BlockPos.ZERO, block) instanceof Clearable;
     }
 
 }

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricBlockRegistry.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricBlockRegistry.java
@@ -26,7 +26,7 @@ import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
-import com.sk89q.worldedit.world.registry.BundledBlockRegistry;
+import com.sk89q.worldedit.world.registry.BlockRegistry;
 import net.minecraft.world.level.block.Block;
 
 import java.util.Collection;
@@ -35,7 +35,7 @@ import java.util.Map;
 import java.util.OptionalInt;
 import java.util.TreeMap;
 
-public class FabricBlockRegistry extends BundledBlockRegistry {
+public class FabricBlockRegistry implements BlockRegistry {
 
     private final Map<net.minecraft.world.level.block.state.BlockState, FabricBlockMaterial> materialMap = new HashMap<>();
 
@@ -49,7 +49,7 @@ public class FabricBlockRegistry extends BundledBlockRegistry {
         Block block = FabricAdapter.adapt(blockType);
         return materialMap.computeIfAbsent(
             block.defaultBlockState(),
-            m -> new FabricBlockMaterial(m, super.getMaterial(blockType))
+            FabricBlockMaterial::new
         );
     }
 

--- a/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgeBlockMaterial.java
+++ b/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgeBlockMaterial.java
@@ -20,29 +20,40 @@
 package com.sk89q.worldedit.neoforge;
 
 import com.sk89q.worldedit.world.registry.BlockMaterial;
-import com.sk89q.worldedit.world.registry.PassthroughBlockMaterial;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.Clearable;
+import net.minecraft.world.level.EmptyBlockGetter;
+import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
-
-import javax.annotation.Nullable;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
 /**
  * Forge block material that pulls as much info as possible from the Minecraft
  * Material, and passes the rest to another implementation, typically the
  * bundled block info.
  */
-public class NeoForgeBlockMaterial extends PassthroughBlockMaterial {
+public class NeoForgeBlockMaterial implements BlockMaterial {
+
+    private static final AABB FULL_CUBE = AABB.unitCubeFromLowerCorner(Vec3.ZERO);
 
     private final BlockState block;
 
-    public NeoForgeBlockMaterial(BlockState block, @Nullable BlockMaterial secondary) {
-        super(secondary);
+    public NeoForgeBlockMaterial(BlockState block) {
         this.block = block;
     }
 
     @Override
     public boolean isAir() {
-        return block.isAir() || super.isAir();
+        return block.isAir();
+    }
+
+    @Override
+    public boolean isFullCube() {
+        VoxelShape vs = block.getCollisionShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
+        return !vs.isEmpty() && vs.bounds().equals(FULL_CUBE);
     }
 
     @Override
@@ -50,16 +61,43 @@ public class NeoForgeBlockMaterial extends PassthroughBlockMaterial {
         return block.canOcclude();
     }
 
-    @SuppressWarnings("deprecation")
     @Override
+    public boolean isPowerSource() {
+        return block.isSignalSource();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
     public boolean isLiquid() {
         return block.liquid();
     }
 
-    @SuppressWarnings("deprecation")
     @Override
+    @SuppressWarnings("deprecation")
     public boolean isSolid() {
         return block.isSolid();
+    }
+
+    @Override
+    public float getHardness() {
+        return block.getDestroySpeed(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public float getResistance() {
+        return block.getBlock().getExplosionResistance();
+    }
+
+    @Override
+    public float getSlipperiness() {
+        return block.getBlock().getFriction();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public int getLightValue() {
+        return block.getLightEmission();
     }
 
     @Override
@@ -72,8 +110,13 @@ public class NeoForgeBlockMaterial extends PassthroughBlockMaterial {
         return block.getPistonPushReaction() == PushReaction.BLOCK;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
+    public boolean isTicksRandomly() {
+        return block.isRandomlyTicking();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
     public boolean isMovementBlocker() {
         return block.blocksMotion();
     }
@@ -85,12 +128,23 @@ public class NeoForgeBlockMaterial extends PassthroughBlockMaterial {
 
     @Override
     public boolean isToolRequired() {
-        return !block.requiresCorrectToolForDrops();
+        return block.requiresCorrectToolForDrops();
     }
 
     @Override
     public boolean isReplacedDuringPlacement() {
         return block.canBeReplaced();
+    }
+
+    @Override
+    public boolean isTranslucent() {
+        return !block.canOcclude();
+    }
+
+    @Override
+    public boolean hasContainer() {
+        return block.getBlock() instanceof EntityBlock entityBlock
+                && entityBlock.newBlockEntity(BlockPos.ZERO, block) instanceof Clearable;
     }
 
 }

--- a/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgeBlockMaterial.java
+++ b/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgeBlockMaterial.java
@@ -23,12 +23,10 @@ import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
-import net.minecraft.world.phys.AABB;
-import net.minecraft.world.phys.Vec3;
-import net.minecraft.world.phys.shapes.VoxelShape;
 
 /**
  * Forge block material that pulls as much info as possible from the Minecraft
@@ -36,8 +34,6 @@ import net.minecraft.world.phys.shapes.VoxelShape;
  * bundled block info.
  */
 public class NeoForgeBlockMaterial implements BlockMaterial {
-
-    private static final AABB FULL_CUBE = AABB.unitCubeFromLowerCorner(Vec3.ZERO);
 
     private final BlockState block;
 
@@ -52,8 +48,7 @@ public class NeoForgeBlockMaterial implements BlockMaterial {
 
     @Override
     public boolean isFullCube() {
-        VoxelShape vs = block.getCollisionShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
-        return !vs.isEmpty() && vs.bounds().equals(FULL_CUBE);
+        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
     }
 
     @Override

--- a/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgeBlockRegistry.java
+++ b/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgeBlockRegistry.java
@@ -26,7 +26,7 @@ import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
-import com.sk89q.worldedit.world.registry.BundledBlockRegistry;
+import com.sk89q.worldedit.world.registry.BlockRegistry;
 import net.minecraft.world.level.block.Block;
 
 import java.util.Collection;
@@ -35,7 +35,7 @@ import java.util.Map;
 import java.util.OptionalInt;
 import java.util.TreeMap;
 
-public class NeoForgeBlockRegistry extends BundledBlockRegistry {
+public class NeoForgeBlockRegistry implements BlockRegistry {
 
     private final Map<net.minecraft.world.level.block.state.BlockState, NeoForgeBlockMaterial> materialMap = new HashMap<>();
 
@@ -47,12 +47,9 @@ public class NeoForgeBlockRegistry extends BundledBlockRegistry {
     @Override
     public BlockMaterial getMaterial(BlockType blockType) {
         Block block = NeoForgeAdapter.adapt(blockType);
-        if (block == null) {
-            return super.getMaterial(blockType);
-        }
         return materialMap.computeIfAbsent(
             block.defaultBlockState(),
-            s -> new NeoForgeBlockMaterial(s, super.getMaterial(blockType))
+            NeoForgeBlockMaterial::new
         );
     }
 

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeBlockMaterial.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeBlockMaterial.java
@@ -23,12 +23,10 @@ import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
-import net.minecraft.world.phys.AABB;
-import net.minecraft.world.phys.Vec3;
-import net.minecraft.world.phys.shapes.VoxelShape;
 
 /**
  * Sponge block material that pulls as much info as possible from the Minecraft
@@ -36,8 +34,6 @@ import net.minecraft.world.phys.shapes.VoxelShape;
  * bundled block info.
  */
 public class SpongeBlockMaterial implements BlockMaterial {
-
-    private static final AABB FULL_CUBE = AABB.unitCubeFromLowerCorner(Vec3.ZERO);
 
     private final BlockState block;
 
@@ -52,8 +48,7 @@ public class SpongeBlockMaterial implements BlockMaterial {
 
     @Override
     public boolean isFullCube() {
-        VoxelShape vs = block.getCollisionShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
-        return !vs.isEmpty() && vs.bounds().equals(FULL_CUBE);
+        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
     }
 
     @Override

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeBlockMaterial.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeBlockMaterial.java
@@ -20,34 +20,50 @@
 package com.sk89q.worldedit.sponge;
 
 import com.sk89q.worldedit.world.registry.BlockMaterial;
-import com.sk89q.worldedit.world.registry.PassthroughBlockMaterial;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.Clearable;
+import net.minecraft.world.level.EmptyBlockGetter;
+import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
-
-import javax.annotation.Nullable;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
 /**
  * Sponge block material that pulls as much info as possible from the Minecraft
  * Material, and passes the rest to another implementation, typically the
  * bundled block info.
  */
-public class SpongeBlockMaterial extends PassthroughBlockMaterial {
+public class SpongeBlockMaterial implements BlockMaterial {
+
+    private static final AABB FULL_CUBE = AABB.unitCubeFromLowerCorner(Vec3.ZERO);
 
     private final BlockState block;
 
-    public SpongeBlockMaterial(BlockState block, @Nullable BlockMaterial secondary) {
-        super(secondary);
+    public SpongeBlockMaterial(BlockState block) {
         this.block = block;
     }
 
     @Override
     public boolean isAir() {
-        return block.isAir() || super.isAir();
+        return block.isAir();
+    }
+
+    @Override
+    public boolean isFullCube() {
+        VoxelShape vs = block.getCollisionShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
+        return !vs.isEmpty() && vs.bounds().equals(FULL_CUBE);
     }
 
     @Override
     public boolean isOpaque() {
         return block.canOcclude();
+    }
+
+    @Override
+    public boolean isPowerSource() {
+        return block.isSignalSource();
     }
 
     @Override
@@ -63,6 +79,26 @@ public class SpongeBlockMaterial extends PassthroughBlockMaterial {
     }
 
     @Override
+    public float getHardness() {
+        return block.getDestroySpeed(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
+    }
+
+    @Override
+    public float getResistance() {
+        return block.getBlock().getExplosionResistance();
+    }
+
+    @Override
+    public float getSlipperiness() {
+        return block.getBlock().getFriction();
+    }
+
+    @Override
+    public int getLightValue() {
+        return block.getLightEmission();
+    }
+
+    @Override
     public boolean isFragileWhenPushed() {
         return block.getPistonPushReaction() == PushReaction.DESTROY;
     }
@@ -70,6 +106,11 @@ public class SpongeBlockMaterial extends PassthroughBlockMaterial {
     @Override
     public boolean isUnpushable() {
         return block.getPistonPushReaction() == PushReaction.BLOCK;
+    }
+
+    @Override
+    public boolean isTicksRandomly() {
+        return block.isRandomlyTicking();
     }
 
     @Override
@@ -91,6 +132,17 @@ public class SpongeBlockMaterial extends PassthroughBlockMaterial {
     @Override
     public boolean isReplacedDuringPlacement() {
         return block.canBeReplaced();
+    }
+
+    @Override
+    public boolean isTranslucent() {
+        return !block.canOcclude();
+    }
+
+    @Override
+    public boolean hasContainer() {
+        return block.getBlock() instanceof EntityBlock entityBlock
+                && entityBlock.newBlockEntity(BlockPos.ZERO, block) instanceof Clearable;
     }
 
 }

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeBlockRegistry.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeBlockRegistry.java
@@ -25,7 +25,7 @@ import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
-import com.sk89q.worldedit.world.registry.BundledBlockRegistry;
+import com.sk89q.worldedit.world.registry.BlockRegistry;
 import net.minecraft.world.level.block.Block;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
@@ -38,7 +38,7 @@ import java.util.Map;
 import java.util.OptionalInt;
 import java.util.TreeMap;
 
-public class SpongeBlockRegistry extends BundledBlockRegistry {
+public class SpongeBlockRegistry implements BlockRegistry {
 
     private final Map<org.spongepowered.api.block.BlockState, SpongeBlockMaterial> materialMap =
         new HashMap<>();
@@ -60,8 +60,7 @@ public class SpongeBlockRegistry extends BundledBlockRegistry {
                 net.minecraft.world.level.block.state.BlockState blockState =
                     (net.minecraft.world.level.block.state.BlockState) m;
                 return new SpongeBlockMaterial(
-                    blockState,
-                    super.getMaterial(blockType)
+                    blockState
                 );
             }
         );


### PR DESCRIPTION
This PR deprecates the concept of bundled block data, and removes it from all non-CLI platforms.

To fully remove it from CLI, we'll have to likely add this data into the current CLI data format, which is out of scope for this PR and a bit of a larger task (new version; also needs to include items etc)

This also, like with the item registry changes, allows us to skip loading of the bundled data on startup. If a plugin is using it for some reason, it'll still load, but by default it won't be loaded into server memory.