### PR TITLE
Folia support

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,4 +32,8 @@ jobs:
       with:
         name: logs for ${{ matrix.os }}
         path: '**/*.log'
-
+    - name: Upload WorldEdit jar
+      uses: actions/upload-artifact@v2
+      with:
+        name: WorldEdit-Folia-Snapshot
+        path: worldedit-bukkit/build/libs/*

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,24 +11,24 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK
-      uses: actions/setup-java@v3
-      with:
-        java-version: 17
-        cache: 'gradle'
-        distribution: 'temurin'
-    - name: Build with Gradle
-      run: ./gradlew build -s
-    - uses: actions/upload-artifact@v3
-      name: Archive Reports
-      if: always()
-      with:
-        name: reports for ${{ matrix.os }}
-        path: '**/build/reports/**'
-    - uses: actions/upload-artifact@v3
-      name: Archive Logs
-      if: always()
-      with:
-        name: logs for ${{ matrix.os }}
-        path: '**/*.log'
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          cache: 'gradle'
+          distribution: 'temurin'
+      - name: Build with Gradle
+        run: ./gradlew build -s
+      - uses: actions/upload-artifact@v3
+        name: Archive Reports
+        if: always()
+        with:
+          name: reports for ${{ matrix.os }}
+          path: '**/build/reports/**'
+      - uses: actions/upload-artifact@v3
+        name: Archive Logs
+        if: always()
+        with:
+          name: logs for ${{ matrix.os }}
+          path: '**/*.log'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,24 +11,25 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          java-version: 17
-          cache: 'gradle'
-          distribution: 'temurin'
-      - name: Build with Gradle
-        run: ./gradlew build -s
-      - uses: actions/upload-artifact@v3
-        name: Archive Reports
-        if: always()
-        with:
-          name: reports for ${{ matrix.os }}
-          path: '**/build/reports/**'
-      - uses: actions/upload-artifact@v3
-        name: Archive Logs
-        if: always()
-        with:
-          name: logs for ${{ matrix.os }}
-          path: '**/*.log'
+    - uses: actions/checkout@v3
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: 17
+        cache: 'gradle'
+        distribution: 'temurin'
+    - name: Build with Gradle
+      run: ./gradlew build -s
+    - uses: actions/upload-artifact@v3
+      name: Archive Reports
+      if: always()
+      with:
+        name: reports for ${{ matrix.os }}
+        path: '**/build/reports/**'
+    - uses: actions/upload-artifact@v3
+      name: Archive Logs
+      if: always()
+      with:
+        name: logs for ${{ matrix.os }}
+        path: '**/*.log'
+

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,8 +32,3 @@ jobs:
       with:
         name: logs for ${{ matrix.os }}
         path: '**/*.log'
-    - name: Upload WorldEdit jar
-      uses: actions/upload-artifact@v2
-      with:
-        name: WorldEdit-Folia-Snapshot
-        path: worldedit-bukkit/build/libs/*

--- a/buildSrc/src/main/kotlin/CommonConfig.kt
+++ b/buildSrc/src/main/kotlin/CommonConfig.kt
@@ -25,6 +25,7 @@ fun Project.applyCommonConfiguration() {
                 snapshotsOnly()
             }
         }
+        maven { url = uri("https://jitpack.io") }
     }
 
     configurations.all {

--- a/worldedit-bukkit/build.gradle.kts
+++ b/worldedit-bukkit/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     "implementation"("org.bstats:bstats-bukkit:2.2.1")
     "implementation"("it.unimi.dsi:fastutil")
     "testImplementation"("org.mockito:mockito-core:1.9.0-rc1")
+    "implementation"("com.github.Euphillya:Energie:26cdee42f4")
 
     project.project(":worldedit-bukkit:adapters").subprojects.forEach {
         "adapters"(project(it.path))
@@ -91,6 +92,7 @@ tasks.named<ShadowJar>("shadowJar") {
         include(dependency("io.papermc:paperlib"))
         include(dependency("it.unimi.dsi:fastutil"))
         include(dependency("com.sk89q.lib:jlibnoise"))
+        include(dependency("com.github.Euphillya:Energie"))
 
         exclude(dependency("$group:$name"))
 

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockCommandSender.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockCommandSender.java
@@ -28,6 +28,8 @@ import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.util.formatting.text.adapter.bukkit.TextAdapter;
 import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import fr.euphyllia.energie.Energie;
+import fr.euphyllia.energie.model.SchedulerType;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -156,11 +158,11 @@ public class BukkitBlockCommandSender extends AbstractCommandBlockActor {
                     updateActive();
                 } else {
                     // we should update it eventually
-                    Bukkit.getScheduler().callSyncMethod(plugin,
-                        () -> {
-                            updateActive();
-                            return null;
-                        });
+                    WorldEditPlugin.getEnergieTask().getScheduler(Energie.SchedulerSoft.MINECRAFT).execute(
+                            SchedulerType.GLOBAL, schedulerTaskInter -> {
+                                updateActive();
+                            }
+                    );
                 }
                 return active;
             }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitServerInterface.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitServerInterface.java
@@ -37,6 +37,8 @@ import com.sk89q.worldedit.util.SideEffect;
 import com.sk89q.worldedit.util.lifecycle.Lifecycled;
 import com.sk89q.worldedit.world.DataFixer;
 import com.sk89q.worldedit.world.registry.Registries;
+import fr.euphyllia.energie.Energie;
+import fr.euphyllia.energie.model.SchedulerType;
 import io.papermc.lib.PaperLib;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
@@ -51,6 +53,7 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -121,7 +124,15 @@ public class BukkitServerInterface extends AbstractPlatform implements MultiUser
 
     @Override
     public int schedule(long delay, long period, Runnable task) {
-        return Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, task, delay, period);
+        AtomicInteger taskId = new AtomicInteger(0);
+        WorldEditPlugin.getEnergieTask().getScheduler(Energie.SchedulerSoft.MINECRAFT)
+                .runAtFixedRate(SchedulerType.GLOBAL, delay, period, schedulerTaskInter -> {
+                    task.run();
+                    if (schedulerTaskInter != null) {
+                        taskId.set(schedulerTaskInter.getTaskId());
+                    }
+                });
+        return taskId.get();
     }
 
     @Override

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -58,6 +58,7 @@ import com.sk89q.worldedit.world.gamemode.GameModes;
 import com.sk89q.worldedit.world.item.ItemCategory;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.weather.WeatherTypes;
+import fr.euphyllia.energie.Energie;
 import io.papermc.lib.PaperLib;
 import org.apache.logging.log4j.Logger;
 import org.bstats.bukkit.Metrics;
@@ -116,6 +117,7 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
     public static final String CUI_PLUGIN_CHANNEL = "worldedit:cui";
     private static WorldEditPlugin INSTANCE;
     private static final int BSTATS_PLUGIN_ID = 3328;
+    private static fr.euphyllia.energie.Energie energieTask; // Euphyllia
 
     private final SimpleLifecycled<BukkitImplAdapter> adapter =
         SimpleLifecycled.invalid();
@@ -154,6 +156,7 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
         // Catch bad things being done by naughty plugins that include
         // WorldEdit's classes
         ClassSourceValidator verifier = new ClassSourceValidator(this);
+        energieTask = new Energie(this); // Euphyllia
         verifier.reportMismatches(ImmutableList.of(World.class, CommandManager.class, EditSession.class, Actor.class));
 
         WorldEdit.getInstance().getEventBus().post(new PlatformsRegisteredEvent());
@@ -321,7 +324,8 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
         if (config != null) {
             config.unload();
         }
-        this.getServer().getScheduler().cancelTasks(this);
+        getEnergieTask().getScheduler(Energie.SchedulerSoft.MINECRAFT).cancelAllTask();
+        getEnergieTask().getScheduler(Energie.SchedulerSoft.NATIVE).cancelAllTask();
     }
 
     /**
@@ -569,4 +573,10 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
             event.setHandled(true);
         }
     }
+
+    // Euphyllia start
+    public static Energie getEnergieTask() {
+        return energieTask;
+    }
+    // Euphyllia end
 }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -117,7 +117,7 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
     public static final String CUI_PLUGIN_CHANNEL = "worldedit:cui";
     private static WorldEditPlugin INSTANCE;
     private static final int BSTATS_PLUGIN_ID = 3328;
-    private static fr.euphyllia.energie.Energie energieTask; // Euphyllia
+    private static fr.euphyllia.energie.Energie energieTask;
 
     private final SimpleLifecycled<BukkitImplAdapter> adapter =
         SimpleLifecycled.invalid();
@@ -156,7 +156,7 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
         // Catch bad things being done by naughty plugins that include
         // WorldEdit's classes
         ClassSourceValidator verifier = new ClassSourceValidator(this);
-        energieTask = new Energie(this); // Euphyllia
+        energieTask = new Energie(this);
         verifier.reportMismatches(ImmutableList.of(World.class, CommandManager.class, EditSession.class, Actor.class));
 
         WorldEdit.getInstance().getEventBus().post(new PlatformsRegisteredEvent());
@@ -574,9 +574,7 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
         }
     }
 
-    // Euphyllia start
     public static Energie getEnergieTask() {
         return energieTask;
     }
-    // Euphyllia end
 }

--- a/worldedit-bukkit/src/main/resources/plugin.yml
+++ b/worldedit-bukkit/src/main/resources/plugin.yml
@@ -6,3 +6,4 @@ api-version: 1.13
 softdepend: [Vault]
 author: EngineHub
 website: https://enginehub.org/worldedit
+folia-supported: true


### PR DESCRIPTION
Yes, another PR for Folia...

I'm using [Energy](https://github.com/Euphillya/Energie) to make WorldEdit compatible for Folia while keeping Spigot and older versions of Minecraft available. 

## Will Energie be kept up to date without breaking Spigot? 

If Folia makes a change, yes I'll update it because I need it for my Skyllia plugin (Skyblock for Folia/Spigot).

## Are any of the current features no longer working?

I tested Paper and Folia on my side and nothing seemed to be broken, but checks are requested just in case.

## Is it mergeable?

At the moment, I'd say there isn't enough feedback to merge it and mark it: SUPPORT FOLIA! 

## Will Energie still be available?

I'm using Jitpack.io, because I can't afford hosting for only 1 repo.