### PR TITLE
Make the Vector classes into Records

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector2.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector2.java
@@ -26,7 +26,7 @@ import java.util.Comparator;
 /**
  * An immutable 2-dimensional vector.
  */
-public final class BlockVector2 {
+public record BlockVector2(int x, int z) {
 
     public static final BlockVector2 ZERO = new BlockVector2(0, 0);
     public static final BlockVector2 UNIT_X = new BlockVector2(1, 0);
@@ -74,25 +74,13 @@ public final class BlockVector2 {
         return new BlockVector2(x, z);
     }
 
-    private final int x;
-    private final int z;
-
-    /**
-     * Construct an instance.
-     *
-     * @param x the X coordinate
-     * @param z the Z coordinate
-     */
-    private BlockVector2(int x, int z) {
-        this.x = x;
-        this.z = z;
-    }
-
     /**
      * Get the X coordinate.
      *
      * @return the x coordinate
+     * @deprecated use {@link #x()} instead
      */
+    @Deprecated(forRemoval = true)
     public int getX() {
         return x;
     }
@@ -101,7 +89,9 @@ public final class BlockVector2 {
      * Get the X coordinate.
      *
      * @return the x coordinate
+     * @deprecated use {@link #x()} instead
      */
+    @Deprecated(forRemoval = true)
     public int getBlockX() {
         return x;
     }
@@ -120,7 +110,9 @@ public final class BlockVector2 {
      * Get the Z coordinate.
      *
      * @return the z coordinate
+     * @deprecated use {@link #z()} instead
      */
+    @Deprecated(forRemoval = true)
     public int getZ() {
         return z;
     }
@@ -129,7 +121,9 @@ public final class BlockVector2 {
      * Get the Z coordinate.
      *
      * @return the z coordinate
+     * @deprecated use {@link #z()} instead
      */
+    @Deprecated(forRemoval = true)
     public int getBlockZ() {
         return z;
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector2.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector2.java
@@ -531,21 +531,6 @@ public record BlockVector2(int x, int z) {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (!(obj instanceof BlockVector2 other)) {
-            return false;
-        }
-
-        return other.x == this.x && other.z == this.z;
-
-    }
-
-    @Override
-    public int hashCode() {
-        return (x << 16) ^ z;
-    }
-
-    @Override
     public String toString() {
         return "(" + x + ", " + z + ")";
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector3.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector3.java
@@ -682,20 +682,6 @@ public record BlockVector3(int x, int y, int z) {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (!(obj instanceof BlockVector3 other)) {
-            return false;
-        }
-
-        return other.x == this.x && other.y == this.y && other.z == this.z;
-    }
-
-    @Override
-    public int hashCode() {
-        return (x ^ (z << 12)) ^ (y << 24);
-    }
-
-    @Override
     public String toString() {
         return "(" + x + ", " + y + ", " + z + ")";
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector3.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector3.java
@@ -32,7 +32,7 @@ import static com.sk89q.worldedit.math.BitMath.unpackZ;
 /**
  * An immutable 3-dimensional vector.
  */
-public final class BlockVector3 {
+public record BlockVector3(int x, int y, int z) {
 
     public static final BlockVector3 ZERO = new BlockVector3(0, 0, 0);
     public static final BlockVector3 UNIT_X = new BlockVector3(1, 0, 0);
@@ -112,23 +112,6 @@ public final class BlockVector3 {
         return YzxOrderComparator.YZX_ORDER;
     }
 
-    private final int x;
-    private final int y;
-    private final int z;
-
-    /**
-     * Construct an instance.
-     *
-     * @param x the X coordinate
-     * @param y the Y coordinate
-     * @param z the Z coordinate
-     */
-    private BlockVector3(int x, int y, int z) {
-        this.x = x;
-        this.y = y;
-        this.z = z;
-    }
-
     public long toLongPackedForm() {
         checkLongPackable(this);
         return (x & BITS_26) | ((z & BITS_26) << 26) | (((y & BITS_12) << (26 + 26)));
@@ -138,7 +121,9 @@ public final class BlockVector3 {
      * Get the X coordinate.
      *
      * @return the x coordinate
+     * @deprecated use {@link #x()} instead
      */
+    @Deprecated(forRemoval = true)
     public int getX() {
         return x;
     }
@@ -147,7 +132,9 @@ public final class BlockVector3 {
      * Get the X coordinate.
      *
      * @return the x coordinate
+     * @deprecated use {@link #x()} instead
      */
+    @Deprecated(forRemoval = true)
     public int getBlockX() {
         return x;
     }
@@ -166,7 +153,9 @@ public final class BlockVector3 {
      * Get the Y coordinate.
      *
      * @return the y coordinate
+     * @deprecated use {@link #y()} instead
      */
+    @Deprecated(forRemoval = true)
     public int getY() {
         return y;
     }
@@ -175,7 +164,9 @@ public final class BlockVector3 {
      * Get the Y coordinate.
      *
      * @return the y coordinate
+     * @deprecated use {@link #y()} instead
      */
+    @Deprecated(forRemoval = true)
     public int getBlockY() {
         return y;
     }
@@ -194,7 +185,9 @@ public final class BlockVector3 {
      * Get the Z coordinate.
      *
      * @return the z coordinate
+     * @deprecated use {@link #z()} instead
      */
+    @Deprecated(forRemoval = true)
     public int getZ() {
         return z;
     }
@@ -203,7 +196,9 @@ public final class BlockVector3 {
      * Get the Z coordinate.
      *
      * @return the z coordinate
+     * @deprecated use {@link #z()} instead
      */
+    @Deprecated(forRemoval = true)
     public int getBlockZ() {
         return z;
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/Vector2.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/Vector2.java
@@ -24,7 +24,7 @@ import com.sk89q.worldedit.math.transform.AffineTransform;
 /**
  * An immutable 2-dimensional vector.
  */
-public final class Vector2 {
+public record Vector2(double x, double z) {
 
     public static final Vector2 ZERO = new Vector2(0, 0);
     public static final Vector2 UNIT_X = new Vector2(1, 0);
@@ -50,27 +50,24 @@ public final class Vector2 {
         return new Vector2(x, z);
     }
 
-    private final double x;
-    private final double z;
-
-    /**
-     * Construct an instance.
-     *
-     * @param x the X coordinate
-     * @param z the Z coordinate
-     */
-    private Vector2(double x, double z) {
-        this.x = x;
-        this.z = z;
-    }
-
     /**
      * Get the X coordinate.
      *
      * @return the x coordinate
+     * @deprecated use {@link #x()} instead
      */
+    @Deprecated(forRemoval = true)
     public double getX() {
         return x;
+    }
+
+    /**
+     * Get the X coordinate, aligned to the block grid.
+     *
+     * @return the block-aligned x coordinate
+     */
+    public int blockX() {
+        return (int) Math.floor(x);
     }
 
     /**
@@ -84,10 +81,21 @@ public final class Vector2 {
     }
 
     /**
+     * Get the Z coordinate, aligned to the block grid.
+     *
+     * @return the block-aligned z coordinate
+     */
+    public int blockZ() {
+        return (int) Math.floor(z);
+    }
+
+    /**
      * Get the Z coordinate.
      *
      * @return the z coordinate
+     * @deprecated use {@link #z()} instead
      */
+    @Deprecated(forRemoval = true)
     public double getZ() {
         return z;
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/Vector2.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/Vector2.java
@@ -466,24 +466,6 @@ public record Vector2(double x, double z) {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (!(obj instanceof Vector2 other)) {
-            return false;
-        }
-
-        return other.x == this.x && other.z == this.z;
-
-    }
-
-    @Override
-    public int hashCode() {
-        int hash = 17;
-        hash = 31 * hash + Double.hashCode(x);
-        hash = 31 * hash + Double.hashCode(z);
-        return hash;
-    }
-
-    @Override
     public String toString() {
         return "(" + x + ", " + z + ")";
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/Vector3.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/Vector3.java
@@ -605,24 +605,6 @@ public record Vector3(double x, double y, double z) {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (!(obj instanceof Vector3 other)) {
-            return false;
-        }
-
-        return other.x == this.x && other.y == this.y && other.z == this.z;
-    }
-
-    @Override
-    public int hashCode() {
-        int hash = 17;
-        hash = 31 * hash + Double.hashCode(x);
-        hash = 31 * hash + Double.hashCode(y);
-        hash = 31 * hash + Double.hashCode(z);
-        return hash;
-    }
-
-    @Override
     public String toString() {
         return "(" + x + ", " + y + ", " + z + ")";
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/Vector3.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/Vector3.java
@@ -29,7 +29,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 /**
  * An immutable 3-dimensional vector.
  */
-public final class Vector3 {
+public record Vector3(double x, double y, double z) {
 
     public static final Vector3 ZERO = new Vector3(0, 0, 0);
     public static final Vector3 UNIT_X = new Vector3(1, 0, 0);
@@ -80,28 +80,22 @@ public final class Vector3 {
         return YzxOrderComparator.YZX_ORDER;
     }
 
-    private final double x;
-    private final double y;
-    private final double z;
-
     /**
-     * Construct an instance.
+     * Get the X coordinate, aligned to the block grid.
      *
-     * @param x the X coordinate
-     * @param y the Y coordinate
-     * @param z the Z coordinate
+     * @return the block-aligned x coordinate
      */
-    private Vector3(double x, double y, double z) {
-        this.x = x;
-        this.y = y;
-        this.z = z;
+    public int blockX() {
+        return (int) Math.floor(x);
     }
 
     /**
      * Get the X coordinate.
      *
      * @return the x coordinate
+     * @deprecated use {@link #x()} instead
      */
+    @Deprecated(forRemoval = true)
     public double getX() {
         return x;
     }
@@ -117,10 +111,21 @@ public final class Vector3 {
     }
 
     /**
+     * Get the Y coordinate, aligned to the block grid.
+     *
+     * @return the block-aligned y coordinate
+     */
+    public int blockY() {
+        return (int) Math.floor(y);
+    }
+
+    /**
      * Get the Y coordinate.
      *
      * @return the y coordinate
+     * @deprecated use {@link #y()} instead
      */
+    @Deprecated(forRemoval = true)
     public double getY() {
         return y;
     }
@@ -136,10 +141,21 @@ public final class Vector3 {
     }
 
     /**
+     * Get the Z coordinate, aligned to the block grid.
+     *
+     * @return the block-aligned z coordinate
+     */
+    public int blockZ() {
+        return (int) Math.floor(z);
+    }
+
+    /**
      * Get the Z coordinate.
      *
      * @return the z coordinate
+     * @deprecated use {@link #z()} instead
      */
+    @Deprecated(forRemoval = true)
     public double getZ() {
         return z;
     }


### PR DESCRIPTION
This turns the vector classes into records, to make use of the various syntactical features that have been added to Java recently around records.

The old getters were deprecated in favour of the record accessors. The block-grid accessors were deprecated in the BlockVector classes, and new ones were added to the Vector classes, as it makes much more sense for those to exist in the non-block version.

This PR does not update any usages within WorldEdit, therefore this PR will substantially increase the number of deprecation warnings in the codebase. However, this makes sense to keep the PR small. Cleanups can happen in future PRs.