### PR TITLE
Improve error handling for unsupported schematic files

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicLoadException.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicLoadException.java
@@ -24,7 +24,7 @@ import com.sk89q.worldedit.util.formatting.text.Component;
 /**
  * Raised when a known exception occurs during schematic load.
  */
-public class SchematicLoadException extends RuntimeException {
+public final class SchematicLoadException extends RuntimeException {
 
     private final Component message;
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicLoadException.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicLoadException.java
@@ -1,0 +1,43 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.extent.clipboard.io;
+
+import com.sk89q.worldedit.util.formatting.text.Component;
+
+/**
+ * Raised when a known exception occurs during schematic load.
+ */
+public class SchematicLoadException extends RuntimeException {
+
+    private final Component message;
+
+    public SchematicLoadException(Component message) {
+        this.message = message;
+    }
+
+    /**
+     * Get the message of this exception as a rich text component.
+     *
+     * @return The rich message
+     */
+    public Component getRichMessage() {
+        return this.message;
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SpongeSchematicReader.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SpongeSchematicReader.java
@@ -45,6 +45,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.DataFixer;
 import com.sk89q.worldedit.world.biome.BiomeType;
@@ -125,7 +126,7 @@ public class SpongeSchematicReader extends NBTSchematicReader {
             BlockArrayClipboard clip = readVersion1(schematicTag);
             return readVersion2(clip, schematicTag);
         }
-        throw new SchematicLoadException(TranslatableComponent.of("worldedit.schematic.load.unsupported-version"));
+        throw new SchematicLoadException(TranslatableComponent.of("worldedit.schematic.load.unsupported-version", TextComponent.of(schematicVersion)));
     }
 
     @Override
@@ -155,7 +156,8 @@ public class SpongeSchematicReader extends NBTSchematicReader {
         // Check
         Map<String, Tag> schematic = schematicTag.getValue();
 
-        // Handle newer versions in a cleaner way
+        // Be lenient about the specific nesting level of the Schematic tag
+        // Also allows checking the version from newer versions of the specification
         if (schematic.size() == 1 && schematic.containsKey("Schematic")) {
             schematicTag = requireTag(schematic, "Schematic", CompoundTag.class);
             schematic = schematicTag.getValue();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SpongeSchematicReader.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SpongeSchematicReader.java
@@ -45,6 +45,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.DataFixer;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.biome.BiomeTypes;
@@ -124,7 +125,7 @@ public class SpongeSchematicReader extends NBTSchematicReader {
             BlockArrayClipboard clip = readVersion1(schematicTag);
             return readVersion2(clip, schematicTag);
         }
-        throw new IOException("This schematic version is currently not supported");
+        throw new SchematicLoadException(TranslatableComponent.of("worldedit.schematic.load.unsupported-version"));
     }
 
     @Override
@@ -153,6 +154,12 @@ public class SpongeSchematicReader extends NBTSchematicReader {
 
         // Check
         Map<String, Tag> schematic = schematicTag.getValue();
+
+        // Handle newer versions in a cleaner way
+        if (schematic.size() == 1 && schematic.containsKey("Schematic")) {
+            schematicTag = requireTag(schematic, "Schematic", CompoundTag.class);
+            schematic = schematicTag.getValue();
+        }
 
         schematicVersion = requireTag(schematic, "Version", IntTag.class).getValue();
         return schematicTag;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/command/exception/WorldEditExceptionConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/command/exception/WorldEditExceptionConverter.java
@@ -34,6 +34,7 @@ import com.sk89q.worldedit.command.InsufficientArgumentsException;
 import com.sk89q.worldedit.command.tool.InvalidToolBindException;
 import com.sk89q.worldedit.extension.input.DisallowedUsageException;
 import com.sk89q.worldedit.extension.input.NoMatchException;
+import com.sk89q.worldedit.extent.clipboard.io.SchematicLoadException;
 import com.sk89q.worldedit.internal.expression.ExpressionException;
 import com.sk89q.worldedit.regions.RegionOperationException;
 import com.sk89q.worldedit.util.formatting.text.Component;
@@ -181,6 +182,11 @@ public class WorldEditExceptionConverter extends ExceptionConverterHelper {
     @ExceptionMatch
     public void convert(FileSelectionAbortedException e) throws CommandException {
         throw newCommandException(TranslatableComponent.of("worldedit.error.file-aborted"), e);
+    }
+
+    @ExceptionMatch
+    public void convert(SchematicLoadException e) throws CommandException {
+        throw newCommandException(e.getRichMessage(), e);
     }
 
     @ExceptionMatch

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -106,7 +106,7 @@
     "worldedit.schematic.load.does-not-exist": "Schematic {0} does not exist!",
     "worldedit.schematic.load.loading": "(Please wait... loading schematic.)",
     "worldedit.schematic.load.still-loading": "(Please wait... still loading schematic.)",
-    "worldedit.schematic.load.unsupported-version": "This schematic version is currently not supported.",
+    "worldedit.schematic.load.unsupported-version": "This schematic version is currently not supported. Version: {0}.",
     "worldedit.schematic.save.already-exists": "That schematic already exists. Use the -f flag to overwrite it.",
     "worldedit.schematic.save.failed-directory": "Could not create folder for schematics!",
     "worldedit.schematic.save.saving": "(Please wait... saving schematic.)",

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -106,6 +106,7 @@
     "worldedit.schematic.load.does-not-exist": "Schematic {0} does not exist!",
     "worldedit.schematic.load.loading": "(Please wait... loading schematic.)",
     "worldedit.schematic.load.still-loading": "(Please wait... still loading schematic.)",
+    "worldedit.schematic.load.unsupported-version": "This schematic version is currently not supported.",
     "worldedit.schematic.save.already-exists": "That schematic already exists. Use the -f flag to overwrite it.",
     "worldedit.schematic.save.failed-directory": "Could not create folder for schematics!",
     "worldedit.schematic.save.saving": "(Please wait... saving schematic.)",


### PR DESCRIPTION
This PR does two things:

* Unwraps an internal `Schematic` tag, to improve cross-version compatibility when reading schematic files (or ones that violate spec)
* Prints the unsupported version error to the player, rather than as an IOException. This also means it now supports translation.