### PR TITLE
fix hang on shutdown for fabric due to hanging user threads

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/util/FutureProgressListener.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/util/FutureProgressListener.java
@@ -32,7 +32,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class FutureProgressListener implements Runnable {
 
-    private static final Timer timer = new Timer();
+    private static final Timer timer = new Timer(true);
     private static final int MESSAGE_DELAY = 1000; // 1 second
     private static final int MESSAGE_PERIOD = 10000; // 10 seconds
 

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorldEdit.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorldEdit.java
@@ -90,6 +90,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -286,6 +287,7 @@ public class FabricWorldEdit implements ModInitializer {
         WorldEdit worldEdit = WorldEdit.getInstance();
         worldEdit.getSessionManager().unload();
         WorldEdit.getInstance().getEventBus().post(new PlatformUnreadyEvent(platform));
+        WorldEdit.getInstance().getExecutorService().shutdown();
     }
 
     private boolean skipEvents() {


### PR DESCRIPTION
The JVM initiates shutdown when all non-daemon java threads have terminated. When saving a schematic two threads are created that are never stopped, thus preventing the server for finishing the shutdown.

One is the "WorldEdit Task Executor - 0", shich is easily fixed.

The second is the TimerThread created by FutureProgressListener. In this patch the timer is made to use a deamon thread instead. If critical scheduled events on this timer persost after a server shutdown is otherwise complete maybe this needs to be changed to an executor service? Otherwise scheduled events may get lost by the server shutting down.

This fixes #2459 