### PR TITLE
Cleanup usages of deprecated Vector getters

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1.17.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_17_R1_2/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.17.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_17_R1_2/PaperweightAdapter.java
@@ -409,7 +409,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
         final ServerLevel handle = craftWorld.getHandle();
         LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
-        chunk.getBiomes().setBiome(x >> 2, y >> 2, z >> 2, biomeTypeToNMSCache.computeIfAbsent(biome, b -> ((CraftServer) Bukkit.getServer()).getServer().registryAccess().registryOrThrow(Registry.BIOME_REGISTRY).get(ResourceKey.create(Registry.BIOME_REGISTRY, new ResourceLocation(b.getId())))));
+        chunk.getBiomes().setBiome(x >> 2, y >> 2, z >> 2, biomeTypeToNMSCache.computeIfAbsent(biome, b -> ((CraftServer) Bukkit.getServer()).getServer().registryAccess().registryOrThrow(Registry.BIOME_REGISTRY).get(ResourceKey.create(Registry.BIOME_REGISTRY, new ResourceLocation(b.id())))));
         chunk.setUnsaved(true);
     }
 
@@ -500,7 +500,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         CraftWorld craftWorld = ((CraftWorld) location.getWorld());
         ServerLevel worldServer = craftWorld.getHandle();
 
-        String entityId = state.getType().getId();
+        String entityId = state.getType().id();
 
         LinCompoundTag nativeTag = state.getNbt();
         CompoundTag tag;
@@ -594,7 +594,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     @Override
     public void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData) {
         ((CraftPlayer) player).getHandle().networkManager.send(new ClientboundBlockEntityDataPacket(
-            new BlockPos(pos.getBlockX(), pos.getBlockY(), pos.getBlockZ()),
+            new BlockPos(pos.x(), pos.y(), pos.z()),
             7,
             (CompoundTag) fromNative(nbtData)
         ));
@@ -640,10 +640,10 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             return false;
         }
         fakePlayer.setItemInHand(InteractionHand.MAIN_HAND, stack);
-        fakePlayer.absMoveTo(position.getBlockX(), position.getBlockY(), position.getBlockZ(),
+        fakePlayer.absMoveTo(position.x(), position.y(), position.z(),
             (float) face.toVector().toYaw(), (float) face.toVector().toPitch());
 
-        final BlockPos blockPos = new BlockPos(position.getBlockX(), position.getBlockY(), position.getBlockZ());
+        final BlockPos blockPos = new BlockPos(position.x(), position.y(), position.z());
         final Vec3 blockVec = Vec3.atLowerCornerOf(blockPos);
         final net.minecraft.core.Direction enumFacing = adapt(face);
         BlockHitResult rayTrace = new BlockHitResult(blockVec, enumFacing, blockPos, false);
@@ -664,7 +664,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     public boolean canPlaceAt(World world, BlockVector3 position, BlockState blockState) {
         int internalId = BlockStateIdAccess.getBlockStateId(blockState);
         net.minecraft.world.level.block.state.BlockState blockData = Block.stateById(internalId);
-        return blockData.canSurvive(((CraftWorld) world).getHandle(), new BlockPos(position.getX(), position.getY(), position.getZ()));
+        return blockData.canSurvive(((CraftWorld) world).getHandle(), new BlockPos(position.x(), position.y(), position.z()));
     }
 
     @Override
@@ -773,7 +773,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         }
 
         for (BlockVector3 vec : region) {
-            BlockPos pos = new BlockPos(vec.getBlockX(), vec.getBlockY(), vec.getBlockZ());
+            BlockPos pos = new BlockPos(vec.x(), vec.y(), vec.z());
             ChunkAccess chunk = chunks.get(new ChunkPos(pos));
             final net.minecraft.world.level.block.state.BlockState blockData = chunk.getBlockState(pos);
             int internalId = Block.getId(blockData);
@@ -789,7 +789,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             if (options.shouldRegenBiomes()) {
                 ChunkBiomeContainer biomeIndex = chunk.getBiomes();
                 if (biomeIndex != null) {
-                    Biome origBiome = biomeIndex.getNoiseBiome(vec.getBlockX(), vec.getBlockY(), vec.getBlockZ());
+                    Biome origBiome = biomeIndex.getNoiseBiome(vec.x(), vec.y(), vec.z());
                     BiomeType adaptedBiome = adapt(serverWorld, origBiome);
                     if (adaptedBiome != null) {
                         extent.setBiome(vec, adaptedBiome);
@@ -809,7 +809,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
                 //noinspection unchecked
                 chunkLoadings.add(
                     ((CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>>)
-                        getChunkFutureMethod.invoke(chunkManager, chunk.getX(), chunk.getZ(), ChunkStatus.FEATURES, true))
+                        getChunkFutureMethod.invoke(chunkManager, chunk.x(), chunk.z(), ChunkStatus.FEATURES, true))
                         .thenApply(either -> either.left().orElse(null))
                 );
             } catch (IllegalAccessException | InvocationTargetException e) {
@@ -849,7 +849,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     public boolean clearContainerBlockContents(World world, BlockVector3 pt) {
         ServerLevel originalWorld = ((CraftWorld) world).getHandle();
 
-        BlockEntity entity = originalWorld.getBlockEntity(new BlockPos(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ()));
+        BlockEntity entity = originalWorld.getBlockEntity(new BlockPos(pt.x(), pt.y(), pt.z()));
         if (entity instanceof Clearable) {
             ((Clearable) entity).clearContent();
             return true;

--- a/worldedit-bukkit/adapters/adapter-1.18.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_18_R2/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.18.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_18_R2/PaperweightAdapter.java
@@ -401,7 +401,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
         final ServerLevel handle = craftWorld.getHandle();
         LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
-        chunk.setBiome(x >> 2, y >> 2, z >> 2, biomeTypeToNMSCache.computeIfAbsent(biome, b -> ((CraftServer) Bukkit.getServer()).getServer().registryAccess().registryOrThrow(Registry.BIOME_REGISTRY).getHolderOrThrow(ResourceKey.create(Registry.BIOME_REGISTRY, new ResourceLocation(b.getId())))));
+        chunk.setBiome(x >> 2, y >> 2, z >> 2, biomeTypeToNMSCache.computeIfAbsent(biome, b -> ((CraftServer) Bukkit.getServer()).getServer().registryAccess().registryOrThrow(Registry.BIOME_REGISTRY).getHolderOrThrow(ResourceKey.create(Registry.BIOME_REGISTRY, new ResourceLocation(b.id())))));
         chunk.setUnsaved(true);
     }
 
@@ -492,7 +492,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         CraftWorld craftWorld = ((CraftWorld) location.getWorld());
         ServerLevel worldServer = craftWorld.getHandle();
 
-        String entityId = state.getType().getId();
+        String entityId = state.getType().id();
 
         LinCompoundTag nativeTag = state.getNbt();
         CompoundTag tag;
@@ -587,7 +587,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     public void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData) {
         ((CraftPlayer) player).getHandle().networkManager.send(ClientboundBlockEntityDataPacket.create(
             new StructureBlockEntity(
-                new BlockPos(pos.getBlockX(), pos.getBlockY(), pos.getBlockZ()),
+                new BlockPos(pos.x(), pos.y(), pos.z()),
                 Blocks.STRUCTURE_BLOCK.defaultBlockState()
             ),
             __ -> (CompoundTag) fromNative(nbtData)
@@ -634,10 +634,10 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             return false;
         }
         fakePlayer.setItemInHand(InteractionHand.MAIN_HAND, stack);
-        fakePlayer.absMoveTo(position.getBlockX(), position.getBlockY(), position.getBlockZ(),
+        fakePlayer.absMoveTo(position.x(), position.y(), position.z(),
             (float) face.toVector().toYaw(), (float) face.toVector().toPitch());
 
-        final BlockPos blockPos = new BlockPos(position.getBlockX(), position.getBlockY(), position.getBlockZ());
+        final BlockPos blockPos = new BlockPos(position.x(), position.y(), position.z());
         final Vec3 blockVec = Vec3.atLowerCornerOf(blockPos);
         final net.minecraft.core.Direction enumFacing = adapt(face);
         BlockHitResult rayTrace = new BlockHitResult(blockVec, enumFacing, blockPos, false);
@@ -658,7 +658,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     public boolean canPlaceAt(World world, BlockVector3 position, BlockState blockState) {
         int internalId = BlockStateIdAccess.getBlockStateId(blockState);
         net.minecraft.world.level.block.state.BlockState blockData = Block.stateById(internalId);
-        return blockData.canSurvive(((CraftWorld) world).getHandle(), new BlockPos(position.getX(), position.getY(), position.getZ()));
+        return blockData.canSurvive(((CraftWorld) world).getHandle(), new BlockPos(position.x(), position.y(), position.z()));
     }
 
     @Override
@@ -767,7 +767,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         }
 
         for (BlockVector3 vec : region) {
-            BlockPos pos = new BlockPos(vec.getBlockX(), vec.getBlockY(), vec.getBlockZ());
+            BlockPos pos = new BlockPos(vec.x(), vec.y(), vec.z());
             ChunkAccess chunk = chunks.get(new ChunkPos(pos));
             final net.minecraft.world.level.block.state.BlockState blockData = chunk.getBlockState(pos);
             int internalId = Block.getId(blockData);
@@ -780,7 +780,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             }
             extent.setBlock(vec, state.toBaseBlock());
             if (options.shouldRegenBiomes()) {
-                Biome origBiome = chunk.getNoiseBiome(vec.getX(), vec.getY(), vec.getZ()).value();
+                Biome origBiome = chunk.getNoiseBiome(vec.x(), vec.y(), vec.z()).value();
                 BiomeType adaptedBiome = adapt(serverWorld, origBiome);
                 if (adaptedBiome != null) {
                     extent.setBiome(vec, adaptedBiome);
@@ -799,7 +799,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
                 //noinspection unchecked
                 chunkLoadings.add(
                     ((CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>>)
-                        getChunkFutureMethod.invoke(chunkManager, chunk.getX(), chunk.getZ(), ChunkStatus.FEATURES, true))
+                        getChunkFutureMethod.invoke(chunkManager, chunk.x(), chunk.z(), ChunkStatus.FEATURES, true))
                         .thenApply(either -> either.left().orElse(null))
                 );
             } catch (IllegalAccessException | InvocationTargetException e) {
@@ -839,7 +839,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     public boolean clearContainerBlockContents(World world, BlockVector3 pt) {
         ServerLevel originalWorld = ((CraftWorld) world).getHandle();
 
-        BlockEntity entity = originalWorld.getBlockEntity(new BlockPos(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ()));
+        BlockEntity entity = originalWorld.getBlockEntity(new BlockPos(pt.x(), pt.y(), pt.z()));
         if (entity instanceof Clearable) {
             ((Clearable) entity).clearContent();
             return true;

--- a/worldedit-bukkit/adapters/adapter-1.19.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_19_R3/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.19.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_19_R3/PaperweightAdapter.java
@@ -435,7 +435,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
         final ServerLevel handle = craftWorld.getHandle();
         LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
-        chunk.setBiome(x >> 2, y >> 2, z >> 2, biomeTypeToNMSCache.computeIfAbsent(biome, b -> ((CraftServer) Bukkit.getServer()).getServer().registryAccess().registryOrThrow(Registries.BIOME).getHolderOrThrow(ResourceKey.create(Registries.BIOME, new ResourceLocation(b.getId())))));
+        chunk.setBiome(x >> 2, y >> 2, z >> 2, biomeTypeToNMSCache.computeIfAbsent(biome, b -> ((CraftServer) Bukkit.getServer()).getServer().registryAccess().registryOrThrow(Registries.BIOME).getHolderOrThrow(ResourceKey.create(Registries.BIOME, new ResourceLocation(b.id())))));
         chunk.setUnsaved(true);
     }
 
@@ -526,7 +526,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         CraftWorld craftWorld = ((CraftWorld) location.getWorld());
         ServerLevel worldServer = craftWorld.getHandle();
 
-        String entityId = state.getType().getId();
+        String entityId = state.getType().id();
 
         LinCompoundTag nativeTag = state.getNbt();
         net.minecraft.nbt.CompoundTag tag;
@@ -621,7 +621,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     public void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData) {
         ((CraftPlayer) player).getHandle().connection.send(ClientboundBlockEntityDataPacket.create(
             new StructureBlockEntity(
-                new BlockPos(pos.getBlockX(), pos.getBlockY(), pos.getBlockZ()),
+                new BlockPos(pos.x(), pos.y(), pos.z()),
                 Blocks.STRUCTURE_BLOCK.defaultBlockState()
             ),
             __ -> (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
@@ -674,10 +674,10 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             return false;
         }
         fakePlayer.setItemInHand(InteractionHand.MAIN_HAND, stack);
-        fakePlayer.absMoveTo(position.getBlockX(), position.getBlockY(), position.getBlockZ(),
+        fakePlayer.absMoveTo(position.x(), position.y(), position.z(),
             (float) face.toVector().toYaw(), (float) face.toVector().toPitch());
 
-        final BlockPos blockPos = new BlockPos(position.getBlockX(), position.getBlockY(), position.getBlockZ());
+        final BlockPos blockPos = new BlockPos(position.x(), position.y(), position.z());
         final Vec3 blockVec = Vec3.atLowerCornerOf(blockPos);
         final net.minecraft.core.Direction enumFacing = adapt(face);
         BlockHitResult rayTrace = new BlockHitResult(blockVec, enumFacing, blockPos, false);
@@ -698,7 +698,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     public boolean canPlaceAt(World world, BlockVector3 position, BlockState blockState) {
         int internalId = BlockStateIdAccess.getBlockStateId(blockState);
         net.minecraft.world.level.block.state.BlockState blockData = Block.stateById(internalId);
-        return blockData.canSurvive(((CraftWorld) world).getHandle(), new BlockPos(position.getX(), position.getY(), position.getZ()));
+        return blockData.canSurvive(((CraftWorld) world).getHandle(), new BlockPos(position.x(), position.y(), position.z()));
     }
 
     @Override
@@ -818,7 +818,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         }
 
         for (BlockVector3 vec : region) {
-            BlockPos pos = new BlockPos(vec.getBlockX(), vec.getBlockY(), vec.getBlockZ());
+            BlockPos pos = new BlockPos(vec.x(), vec.y(), vec.z());
             ChunkAccess chunk = chunks.get(new ChunkPos(pos));
             final net.minecraft.world.level.block.state.BlockState blockData = chunk.getBlockState(pos);
             int internalId = Block.getId(blockData);
@@ -831,7 +831,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             }
             extent.setBlock(vec, state.toBaseBlock());
             if (options.shouldRegenBiomes()) {
-                Biome origBiome = chunk.getNoiseBiome(vec.getX(), vec.getY(), vec.getZ()).value();
+                Biome origBiome = chunk.getNoiseBiome(vec.x(), vec.y(), vec.z()).value();
                 BiomeType adaptedBiome = adapt(serverWorld, origBiome);
                 if (adaptedBiome != null) {
                     extent.setBiome(vec, adaptedBiome);
@@ -850,7 +850,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
                 //noinspection unchecked
                 chunkLoadings.add(
                     ((CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>>)
-                        getChunkFutureMethod.invoke(chunkManager, chunk.getX(), chunk.getZ(), ChunkStatus.FEATURES, true))
+                        getChunkFutureMethod.invoke(chunkManager, chunk.x(), chunk.z(), ChunkStatus.FEATURES, true))
                         .thenApply(either -> either.left().orElse(null))
                 );
             } catch (IllegalAccessException | InvocationTargetException e) {
@@ -890,7 +890,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     public boolean clearContainerBlockContents(World world, BlockVector3 pt) {
         ServerLevel originalWorld = ((CraftWorld) world).getHandle();
 
-        BlockEntity entity = originalWorld.getBlockEntity(new BlockPos(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ()));
+        BlockEntity entity = originalWorld.getBlockEntity(new BlockPos(pt.x(), pt.y(), pt.z()));
         if (entity instanceof Clearable) {
             ((Clearable) entity).clearContent();
             return true;
@@ -942,22 +942,22 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
     public boolean generateFeature(ConfiguredFeatureType type, World world, EditSession session, BlockVector3 pt) {
         ServerLevel originalWorld = ((CraftWorld) world).getHandle();
-        ConfiguredFeature<?, ?> k = originalWorld.registryAccess().registryOrThrow(Registries.CONFIGURED_FEATURE).get(ResourceLocation.tryParse(type.getId()));
+        ConfiguredFeature<?, ?> k = originalWorld.registryAccess().registryOrThrow(Registries.CONFIGURED_FEATURE).get(ResourceLocation.tryParse(type.id()));
         ServerChunkCache chunkManager = originalWorld.getChunkSource();
         WorldGenLevel proxyLevel = PaperweightServerLevelDelegateProxy.newInstance(session, originalWorld, this);
-        return k != null && k.place(proxyLevel, chunkManager.getGenerator(), random, new BlockPos(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ()));
+        return k != null && k.place(proxyLevel, chunkManager.getGenerator(), random, new BlockPos(pt.x(), pt.y(), pt.z()));
     }
 
     public boolean generateStructure(StructureType type, World world, EditSession session, BlockVector3 pt) {
         ServerLevel originalWorld = ((CraftWorld) world).getHandle();
-        Structure k = originalWorld.registryAccess().registryOrThrow(Registries.STRUCTURE).get(ResourceLocation.tryParse(type.getId()));
+        Structure k = originalWorld.registryAccess().registryOrThrow(Registries.STRUCTURE).get(ResourceLocation.tryParse(type.id()));
         if (k == null) {
             return false;
         }
 
         ServerChunkCache chunkManager = originalWorld.getChunkSource();
         WorldGenLevel proxyLevel = PaperweightServerLevelDelegateProxy.newInstance(session, originalWorld, this);
-        ChunkPos chunkPos = new ChunkPos(new BlockPos(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ()));
+        ChunkPos chunkPos = new ChunkPos(new BlockPos(pt.x(), pt.y(), pt.z()));
         StructureStart structureStart = k.generate(originalWorld.registryAccess(), chunkManager.getGenerator(), chunkManager.getGenerator().getBiomeSource(), chunkManager.randomState(), originalWorld.getStructureManager(), originalWorld.getSeed(), chunkPos, 0, proxyLevel, biome -> true);
 
         if (!structureStart.isValid()) {
@@ -977,7 +977,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
         List<ChunkAccess> nativeChunks = chunks instanceof Collection<BlockVector2> chunkCollection ? Lists.newArrayListWithCapacity(chunkCollection.size()) : Lists.newArrayList();
         for (BlockVector2 chunk : chunks) {
-            nativeChunks.add(originalWorld.getChunk(chunk.getBlockX(), chunk.getBlockZ(), ChunkStatus.BIOMES, false));
+            nativeChunks.add(originalWorld.getChunk(chunk.x(), chunk.z(), ChunkStatus.BIOMES, false));
         }
         originalWorld.getChunkSource().chunkMap.resendBiomesForChunks(nativeChunks);
     }

--- a/worldedit-bukkit/adapters/adapter-1.20.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R2/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.20.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R2/PaperweightAdapter.java
@@ -435,7 +435,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
         final ServerLevel handle = craftWorld.getHandle();
         LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
-        chunk.setBiome(x >> 2, y >> 2, z >> 2, biomeTypeToNMSCache.computeIfAbsent(biome, b -> ((CraftServer) Bukkit.getServer()).getServer().registryAccess().registryOrThrow(Registries.BIOME).getHolderOrThrow(ResourceKey.create(Registries.BIOME, new ResourceLocation(b.getId())))));
+        chunk.setBiome(x >> 2, y >> 2, z >> 2, biomeTypeToNMSCache.computeIfAbsent(biome, b -> ((CraftServer) Bukkit.getServer()).getServer().registryAccess().registryOrThrow(Registries.BIOME).getHolderOrThrow(ResourceKey.create(Registries.BIOME, new ResourceLocation(b.id())))));
         chunk.setUnsaved(true);
     }
 
@@ -526,7 +526,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         CraftWorld craftWorld = ((CraftWorld) location.getWorld());
         ServerLevel worldServer = craftWorld.getHandle();
 
-        String entityId = state.getType().getId();
+        String entityId = state.getType().id();
 
         LinCompoundTag nativeTag = state.getNbt();
         net.minecraft.nbt.CompoundTag tag;
@@ -621,7 +621,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     public void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData) {
         ((CraftPlayer) player).getHandle().connection.send(ClientboundBlockEntityDataPacket.create(
             new StructureBlockEntity(
-                new BlockPos(pos.getBlockX(), pos.getBlockY(), pos.getBlockZ()),
+                new BlockPos(pos.x(), pos.y(), pos.z()),
                 Blocks.STRUCTURE_BLOCK.defaultBlockState()
             ),
             __ -> (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
@@ -674,10 +674,10 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             return false;
         }
         fakePlayer.setItemInHand(InteractionHand.MAIN_HAND, stack);
-        fakePlayer.absMoveTo(position.getBlockX(), position.getBlockY(), position.getBlockZ(),
+        fakePlayer.absMoveTo(position.x(), position.y(), position.z(),
             (float) face.toVector().toYaw(), (float) face.toVector().toPitch());
 
-        final BlockPos blockPos = new BlockPos(position.getBlockX(), position.getBlockY(), position.getBlockZ());
+        final BlockPos blockPos = new BlockPos(position.x(), position.y(), position.z());
         final Vec3 blockVec = Vec3.atLowerCornerOf(blockPos);
         final net.minecraft.core.Direction enumFacing = adapt(face);
         BlockHitResult rayTrace = new BlockHitResult(blockVec, enumFacing, blockPos, false);
@@ -698,7 +698,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     public boolean canPlaceAt(World world, BlockVector3 position, BlockState blockState) {
         int internalId = BlockStateIdAccess.getBlockStateId(blockState);
         net.minecraft.world.level.block.state.BlockState blockData = Block.stateById(internalId);
-        return blockData.canSurvive(((CraftWorld) world).getHandle(), new BlockPos(position.getX(), position.getY(), position.getZ()));
+        return blockData.canSurvive(((CraftWorld) world).getHandle(), new BlockPos(position.x(), position.y(), position.z()));
     }
 
     @Override
@@ -819,7 +819,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         }
 
         for (BlockVector3 vec : region) {
-            BlockPos pos = new BlockPos(vec.getBlockX(), vec.getBlockY(), vec.getBlockZ());
+            BlockPos pos = new BlockPos(vec.x(), vec.y(), vec.z());
             ChunkAccess chunk = chunks.get(new ChunkPos(pos));
             final net.minecraft.world.level.block.state.BlockState blockData = chunk.getBlockState(pos);
             int internalId = Block.getId(blockData);
@@ -832,7 +832,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             }
             extent.setBlock(vec, state.toBaseBlock());
             if (options.shouldRegenBiomes()) {
-                Biome origBiome = chunk.getNoiseBiome(vec.getX(), vec.getY(), vec.getZ()).value();
+                Biome origBiome = chunk.getNoiseBiome(vec.x(), vec.y(), vec.z()).value();
                 BiomeType adaptedBiome = adapt(serverWorld, origBiome);
                 if (adaptedBiome != null) {
                     extent.setBiome(vec, adaptedBiome);
@@ -851,7 +851,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
                 //noinspection unchecked
                 chunkLoadings.add(
                     ((CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>>)
-                        getChunkFutureMethod.invoke(chunkManager, chunk.getX(), chunk.getZ(), ChunkStatus.FEATURES, true))
+                        getChunkFutureMethod.invoke(chunkManager, chunk.x(), chunk.z(), ChunkStatus.FEATURES, true))
                         .thenApply(either -> either.left().orElse(null))
                 );
             } catch (IllegalAccessException | InvocationTargetException e) {
@@ -891,7 +891,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     public boolean clearContainerBlockContents(World world, BlockVector3 pt) {
         ServerLevel originalWorld = ((CraftWorld) world).getHandle();
 
-        BlockEntity entity = originalWorld.getBlockEntity(new BlockPos(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ()));
+        BlockEntity entity = originalWorld.getBlockEntity(new BlockPos(pt.x(), pt.y(), pt.z()));
         if (entity instanceof Clearable) {
             ((Clearable) entity).clearContent();
             return true;
@@ -943,22 +943,22 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
     public boolean generateFeature(ConfiguredFeatureType type, World world, EditSession session, BlockVector3 pt) {
         ServerLevel originalWorld = ((CraftWorld) world).getHandle();
-        ConfiguredFeature<?, ?> k = originalWorld.registryAccess().registryOrThrow(Registries.CONFIGURED_FEATURE).get(ResourceLocation.tryParse(type.getId()));
+        ConfiguredFeature<?, ?> k = originalWorld.registryAccess().registryOrThrow(Registries.CONFIGURED_FEATURE).get(ResourceLocation.tryParse(type.id()));
         ServerChunkCache chunkManager = originalWorld.getChunkSource();
         WorldGenLevel proxyLevel = PaperweightServerLevelDelegateProxy.newInstance(session, originalWorld, this);
-        return k != null && k.place(proxyLevel, chunkManager.getGenerator(), random, new BlockPos(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ()));
+        return k != null && k.place(proxyLevel, chunkManager.getGenerator(), random, new BlockPos(pt.x(), pt.y(), pt.z()));
     }
 
     public boolean generateStructure(StructureType type, World world, EditSession session, BlockVector3 pt) {
         ServerLevel originalWorld = ((CraftWorld) world).getHandle();
-        Structure k = originalWorld.registryAccess().registryOrThrow(Registries.STRUCTURE).get(ResourceLocation.tryParse(type.getId()));
+        Structure k = originalWorld.registryAccess().registryOrThrow(Registries.STRUCTURE).get(ResourceLocation.tryParse(type.id()));
         if (k == null) {
             return false;
         }
 
         ServerChunkCache chunkManager = originalWorld.getChunkSource();
         WorldGenLevel proxyLevel = PaperweightServerLevelDelegateProxy.newInstance(session, originalWorld, this);
-        ChunkPos chunkPos = new ChunkPos(new BlockPos(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ()));
+        ChunkPos chunkPos = new ChunkPos(new BlockPos(pt.x(), pt.y(), pt.z()));
         StructureStart structureStart = k.generate(originalWorld.registryAccess(), chunkManager.getGenerator(), chunkManager.getGenerator().getBiomeSource(), chunkManager.randomState(), originalWorld.getStructureManager(), originalWorld.getSeed(), chunkPos, 0, proxyLevel, biome -> true);
 
         if (!structureStart.isValid()) {
@@ -978,7 +978,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
         List<ChunkAccess> nativeChunks = chunks instanceof Collection<BlockVector2> chunkCollection ? Lists.newArrayListWithCapacity(chunkCollection.size()) : Lists.newArrayList();
         for (BlockVector2 chunk : chunks) {
-            nativeChunks.add(originalWorld.getChunk(chunk.getBlockX(), chunk.getBlockZ(), ChunkStatus.BIOMES, false));
+            nativeChunks.add(originalWorld.getChunk(chunk.x(), chunk.z(), ChunkStatus.BIOMES, false));
         }
         originalWorld.getChunkSource().chunkMap.resendBiomesForChunks(nativeChunks);
     }

--- a/worldedit-bukkit/adapters/adapter-1.20.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R3/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.20.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R3/PaperweightAdapter.java
@@ -435,7 +435,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
         final ServerLevel handle = craftWorld.getHandle();
         LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
-        chunk.setBiome(x >> 2, y >> 2, z >> 2, biomeTypeToNMSCache.computeIfAbsent(biome, b -> ((CraftServer) Bukkit.getServer()).getServer().registryAccess().registryOrThrow(Registries.BIOME).getHolderOrThrow(ResourceKey.create(Registries.BIOME, new ResourceLocation(b.getId())))));
+        chunk.setBiome(x >> 2, y >> 2, z >> 2, biomeTypeToNMSCache.computeIfAbsent(biome, b -> ((CraftServer) Bukkit.getServer()).getServer().registryAccess().registryOrThrow(Registries.BIOME).getHolderOrThrow(ResourceKey.create(Registries.BIOME, new ResourceLocation(b.id())))));
         chunk.setUnsaved(true);
     }
 
@@ -525,7 +525,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         CraftWorld craftWorld = ((CraftWorld) location.getWorld());
         ServerLevel worldServer = craftWorld.getHandle();
 
-        String entityId = state.getType().getId();
+        String entityId = state.getType().id();
 
         LinCompoundTag nativeTag = state.getNbt();
         net.minecraft.nbt.CompoundTag tag;
@@ -620,7 +620,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     public void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData) {
         ((CraftPlayer) player).getHandle().connection.send(ClientboundBlockEntityDataPacket.create(
             new StructureBlockEntity(
-                new BlockPos(pos.getBlockX(), pos.getBlockY(), pos.getBlockZ()),
+                new BlockPos(pos.x(), pos.y(), pos.z()),
                 Blocks.STRUCTURE_BLOCK.defaultBlockState()
             ),
             __ -> (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
@@ -673,10 +673,10 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             return false;
         }
         fakePlayer.setItemInHand(InteractionHand.MAIN_HAND, stack);
-        fakePlayer.absMoveTo(position.getBlockX(), position.getBlockY(), position.getBlockZ(),
+        fakePlayer.absMoveTo(position.x(), position.y(), position.z(),
             (float) face.toVector().toYaw(), (float) face.toVector().toPitch());
 
-        final BlockPos blockPos = new BlockPos(position.getBlockX(), position.getBlockY(), position.getBlockZ());
+        final BlockPos blockPos = new BlockPos(position.x(), position.y(), position.z());
         final Vec3 blockVec = Vec3.atLowerCornerOf(blockPos);
         final net.minecraft.core.Direction enumFacing = adapt(face);
         BlockHitResult rayTrace = new BlockHitResult(blockVec, enumFacing, blockPos, false);
@@ -697,7 +697,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     public boolean canPlaceAt(World world, BlockVector3 position, BlockState blockState) {
         int internalId = BlockStateIdAccess.getBlockStateId(blockState);
         net.minecraft.world.level.block.state.BlockState blockData = Block.stateById(internalId);
-        return blockData.canSurvive(((CraftWorld) world).getHandle(), new BlockPos(position.getX(), position.getY(), position.getZ()));
+        return blockData.canSurvive(((CraftWorld) world).getHandle(), new BlockPos(position.x(), position.y(), position.z()));
     }
 
     @Override
@@ -818,7 +818,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         }
 
         for (BlockVector3 vec : region) {
-            BlockPos pos = new BlockPos(vec.getBlockX(), vec.getBlockY(), vec.getBlockZ());
+            BlockPos pos = new BlockPos(vec.x(), vec.y(), vec.z());
             ChunkAccess chunk = chunks.get(new ChunkPos(pos));
             final net.minecraft.world.level.block.state.BlockState blockData = chunk.getBlockState(pos);
             int internalId = Block.getId(blockData);
@@ -831,7 +831,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             }
             extent.setBlock(vec, state.toBaseBlock());
             if (options.shouldRegenBiomes()) {
-                Biome origBiome = chunk.getNoiseBiome(vec.getX(), vec.getY(), vec.getZ()).value();
+                Biome origBiome = chunk.getNoiseBiome(vec.x(), vec.y(), vec.z()).value();
                 BiomeType adaptedBiome = adapt(serverWorld, origBiome);
                 if (adaptedBiome != null) {
                     extent.setBiome(vec, adaptedBiome);
@@ -850,7 +850,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
                 //noinspection unchecked
                 chunkLoadings.add(
                     ((CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>>)
-                        getChunkFutureMethod.invoke(chunkManager, chunk.getX(), chunk.getZ(), ChunkStatus.FEATURES, true))
+                        getChunkFutureMethod.invoke(chunkManager, chunk.x(), chunk.z(), ChunkStatus.FEATURES, true))
                         .thenApply(either -> either.left().orElse(null))
                 );
             } catch (IllegalAccessException | InvocationTargetException e) {
@@ -890,7 +890,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     public boolean clearContainerBlockContents(World world, BlockVector3 pt) {
         ServerLevel originalWorld = ((CraftWorld) world).getHandle();
 
-        BlockEntity entity = originalWorld.getBlockEntity(new BlockPos(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ()));
+        BlockEntity entity = originalWorld.getBlockEntity(new BlockPos(pt.x(), pt.y(), pt.z()));
         if (entity instanceof Clearable) {
             ((Clearable) entity).clearContent();
             return true;
@@ -942,22 +942,22 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
     public boolean generateFeature(ConfiguredFeatureType type, World world, EditSession session, BlockVector3 pt) {
         ServerLevel originalWorld = ((CraftWorld) world).getHandle();
-        ConfiguredFeature<?, ?> k = originalWorld.registryAccess().registryOrThrow(Registries.CONFIGURED_FEATURE).get(ResourceLocation.tryParse(type.getId()));
+        ConfiguredFeature<?, ?> k = originalWorld.registryAccess().registryOrThrow(Registries.CONFIGURED_FEATURE).get(ResourceLocation.tryParse(type.id()));
         ServerChunkCache chunkManager = originalWorld.getChunkSource();
         WorldGenLevel proxyLevel = PaperweightServerLevelDelegateProxy.newInstance(session, originalWorld, this);
-        return k != null && k.place(proxyLevel, chunkManager.getGenerator(), random, new BlockPos(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ()));
+        return k != null && k.place(proxyLevel, chunkManager.getGenerator(), random, new BlockPos(pt.x(), pt.y(), pt.z()));
     }
 
     public boolean generateStructure(StructureType type, World world, EditSession session, BlockVector3 pt) {
         ServerLevel originalWorld = ((CraftWorld) world).getHandle();
-        Structure k = originalWorld.registryAccess().registryOrThrow(Registries.STRUCTURE).get(ResourceLocation.tryParse(type.getId()));
+        Structure k = originalWorld.registryAccess().registryOrThrow(Registries.STRUCTURE).get(ResourceLocation.tryParse(type.id()));
         if (k == null) {
             return false;
         }
 
         ServerChunkCache chunkManager = originalWorld.getChunkSource();
         WorldGenLevel proxyLevel = PaperweightServerLevelDelegateProxy.newInstance(session, originalWorld, this);
-        ChunkPos chunkPos = new ChunkPos(new BlockPos(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ()));
+        ChunkPos chunkPos = new ChunkPos(new BlockPos(pt.x(), pt.y(), pt.z()));
         StructureStart structureStart = k.generate(originalWorld.registryAccess(), chunkManager.getGenerator(), chunkManager.getGenerator().getBiomeSource(), chunkManager.randomState(), originalWorld.getStructureManager(), originalWorld.getSeed(), chunkPos, 0, proxyLevel, biome -> true);
 
         if (!structureStart.isValid()) {
@@ -977,7 +977,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
         List<ChunkAccess> nativeChunks = chunks instanceof Collection<BlockVector2> chunkCollection ? Lists.newArrayListWithCapacity(chunkCollection.size()) : Lists.newArrayList();
         for (BlockVector2 chunk : chunks) {
-            nativeChunks.add(originalWorld.getChunk(chunk.getBlockX(), chunk.getBlockZ(), ChunkStatus.BIOMES, false));
+            nativeChunks.add(originalWorld.getChunk(chunk.x(), chunk.z(), ChunkStatus.BIOMES, false));
         }
         originalWorld.getChunkSource().chunkMap.resendBiomesForChunks(nativeChunks);
     }

--- a/worldedit-bukkit/adapters/adapter-1.20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_20_R1/PaperweightAdapter.java
@@ -435,7 +435,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
         final ServerLevel handle = craftWorld.getHandle();
         LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
-        chunk.setBiome(x >> 2, y >> 2, z >> 2, biomeTypeToNMSCache.computeIfAbsent(biome, b -> ((CraftServer) Bukkit.getServer()).getServer().registryAccess().registryOrThrow(Registries.BIOME).getHolderOrThrow(ResourceKey.create(Registries.BIOME, new ResourceLocation(b.getId())))));
+        chunk.setBiome(x >> 2, y >> 2, z >> 2, biomeTypeToNMSCache.computeIfAbsent(biome, b -> ((CraftServer) Bukkit.getServer()).getServer().registryAccess().registryOrThrow(Registries.BIOME).getHolderOrThrow(ResourceKey.create(Registries.BIOME, new ResourceLocation(b.id())))));
         chunk.setUnsaved(true);
     }
 
@@ -526,7 +526,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         CraftWorld craftWorld = ((CraftWorld) location.getWorld());
         ServerLevel worldServer = craftWorld.getHandle();
 
-        String entityId = state.getType().getId();
+        String entityId = state.getType().id();
 
         LinCompoundTag nativeTag = state.getNbt();
         net.minecraft.nbt.CompoundTag tag;
@@ -621,7 +621,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     public void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData) {
         ((CraftPlayer) player).getHandle().connection.send(ClientboundBlockEntityDataPacket.create(
             new StructureBlockEntity(
-                new BlockPos(pos.getBlockX(), pos.getBlockY(), pos.getBlockZ()),
+                new BlockPos(pos.x(), pos.y(), pos.z()),
                 Blocks.STRUCTURE_BLOCK.defaultBlockState()
             ),
             __ -> (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
@@ -674,10 +674,10 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             return false;
         }
         fakePlayer.setItemInHand(InteractionHand.MAIN_HAND, stack);
-        fakePlayer.absMoveTo(position.getBlockX(), position.getBlockY(), position.getBlockZ(),
+        fakePlayer.absMoveTo(position.x(), position.y(), position.z(),
             (float) face.toVector().toYaw(), (float) face.toVector().toPitch());
 
-        final BlockPos blockPos = new BlockPos(position.getBlockX(), position.getBlockY(), position.getBlockZ());
+        final BlockPos blockPos = new BlockPos(position.x(), position.y(), position.z());
         final Vec3 blockVec = Vec3.atLowerCornerOf(blockPos);
         final net.minecraft.core.Direction enumFacing = adapt(face);
         BlockHitResult rayTrace = new BlockHitResult(blockVec, enumFacing, blockPos, false);
@@ -698,7 +698,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     public boolean canPlaceAt(World world, BlockVector3 position, BlockState blockState) {
         int internalId = BlockStateIdAccess.getBlockStateId(blockState);
         net.minecraft.world.level.block.state.BlockState blockData = Block.stateById(internalId);
-        return blockData.canSurvive(((CraftWorld) world).getHandle(), new BlockPos(position.getX(), position.getY(), position.getZ()));
+        return blockData.canSurvive(((CraftWorld) world).getHandle(), new BlockPos(position.x(), position.y(), position.z()));
     }
 
     @Override
@@ -819,7 +819,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         }
 
         for (BlockVector3 vec : region) {
-            BlockPos pos = new BlockPos(vec.getBlockX(), vec.getBlockY(), vec.getBlockZ());
+            BlockPos pos = new BlockPos(vec.x(), vec.y(), vec.z());
             ChunkAccess chunk = chunks.get(new ChunkPos(pos));
             final net.minecraft.world.level.block.state.BlockState blockData = chunk.getBlockState(pos);
             int internalId = Block.getId(blockData);
@@ -832,7 +832,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             }
             extent.setBlock(vec, state.toBaseBlock());
             if (options.shouldRegenBiomes()) {
-                Biome origBiome = chunk.getNoiseBiome(vec.getX(), vec.getY(), vec.getZ()).value();
+                Biome origBiome = chunk.getNoiseBiome(vec.x(), vec.y(), vec.z()).value();
                 BiomeType adaptedBiome = adapt(serverWorld, origBiome);
                 if (adaptedBiome != null) {
                     extent.setBiome(vec, adaptedBiome);
@@ -851,7 +851,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
                 //noinspection unchecked
                 chunkLoadings.add(
                     ((CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>>)
-                        getChunkFutureMethod.invoke(chunkManager, chunk.getX(), chunk.getZ(), ChunkStatus.FEATURES, true))
+                        getChunkFutureMethod.invoke(chunkManager, chunk.x(), chunk.z(), ChunkStatus.FEATURES, true))
                         .thenApply(either -> either.left().orElse(null))
                 );
             } catch (IllegalAccessException | InvocationTargetException e) {
@@ -891,7 +891,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     public boolean clearContainerBlockContents(World world, BlockVector3 pt) {
         ServerLevel originalWorld = ((CraftWorld) world).getHandle();
 
-        BlockEntity entity = originalWorld.getBlockEntity(new BlockPos(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ()));
+        BlockEntity entity = originalWorld.getBlockEntity(new BlockPos(pt.x(), pt.y(), pt.z()));
         if (entity instanceof Clearable) {
             ((Clearable) entity).clearContent();
             return true;
@@ -943,22 +943,22 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
     public boolean generateFeature(ConfiguredFeatureType type, World world, EditSession session, BlockVector3 pt) {
         ServerLevel originalWorld = ((CraftWorld) world).getHandle();
-        ConfiguredFeature<?, ?> k = originalWorld.registryAccess().registryOrThrow(Registries.CONFIGURED_FEATURE).get(ResourceLocation.tryParse(type.getId()));
+        ConfiguredFeature<?, ?> k = originalWorld.registryAccess().registryOrThrow(Registries.CONFIGURED_FEATURE).get(ResourceLocation.tryParse(type.id()));
         ServerChunkCache chunkManager = originalWorld.getChunkSource();
         WorldGenLevel proxyLevel = PaperweightServerLevelDelegateProxy.newInstance(session, originalWorld, this);
-        return k != null && k.place(proxyLevel, chunkManager.getGenerator(), random, new BlockPos(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ()));
+        return k != null && k.place(proxyLevel, chunkManager.getGenerator(), random, new BlockPos(pt.x(), pt.y(), pt.z()));
     }
 
     public boolean generateStructure(StructureType type, World world, EditSession session, BlockVector3 pt) {
         ServerLevel originalWorld = ((CraftWorld) world).getHandle();
-        Structure k = originalWorld.registryAccess().registryOrThrow(Registries.STRUCTURE).get(ResourceLocation.tryParse(type.getId()));
+        Structure k = originalWorld.registryAccess().registryOrThrow(Registries.STRUCTURE).get(ResourceLocation.tryParse(type.id()));
         if (k == null) {
             return false;
         }
 
         ServerChunkCache chunkManager = originalWorld.getChunkSource();
         WorldGenLevel proxyLevel = PaperweightServerLevelDelegateProxy.newInstance(session, originalWorld, this);
-        ChunkPos chunkPos = new ChunkPos(new BlockPos(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ()));
+        ChunkPos chunkPos = new ChunkPos(new BlockPos(pt.x(), pt.y(), pt.z()));
         StructureStart structureStart = k.generate(originalWorld.registryAccess(), chunkManager.getGenerator(), chunkManager.getGenerator().getBiomeSource(), chunkManager.randomState(), originalWorld.getStructureManager(), originalWorld.getSeed(), chunkPos, 0, proxyLevel, biome -> true);
 
         if (!structureStart.isValid()) {
@@ -978,7 +978,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
         List<ChunkAccess> nativeChunks = chunks instanceof Collection<BlockVector2> chunkCollection ? Lists.newArrayListWithCapacity(chunkCollection.size()) : Lists.newArrayList();
         for (BlockVector2 chunk : chunks) {
-            nativeChunks.add(originalWorld.getChunk(chunk.getBlockX(), chunk.getBlockZ(), ChunkStatus.BIOMES, false));
+            nativeChunks.add(originalWorld.getChunk(chunk.x(), chunk.z(), ChunkStatus.BIOMES, false));
         }
         originalWorld.getChunkSource().chunkMap.resendBiomesForChunks(nativeChunks);
     }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitAdapter.java
@@ -241,7 +241,7 @@ public class BukkitAdapter {
         Vector3 position = location.toVector();
         return new org.bukkit.Location(
                 adapt((World) location.getExtent()),
-                position.getX(), position.getY(), position.getZ(),
+            position.x(), position.y(), position.z(),
                 location.getYaw(),
                 location.getPitch());
     }
@@ -258,7 +258,7 @@ public class BukkitAdapter {
         checkNotNull(position);
         return new org.bukkit.Location(
                 world,
-                position.getX(), position.getY(), position.getZ());
+            position.x(), position.y(), position.z());
     }
 
     /**
@@ -273,7 +273,7 @@ public class BukkitAdapter {
         checkNotNull(position);
         return new org.bukkit.Location(
                 world,
-                position.getX(), position.getY(), position.getZ());
+            position.x(), position.y(), position.z());
     }
 
     /**
@@ -375,9 +375,9 @@ public class BukkitAdapter {
     }
 
     public static Biome adapt(BiomeType biomeType) {
-        NamespacedKey biomeKey = NamespacedKey.fromString(biomeType.getId());
+        NamespacedKey biomeKey = NamespacedKey.fromString(biomeType.id());
         if (biomeKey == null) {
-            throw new IllegalArgumentException("Biome key '" + biomeType.getId() + "' does not map to Bukkit");
+            throw new IllegalArgumentException("Biome key '" + biomeType.id() + "' does not map to Bukkit");
         }
         try {
             return biomeTypeBiomeCache.computeIfAbsent(biomeType, type -> Registry.BIOME.get(biomeKey));
@@ -397,9 +397,9 @@ public class BukkitAdapter {
     }
 
     public static org.bukkit.entity.EntityType adapt(EntityType entityType) {
-        NamespacedKey entityKey = NamespacedKey.fromString(entityType.getId());
+        NamespacedKey entityKey = NamespacedKey.fromString(entityType.id());
         if (entityKey == null) {
-            throw new IllegalArgumentException("Entity key '" + entityType.getId() + "' does not map to Bukkit");
+            throw new IllegalArgumentException("Entity key '" + entityType.id() + "' does not map to Bukkit");
         }
 
         return Registry.ENTITY_TYPE.get(entityKey);

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
@@ -146,8 +146,8 @@ public class BukkitPlayer extends AbstractPlayerActor {
 
     @Override
     public boolean trySetPosition(Vector3 pos, float pitch, float yaw) {
-        return player.teleport(new Location(player.getWorld(), pos.getX(), pos.getY(),
-            pos.getZ(), yaw, pitch));
+        return player.teleport(new Location(player.getWorld(), pos.x(), pos.y(),
+            pos.z(), yaw, pitch));
     }
 
     @Override
@@ -167,7 +167,7 @@ public class BukkitPlayer extends AbstractPlayerActor {
 
     @Override
     public void setGameMode(GameMode gameMode) {
-        player.setGameMode(org.bukkit.GameMode.valueOf(gameMode.getId().toUpperCase(Locale.ROOT)));
+        player.setGameMode(org.bukkit.GameMode.valueOf(gameMode.id().toUpperCase(Locale.ROOT)));
     }
 
     @Override
@@ -293,7 +293,7 @@ public class BukkitPlayer extends AbstractPlayerActor {
 
     @Override
     public <B extends BlockStateHolder<B>> void sendFakeBlock(BlockVector3 pos, B block) {
-        Location loc = new Location(player.getWorld(), pos.getX(), pos.getY(), pos.getZ());
+        Location loc = new Location(player.getWorld(), pos.x(), pos.y(), pos.z());
         if (block == null) {
             player.sendBlockChange(loc, player.getWorld().getBlockAt(loc).getBlockData());
         } else {

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
@@ -141,7 +141,7 @@ public class BukkitWorld extends AbstractWorld {
                     return null;
                 }
             } catch (Exception e) {
-                LOGGER.warn("Corrupt entity found when creating: " + entity.getType().getId(), e);
+                LOGGER.warn("Corrupt entity found when creating: " + entity.getType().id(), e);
                 if (entity.getNbt() != null) {
                     LOGGER.warn(entity.getNbt().toString());
                 }
@@ -183,7 +183,7 @@ public class BukkitWorld extends AbstractWorld {
 
     @Override
     public int getBlockLightLevel(BlockVector3 pt) {
-        return getWorld().getBlockAt(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ()).getLightLevel();
+        return getWorld().getBlockAt(pt.x(), pt.y(), pt.z()).getLightLevel();
     }
 
     @Override
@@ -217,7 +217,7 @@ public class BukkitWorld extends AbstractWorld {
             return false;
         }
 
-        Block block = getWorld().getBlockAt(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ());
+        Block block = getWorld().getBlockAt(pt.x(), pt.y(), pt.z());
         BlockState state = PaperLib.getBlockState(block, false).getState();
         if (!(state instanceof InventoryHolder inventoryHolder)) {
             return false;
@@ -286,7 +286,7 @@ public class BukkitWorld extends AbstractWorld {
     public void checkLoadedChunk(BlockVector3 pt) {
         World world = getWorld();
 
-        world.getChunkAt(pt.getBlockX() >> 4, pt.getBlockZ() >> 4);
+        world.getChunkAt(pt.x() >> 4, pt.z() >> 4);
     }
 
     @Override
@@ -325,7 +325,7 @@ public class BukkitWorld extends AbstractWorld {
     public void fixAfterFastMode(Iterable<BlockVector2> chunks) {
         World world = getWorld();
         for (BlockVector2 chunkPos : chunks) {
-            world.refreshChunk(chunkPos.getBlockX(), chunkPos.getBlockZ());
+            world.refreshChunk(chunkPos.x(), chunkPos.z());
         }
     }
 
@@ -403,7 +403,7 @@ public class BukkitWorld extends AbstractWorld {
 
     @Override
     public void simulateBlockMine(BlockVector3 pt) {
-        getWorld().getBlockAt(pt.getBlockX(), pt.getBlockY(), pt.getBlockZ()).breakNaturally();
+        getWorld().getBlockAt(pt.x(), pt.y(), pt.z()).breakNaturally();
     }
 
     @Override
@@ -452,7 +452,7 @@ public class BukkitWorld extends AbstractWorld {
             }
         }
         if (WorldEditPlugin.getInstance().getLocalConfiguration().unsupportedVersionEditing) {
-            Block bukkitBlock = getWorld().getBlockAt(position.getBlockX(), position.getBlockY(), position.getBlockZ());
+            Block bukkitBlock = getWorld().getBlockAt(position.x(), position.y(), position.z());
             return BukkitAdapter.adapt(bukkitBlock.getBlockData());
         } else {
             throw new RuntimeException(new UnsupportedVersionEditException());
@@ -475,7 +475,7 @@ public class BukkitWorld extends AbstractWorld {
             }
         }
         if (WorldEditPlugin.getInstance().getLocalConfiguration().unsupportedVersionEditing) {
-            Block bukkitBlock = getWorld().getBlockAt(position.getBlockX(), position.getBlockY(), position.getBlockZ());
+            Block bukkitBlock = getWorld().getBlockAt(position.x(), position.y(), position.z());
             bukkitBlock.setBlockData(BukkitAdapter.adapt(block), sideEffects.doesApplyAny());
             return true;
         } else {
@@ -529,7 +529,7 @@ public class BukkitWorld extends AbstractWorld {
         if (adapter != null && adapter.hasCustomBiomeSupport()) {
             return adapter.getBiome(BukkitAdapter.adapt(getWorld(), position));
         } else {
-            return BukkitAdapter.adapt(getWorld().getBiome(position.getBlockX(), position.getBlockY(), position.getBlockZ()));
+            return BukkitAdapter.adapt(getWorld().getBiome(position.x(), position.y(), position.z()));
         }
     }
 
@@ -539,7 +539,7 @@ public class BukkitWorld extends AbstractWorld {
         if (adapter != null && adapter.hasCustomBiomeSupport()) {
             adapter.setBiome(BukkitAdapter.adapt(getWorld(), position), biome);
         } else {
-            getWorld().setBiome(position.getBlockX(), position.getBlockY(), position.getBlockZ(), BukkitAdapter.adapt(biome));
+            getWorld().setBiome(position.x(), position.y(), position.z(), BukkitAdapter.adapt(biome));
         }
         return true;
     }

--- a/worldedit-core/src/main/java/com/sk89q/util/yaml/YAMLNode.java
+++ b/worldedit-core/src/main/java/com/sk89q/util/yaml/YAMLNode.java
@@ -114,28 +114,28 @@ public class YAMLNode {
         if (value instanceof Vector3) {
             Map<String, Double> out = new LinkedHashMap<>();
             Vector3 vec = (Vector3) value;
-            out.put("x", vec.getX());
-            out.put("y", vec.getY());
-            out.put("z", vec.getZ());
+            out.put("x", vec.x());
+            out.put("y", vec.y());
+            out.put("z", vec.z());
             return out;
         } else if (value instanceof BlockVector3) {
             Map<String, Integer> out = new LinkedHashMap<>();
             BlockVector3 vec = (BlockVector3) value;
-            out.put("x", vec.getBlockX());
-            out.put("y", vec.getBlockY());
-            out.put("z", vec.getBlockZ());
+            out.put("x", vec.x());
+            out.put("y", vec.y());
+            out.put("z", vec.z());
             return out;
         } else if (value instanceof Vector2) {
             Map<String, Double> out = new LinkedHashMap<>();
             Vector2 vec = (Vector2) value;
-            out.put("x", vec.getX());
-            out.put("z", vec.getZ());
+            out.put("x", vec.x());
+            out.put("z", vec.z());
             return out;
         } else if (value instanceof BlockVector2) {
             Map<String, Integer> out = new LinkedHashMap<>();
             BlockVector2 vec = (BlockVector2) value;
-            out.put("x", vec.getBlockX());
-            out.put("z", vec.getBlockZ());
+            out.put("x", vec.x());
+            out.put("z", vec.z());
             return out;
         }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1046,8 +1046,8 @@ public class EditSession implements Extent, AutoCloseable {
 
         // Avoid int overflow (negative coordinate space allows for overflow back round to positive if the depth is large enough).
         // Depth is always 1 or greater, thus the lower bound should always be <= origin y.
-        int lowerBound = origin.getBlockY() - depth + 1;
-        if (lowerBound > origin.getBlockY()) {
+        int lowerBound = origin.y() - depth + 1;
+        if (lowerBound > origin.y()) {
             lowerBound = Integer.MIN_VALUE;
         }
 
@@ -1055,7 +1055,7 @@ public class EditSession implements Extent, AutoCloseable {
                 new RegionMask(new EllipsoidRegion(null, origin, Vector3.at(radius, radius, radius))),
                 new BoundedHeightMask(
                         Math.max(lowerBound, getWorld().getMinY()),
-                        Math.min(getWorld().getMaxY(), origin.getBlockY())),
+                        Math.min(getWorld().getMaxY(), origin.y())),
                 Masks.negate(new ExistingBlockMask(this)));
 
         // Want to replace blocks
@@ -1066,7 +1066,7 @@ public class EditSession implements Extent, AutoCloseable {
         if (recursive) {
             visitor = new RecursiveVisitor(mask, replace);
         } else {
-            visitor = new DownwardVisitor(mask, replace, origin.getBlockY());
+            visitor = new DownwardVisitor(mask, replace, origin.y());
         }
 
         // Start at the origin
@@ -1239,11 +1239,11 @@ public class EditSession implements Extent, AutoCloseable {
         Vector3 center = region.getCenter();
         Region centerRegion = new CuboidRegion(
                 getWorld(), // Causes clamping of Y range
-                BlockVector3.at(((int) center.getX()), ((int) center.getY()), ((int) center.getZ())),
+                BlockVector3.at(((int) center.x()), ((int) center.y()), ((int) center.z())),
                 BlockVector3.at(
-                        MathUtils.roundHalfUp(center.getX()),
-                        MathUtils.roundHalfUp(center.getY()),
-                        MathUtils.roundHalfUp(center.getZ())));
+                        MathUtils.roundHalfUp(center.x()),
+                        MathUtils.roundHalfUp(center.y()),
+                        MathUtils.roundHalfUp(center.z())));
         return setBlocks(centerRegion, pattern);
     }
 
@@ -1348,8 +1348,8 @@ public class EditSession implements Extent, AutoCloseable {
         if (region instanceof CuboidRegion) {
             return makeCuboidWalls(region, pattern);
         } else {
-            final int minY = region.getMinimumPoint().getBlockY();
-            final int maxY = region.getMaximumPoint().getBlockY();
+            final int minY = region.getMinimumPoint().y();
+            final int maxY = region.getMaximumPoint().y();
             final ArbitraryShape shape = new RegionShape(region) {
                 @Override
                 protected BaseBlock getMaterial(int x, int y, int z, BaseBlock defaultMaterial) {
@@ -1483,7 +1483,7 @@ public class EditSession implements Extent, AutoCloseable {
 
         BlockVector3 size = region.getMaximumPoint().subtract(region.getMinimumPoint()).add(1, 1, 1);
         BlockVector3 offsetAbs = offset.abs();
-        if (offsetAbs.getX() < size.getX() && offsetAbs.getY() < size.getY() && offsetAbs.getZ() < size.getZ()) {
+        if (offsetAbs.x() < size.x() && offsetAbs.y() < size.y() && offsetAbs.z() < size.z()) {
             throw new RegionOperationException(TranslatableComponent.of("worldedit.stack.intersecting-region"));
         }
         BlockVector3 to = region.getMinimumPoint();
@@ -1667,7 +1667,7 @@ public class EditSession implements Extent, AutoCloseable {
 
         // There are boundaries that the routine needs to stay in
         MaskIntersection mask = new MaskIntersection(
-                new BoundedHeightMask(getWorld().getMinY(), Math.min(origin.getBlockY(), getWorld().getMaxY())),
+                new BoundedHeightMask(getWorld().getMinY(), Math.min(origin.y(), getWorld().getMaxY())),
                 new RegionMask(new EllipsoidRegion(null, origin, Vector3.at(radius, radius, radius))),
                 blockMask
         );
@@ -1727,10 +1727,10 @@ public class EditSession implements Extent, AutoCloseable {
             pos = pos.subtract(0, height, 0);
         }
 
-        if (pos.getBlockY() < world.getMinY()) {
+        if (pos.y() < world.getMinY()) {
             pos = pos.withY(world.getMinY());
-        } else if (pos.getBlockY() + height - 1 > world.getMaxY()) {
-            height = world.getMaxY() - pos.getBlockY() + 1;
+        } else if (pos.y() + height - 1 > world.getMaxY()) {
+            height = world.getMaxY() - pos.y() + 1;
         }
 
         final double invRadiusX = 1 / radiusX;
@@ -2030,9 +2030,9 @@ public class EditSession implements Extent, AutoCloseable {
         int affected = 0;
         double radiusSq = radius * radius;
 
-        int ox = position.getBlockX();
-        int oy = position.getBlockY();
-        int oz = position.getBlockZ();
+        int ox = position.x();
+        int oy = position.y();
+        int oz = position.z();
 
         BlockState air = BlockTypes.AIR.getDefaultState();
         BlockState water = BlockTypes.WATER.getDefaultState();
@@ -2099,7 +2099,7 @@ public class EditSession implements Extent, AutoCloseable {
     public int simulateSnow(BlockVector3 position, double radius, int height)
         throws MaxChangedBlocksException {
 
-        return simulateSnow(new CylinderRegion(position, Vector2.at(radius, radius), position.getBlockY(), height), false);
+        return simulateSnow(new CylinderRegion(position, Vector2.at(radius, radius), position.y(), height), false);
     }
 
 
@@ -2153,9 +2153,9 @@ public class EditSession implements Extent, AutoCloseable {
         int affected = 0;
         final double radiusSq = radius * radius;
 
-        final int ox = position.getBlockX();
-        final int oy = position.getBlockY();
-        final int oz = position.getBlockZ();
+        final int ox = position.x();
+        final int oy = position.y();
+        final int oz = position.z();
 
         final BlockState grass = BlockTypes.GRASS_BLOCK.getDefaultState();
 
@@ -2349,7 +2349,7 @@ public class EditSession implements Extent, AutoCloseable {
                             dataVar = legacy[1];
                         }
                     }
-                    if (expression.evaluate(new double[]{scaled.getX(), scaled.getY(), scaled.getZ(), typeVar, dataVar}, timeout) <= 0) {
+                    if (expression.evaluate(new double[]{ scaled.x(), scaled.y(), scaled.z(), typeVar, dataVar}, timeout) <= 0) {
                         return null;
                     }
                     int newType = (int) typeVariable.value();
@@ -2448,7 +2448,7 @@ public class EditSession implements Extent, AutoCloseable {
             final Vector3 scaled = position.toVector3().subtract(zero).divide(unit);
 
             // transform
-            expression.evaluate(new double[]{scaled.getX(), scaled.getY(), scaled.getZ()}, timeout);
+            expression.evaluate(new double[]{ scaled.x(), scaled.y(), scaled.z() }, timeout);
 
             final BlockVector3 sourcePosition = environment.toWorld(x.value(), y.value(), z.value());
 
@@ -2491,12 +2491,12 @@ public class EditSession implements Extent, AutoCloseable {
         final BlockVector3 min = region.getMinimumPoint();
         final BlockVector3 max = region.getMaximumPoint();
 
-        final int minX = min.getBlockX();
-        final int minY = min.getBlockY();
-        final int minZ = min.getBlockZ();
-        final int maxX = max.getBlockX();
-        final int maxY = max.getBlockY();
-        final int maxZ = max.getBlockZ();
+        final int minX = min.x();
+        final int minY = min.y();
+        final int minZ = min.z();
+        final int maxX = max.x();
+        final int maxY = max.y();
+        final int maxZ = max.z();
 
         for (int x = minX; x <= maxX; ++x) {
             for (int y = minY; y <= maxY; ++y) {
@@ -2592,12 +2592,12 @@ public class EditSession implements Extent, AutoCloseable {
             BlockVector3 pos1 = vectors.get(i);
             BlockVector3 pos2 = vectors.get(i + 1);
 
-            int x1 = pos1.getBlockX();
-            int y1 = pos1.getBlockY();
-            int z1 = pos1.getBlockZ();
-            int x2 = pos2.getBlockX();
-            int y2 = pos2.getBlockY();
-            int z2 = pos2.getBlockZ();
+            int x1 = pos1.x();
+            int y1 = pos1.y();
+            int z1 = pos1.z();
+            int x2 = pos2.x();
+            int y2 = pos2.y();
+            int z2 = pos2.z();
             int tipx = x1;
             int tipy = y1;
             int tipz = z1;
@@ -2698,9 +2698,9 @@ public class EditSession implements Extent, AutoCloseable {
         double radiusSquare = Math.pow(radius, 2);
 
         for (BlockVector3 v : vset) {
-            int tipx = v.getBlockX();
-            int tipy = v.getBlockY();
-            int tipz = v.getBlockZ();
+            int tipx = v.x();
+            int tipy = v.y();
+            int tipz = v.z();
 
             for (int loopx = tipx - ceilrad; loopx <= tipx + ceilrad; loopx++) {
                 for (int loopy = tipy - ceilrad; loopy <= tipy + ceilrad; loopy++) {
@@ -2718,9 +2718,9 @@ public class EditSession implements Extent, AutoCloseable {
     private static Set<BlockVector3> getHollowed(Set<BlockVector3> vset) {
         Set<BlockVector3> returnset = new HashSet<>();
         for (BlockVector3 v : vset) {
-            double x = v.getX();
-            double y = v.getY();
-            double z = v.getZ();
+            double x = v.x();
+            double y = v.y();
+            double z = v.z();
             if (!(vset.contains(BlockVector3.at(x + 1, y, z))
                 && vset.contains(BlockVector3.at(x - 1, y, z))
                 && vset.contains(BlockVector3.at(x, y + 1, z))
@@ -2782,7 +2782,7 @@ public class EditSession implements Extent, AutoCloseable {
                 final Vector3 scaled = current.subtract(zero).divide(unit);
 
                 try {
-                    if (expression.evaluate(new double[]{scaled.getX(), scaled.getY(), scaled.getZ()}, timeout) <= 0) {
+                    if (expression.evaluate(new double[]{ scaled.x(), scaled.y(), scaled.z() }, timeout) <= 0) {
                         return null;
                     }
 
@@ -2858,7 +2858,7 @@ public class EditSession implements Extent, AutoCloseable {
                         highestFreq = 0;
                         highestState = blockState;
                         for (BlockVector3 vec3 : recurseDirections) {
-                            BlockState adj = currentBuffer[x + 1 + vec3.getX()][y + 1 + vec3.getY()][z + 1 + vec3.getZ()];
+                            BlockState adj = currentBuffer[x + 1 + vec3.x()][y + 1 + vec3.y()][z + 1 + vec3.z()];
 
                             if (!adj.getBlockType().getMaterial().isLiquid() && !adj.getBlockType().getMaterial().isAir()) {
                                 continue;
@@ -2911,7 +2911,7 @@ public class EditSession implements Extent, AutoCloseable {
                         highestFreq = 0;
                         highestState = blockState;
                         for (BlockVector3 vec3 : recurseDirections) {
-                            BlockState adj = currentBuffer[x + 1 + vec3.getX()][y + 1 + vec3.getY()][z + 1 + vec3.getZ()];
+                            BlockState adj = currentBuffer[x + 1 + vec3.x()][y + 1 + vec3.y()][z + 1 + vec3.z()];
                             if (adj.getBlockType().getMaterial().isLiquid() || adj.getBlockType().getMaterial().isAir()) {
                                 continue;
                             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/BrushCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/BrushCommands.java
@@ -247,9 +247,9 @@ public class BrushCommands {
 
         BlockVector3 size = clipboard.getDimensions();
 
-        worldEdit.checkMaxBrushRadius(size.getBlockX() / 2D - 1);
-        worldEdit.checkMaxBrushRadius(size.getBlockY() / 2D - 1);
-        worldEdit.checkMaxBrushRadius(size.getBlockZ() / 2D - 1);
+        worldEdit.checkMaxBrushRadius(size.x() / 2D - 1);
+        worldEdit.checkMaxBrushRadius(size.y() / 2D - 1);
+        worldEdit.checkMaxBrushRadius(size.z() / 2D - 1);
 
         session.forceBrush(
             player.getItemInHand(HandSide.MAIN_HAND).getType(),

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GenerationCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GenerationCommands.java
@@ -396,13 +396,13 @@ public class GenerationCommands {
             zero = max.add(min).multiply(0.5);
             unit = max.subtract(zero);
 
-            if (unit.getX() == 0) {
+            if (unit.x() == 0) {
                 unit = unit.withX(1.0);
             }
-            if (unit.getY() == 0) {
+            if (unit.y() == 0) {
                 unit = unit.withY(1.0);
             }
-            if (unit.getZ() == 0) {
+            if (unit.z() == 0) {
                 unit = unit.withZ(1.0);
             }
         }
@@ -464,13 +464,13 @@ public class GenerationCommands {
             zero = max.add(min).multiply(0.5);
             unit = max.subtract(zero);
 
-            if (unit.getX() == 0) {
+            if (unit.x() == 0) {
                 unit = unit.withX(1.0);
             }
-            if (unit.getY() == 0) {
+            if (unit.y() == 0) {
                 unit = unit.withY(1.0);
             }
-            if (unit.getZ() == 0) {
+            if (unit.z() == 0) {
                 unit = unit.withZ(1.0);
             }
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -505,13 +505,13 @@ public class RegionCommands {
             zero = max.add(min).divide(2);
             unit = max.subtract(zero);
 
-            if (unit.getX() == 0) {
+            if (unit.x() == 0) {
                 unit = unit.withX(1.0);
             }
-            if (unit.getY() == 0) {
+            if (unit.y() == 0) {
                 unit = unit.withY(1.0);
             }
-            if (unit.getZ() == 0) {
+            if (unit.z() == 0) {
                 unit = unit.withZ(1.0);
             }
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SelectionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SelectionCommands.java
@@ -290,12 +290,12 @@ public class SelectionCommands {
 
             actor.printInfo(TranslatableComponent.of(
                 "worldedit.chunk.selected-multiple",
-                TextComponent.of(minChunk.getBlockX()),
-                TextComponent.of(minChunk.getBlockY()),
-                TextComponent.of(minChunk.getBlockZ()),
-                TextComponent.of(maxChunk.getBlockX()),
-                TextComponent.of(maxChunk.getBlockY()),
-                TextComponent.of(maxChunk.getBlockZ())
+                TextComponent.of(minChunk.x()),
+                TextComponent.of(minChunk.y()),
+                TextComponent.of(minChunk.z()),
+                TextComponent.of(maxChunk.x()),
+                TextComponent.of(maxChunk.y()),
+                TextComponent.of(maxChunk.z())
             ));
         } else {
             BlockVector3 minChunk;
@@ -317,9 +317,9 @@ public class SelectionCommands {
             max = min.add(15, 255, 15);
 
             actor.printInfo(TranslatableComponent.of("worldedit.chunk.selected",
-                TextComponent.of(minChunk.getBlockX()),
-                TextComponent.of(minChunk.getBlockY()),
-                TextComponent.of(minChunk.getBlockZ())));
+                TextComponent.of(minChunk.x()),
+                TextComponent.of(minChunk.y()),
+                TextComponent.of(minChunk.z())));
         }
 
         final CuboidRegionSelector selector;
@@ -534,9 +534,9 @@ public class SelectionCommands {
         int minY = 0;
         boolean found = false;
 
-        outer: for (int y = min.getBlockY(); y <= max.getBlockY(); y++) {
-            for (int x = min.getBlockX(); x <= max.getBlockX(); x++) {
-                for (int z = min.getBlockZ(); z <= max.getBlockZ(); z++) {
+        outer: for (int y = min.y(); y <= max.y(); y++) {
+            for (int x = min.x(); x <= max.x(); x++) {
+                for (int z = min.z(); z <= max.z(); z++) {
                     BlockVector3 vec = BlockVector3.at(x, y, z);
 
                     if (mask.test(vec)) {
@@ -557,9 +557,9 @@ public class SelectionCommands {
 
         int maxY = minY;
 
-        outer: for (int y = max.getBlockY(); y > minY; y--) {
-            for (int x = min.getBlockX(); x <= max.getBlockX(); x++) {
-                for (int z = min.getBlockZ(); z <= max.getBlockZ(); z++) {
+        outer: for (int y = max.y(); y > minY; y--) {
+            for (int x = min.x(); x <= max.x(); x++) {
+                for (int z = min.z(); z <= max.z(); z++) {
                     BlockVector3 vec = BlockVector3.at(x, y, z);
 
                     if (mask.test(vec)) {
@@ -572,8 +572,8 @@ public class SelectionCommands {
 
         int minX = 0;
 
-        outer: for (int x = min.getBlockX(); x <= max.getBlockX(); x++) {
-            for (int z = min.getBlockZ(); z <= max.getBlockZ(); z++) {
+        outer: for (int x = min.x(); x <= max.x(); x++) {
+            for (int z = min.z(); z <= max.z(); z++) {
                 for (int y = minY; y <= maxY; y++) {
                     BlockVector3 vec = BlockVector3.at(x, y, z);
 
@@ -587,8 +587,8 @@ public class SelectionCommands {
 
         int maxX = minX;
 
-        outer: for (int x = max.getBlockX(); x > minX; x--) {
-            for (int z = min.getBlockZ(); z <= max.getBlockZ(); z++) {
+        outer: for (int x = max.x(); x > minX; x--) {
+            for (int z = min.z(); z <= max.z(); z++) {
                 for (int y = minY; y <= maxY; y++) {
                     BlockVector3 vec = BlockVector3.at(x, y, z);
 
@@ -602,7 +602,7 @@ public class SelectionCommands {
 
         int minZ = 0;
 
-        outer: for (int z = min.getBlockZ(); z <= max.getBlockZ(); z++) {
+        outer: for (int z = min.z(); z <= max.z(); z++) {
             for (int x = minX; x <= maxX; x++) {
                 for (int y = minY; y <= maxY; y++) {
                     BlockVector3 vec = BlockVector3.at(x, y, z);
@@ -617,7 +617,7 @@ public class SelectionCommands {
 
         int maxZ = minZ;
 
-        outer: for (int z = max.getBlockZ(); z > minZ; z--) {
+        outer: for (int z = max.z(); z > minZ; z--) {
             for (int x = minX; x <= maxX; x++) {
                 for (int y = minY; y <= maxY; y++) {
                     BlockVector3 vec = BlockVector3.at(x, y, z);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/UtilityCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/UtilityCommands.java
@@ -307,7 +307,7 @@ public class UtilityCommands {
 
         BlockVector3 position = session.getPlacementPosition(actor);
 
-        CylinderRegion region = new CylinderRegion(position, Vector2.at(size, size), position.getBlockY() - height, position.getBlockY() + height);
+        CylinderRegion region = new CylinderRegion(position, Vector2.at(size, size), position.y() - height, position.y() + height);
         int affected = editSession.simulateSnow(region, stack);
         actor.printInfo(TranslatableComponent.of(
             "worldedit.snow.created", TextComponent.of(affected)

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/OffsetConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/OffsetConverter.java
@@ -98,9 +98,9 @@ public class OffsetConverter implements ArgumentConverter<BlockVector3> {
 
         // Create an affine transform of the columns (col4 is empty due to no translation)
         AffineTransform transform = new AffineTransform(
-            m1.getX(), m2.getX(), m3.getX(), 0,
-            m1.getY(), m2.getY(), m3.getY(), 0,
-            m1.getZ(), m2.getZ(), m3.getZ(), 0
+            m1.x(), m2.x(), m3.x(), 0,
+            m1.y(), m2.y(), m3.y(), 0,
+            m1.z(), m2.z(), m3.z(), 0
         );
 
         return transform

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/GravityBrush.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/GravityBrush.java
@@ -44,12 +44,12 @@ public class GravityBrush implements Brush {
     @Override
     public void build(EditSession editSession, BlockVector3 position, Pattern pattern, double size) throws MaxChangedBlocksException {
         double sizeOffset = overrideHeight ? heightOffset : size;
-        double yMax = Math.min(position.getY() + sizeOffset, editSession.getWorld().getMaxY());
-        double yMin = Math.max(position.getY() - sizeOffset, editSession.getWorld().getMinY());
+        double yMax = Math.min(position.y() + sizeOffset, editSession.getWorld().getMaxY());
+        double yMin = Math.max(position.y() - sizeOffset, editSession.getWorld().getMinY());
         LocatedBlockList column = new LocatedBlockList();
         Set<BlockVector3> removedBlocks = new LinkedHashSet<>();
-        for (double x = position.getX() - size; x <= position.getX() + size; x++) {
-            for (double z = position.getZ() - size; z <= position.getZ() + size; z++) {
+        for (double x = position.x() - size; x <= position.x() + size; x++) {
+            for (double z = position.z() - size; z <= position.z() + size; z++) {
                 /*
                  * Algorithm:
                  * 1. Find the lowest air block in the selection -> $lowestAir = position

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/ImageHeightmapBrush.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/ImageHeightmapBrush.java
@@ -52,8 +52,8 @@ public class ImageHeightmapBrush implements Brush {
         double random = randomize ? ThreadLocalRandom.current().nextDouble() : 0;
         for (int offX = -size; offX <= size; offX++) {
             for (int offZ = -size; offZ <= size; offZ++) {
-                int posX = position.getX() + offX;
-                int posZ = position.getZ() + offZ;
+                int posX = position.x() + offX;
+                int posZ = position.z() + offZ;
                 int posY = editSession.getHighestTerrainBlock(posX, posZ, 0, 255, editSession.getMask());
                 BlockVector3 block = BlockVector3.at(posX, posY, posZ);
                 if (editSession.getMask() != null && !editSession.getMask().test(block)) {
@@ -70,11 +70,11 @@ public class ImageHeightmapBrush implements Brush {
                 for (int y = 0; y < height; y++) {
                     if (erase) {
                         // Remove blocks if using the erase flag
-                        if (!flatten || block.getY() - y > position.getY()) {
-                            editSession.setBlock(block.withY(block.getY() - y), BlockTypes.AIR.getDefaultState());
+                        if (!flatten || block.y() - y > position.y()) {
+                            editSession.setBlock(block.withY(block.y() - y), BlockTypes.AIR.getDefaultState());
                         }
-                    } else if (!flatten || block.getY() + y <= position.getY()) {
-                        editSession.setBlock(block.withY(block.getY() + y), baseBlock);
+                    } else if (!flatten || block.y() + y <= position.y()) {
+                        editSession.setBlock(block.withY(block.y() + y), baseBlock);
                     }
                 }
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
@@ -108,8 +108,8 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
     public void findFreePosition(Location searchPos) {
         Extent world = searchPos.getExtent();
 
-        int worldMinY = world.getMinimumPoint().getY();
-        int worldMaxY = world.getMaximumPoint().getY();
+        int worldMinY = world.getMinimumPoint().y();
+        int worldMaxY = world.getMaximumPoint().y();
 
         int x = searchPos.getBlockX();
         int y = Math.max(worldMinY, searchPos.getBlockY());
@@ -147,7 +147,7 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
     public void setOnGround(Location searchPos) {
         Extent world = searchPos.getExtent();
 
-        int worldMinY = world.getMinimumPoint().getY();
+        int worldMinY = world.getMinimumPoint().y();
 
         int x = searchPos.getBlockX();
         int y = Math.max(worldMinY, searchPos.getBlockY());

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/BlockArrayClipboard.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/BlockArrayClipboard.java
@@ -64,7 +64,7 @@ public class BlockArrayClipboard implements Clipboard {
         this.origin = region.getMinimumPoint();
 
         BlockVector3 dimensions = getDimensions();
-        blocks = new BaseBlock[dimensions.getBlockX()][dimensions.getBlockY()][dimensions.getBlockZ()];
+        blocks = new BaseBlock[dimensions.x()][dimensions.y()][dimensions.z()];
     }
 
     @Override
@@ -125,7 +125,7 @@ public class BlockArrayClipboard implements Clipboard {
     public BlockState getBlock(BlockVector3 position) {
         if (region.contains(position)) {
             BlockVector3 v = position.subtract(region.getMinimumPoint());
-            BaseBlock block = blocks[v.getBlockX()][v.getBlockY()][v.getBlockZ()];
+            BaseBlock block = blocks[v.x()][v.y()][v.z()];
             if (block != null) {
                 return block.toImmutableState();
             }
@@ -138,7 +138,7 @@ public class BlockArrayClipboard implements Clipboard {
     public BaseBlock getFullBlock(BlockVector3 position) {
         if (region.contains(position)) {
             BlockVector3 v = position.subtract(region.getMinimumPoint());
-            BaseBlock block = blocks[v.getBlockX()][v.getBlockY()][v.getBlockZ()];
+            BaseBlock block = blocks[v.x()][v.y()][v.z()];
             if (block != null) {
                 return block;
             }
@@ -151,7 +151,7 @@ public class BlockArrayClipboard implements Clipboard {
     public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 position, B block) {
         if (region.contains(position)) {
             BlockVector3 v = position.subtract(region.getMinimumPoint());
-            blocks[v.getBlockX()][v.getBlockY()][v.getBlockZ()] = block.toBaseBlock();
+            blocks[v.x()][v.y()][v.z()] = block.toBaseBlock();
             return true;
         } else {
             return false;
@@ -168,7 +168,7 @@ public class BlockArrayClipboard implements Clipboard {
         if (biomes != null
                 && position.containedWithin(getMinimumPoint(), getMaximumPoint())) {
             BlockVector3 v = position.subtract(region.getMinimumPoint());
-            BiomeType biomeType = biomes[v.getBlockX()][v.getBlockY()][v.getBlockZ()];
+            BiomeType biomeType = biomes[v.x()][v.y()][v.z()];
             if (biomeType != null) {
                 return biomeType;
             }
@@ -184,7 +184,7 @@ public class BlockArrayClipboard implements Clipboard {
             if (biomes == null) {
                 biomes = new BiomeType[region.getWidth()][region.getHeight()][region.getLength()];
             }
-            biomes[v.getBlockX()][v.getBlockY()][v.getBlockZ()] = biome;
+            biomes[v.x()][v.y()][v.z()] = biome;
             return true;
         }
         return false;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/sponge/ReaderUtil.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/sponge/ReaderUtil.java
@@ -150,9 +150,9 @@ public class ReaderUtil {
                     decodeBlockVector3(tileEntity.getTag("Pos", LinTagType.intArrayTag()))
                 );
                 LinCompoundTag.Builder values = extractData(dataIsNested, tileEntity);
-                values.putInt("x", pt.getBlockX());
-                values.putInt("y", pt.getBlockY());
-                values.putInt("z", pt.getBlockZ());
+                values.putInt("x", pt.x());
+                values.putInt("y", pt.y());
+                values.putInt("z", pt.z());
                 values.put("id", tileEntity.value().get("Id"));
                 if (fixer.isActive()) {
                     tileEntity = fixer.fixUp(DataFixer.FixTypes.BLOCK_ENTITY, values.build());

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/sponge/SpongeSchematicV2Reader.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/sponge/SpongeSchematicV2Reader.java
@@ -123,7 +123,7 @@ public class SpongeSchematicV2Reader implements ClipboardReader {
 
         Int2ObjectMap<BiomeType> palette = ReaderUtil.readBiomePalette(fixer, paletteTag, LOGGER);
 
-        int width = clipboard.getDimensions().getX();
+        int width = clipboard.getDimensions().x();
 
         byte[] biomes = dataTag.value();
         BlockVector3 min = clipboard.getMinimumPoint();
@@ -135,8 +135,8 @@ public class SpongeSchematicV2Reader implements ClipboardReader {
             BlockVector3 hackDecode = ReaderUtil.decodePositionFromDataIndex(
                 width, 1, index
             );
-            int x = hackDecode.getX();
-            int z = hackDecode.getY();
+            int x = hackDecode.x();
+            int z = hackDecode.y();
             for (int y = 0; y < clipboard.getRegion().getHeight(); y++) {
                 clipboard.setBiome(min.add(x, y, z), type);
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/sponge/SpongeSchematicV2Writer.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/sponge/SpongeSchematicV2Writer.java
@@ -96,9 +96,9 @@ public class SpongeSchematicV2Writer implements ClipboardWriter {
         );
 
         LinCompoundTag.Builder metadata = LinCompoundTag.builder();
-        metadata.putInt("WEOffsetX", offset.getBlockX());
-        metadata.putInt("WEOffsetY", offset.getBlockY());
-        metadata.putInt("WEOffsetZ", offset.getBlockZ());
+        metadata.putInt("WEOffsetX", offset.x());
+        metadata.putInt("WEOffsetY", offset.y());
+        metadata.putInt("WEOffsetZ", offset.z());
 
         LinCompoundTag.Builder worldEditSection = LinCompoundTag.builder();
         worldEditSection.putString("Version", WorldEdit.getVersion());
@@ -107,7 +107,7 @@ public class SpongeSchematicV2Writer implements ClipboardWriter {
             WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.WORLD_EDITING).getId()
         );
         worldEditSection.putIntArray("Offset", new int[] {
-            offset.getBlockX(), offset.getBlockY(), offset.getBlockZ()
+            offset.x(), offset.y(), offset.z()
         });
 
         LinCompoundTag.Builder platformsSection = LinCompoundTag.builder();
@@ -132,9 +132,9 @@ public class SpongeSchematicV2Writer implements ClipboardWriter {
 
         // The Sponge format Offset refers to the 'min' points location in the world. That's our 'Origin'
         schematic.putIntArray("Offset", new int[] {
-            min.getBlockX(),
-            min.getBlockY(),
-            min.getBlockZ(),
+            min.x(),
+            min.y(),
+            min.z(),
         });
 
         int paletteMax = 0;
@@ -145,11 +145,11 @@ public class SpongeSchematicV2Writer implements ClipboardWriter {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream(width * height * length);
 
         for (int y = 0; y < height; y++) {
-            int y0 = min.getBlockY() + y;
+            int y0 = min.y() + y;
             for (int z = 0; z < length; z++) {
-                int z0 = min.getBlockZ() + z;
+                int z0 = min.z() + z;
                 for (int x = 0; x < width; x++) {
-                    int x0 = min.getBlockX() + x;
+                    int x0 = min.x() + x;
                     BlockVector3 point = BlockVector3.at(x0, y0, z0);
                     BaseBlock block = clipboard.getFullBlock(point);
                     LinCompoundTag nbt = block.getNbt();
@@ -223,13 +223,13 @@ public class SpongeSchematicV2Writer implements ClipboardWriter {
         Object2IntMap<String> palette = new Object2IntLinkedOpenHashMap<>();
 
         for (int z = 0; z < length; z++) {
-            int z0 = min.getBlockZ() + z;
+            int z0 = min.z() + z;
             for (int x = 0; x < width; x++) {
-                int x0 = min.getBlockX() + x;
-                BlockVector3 pt = BlockVector3.at(x0, min.getBlockY(), z0);
+                int x0 = min.x() + x;
+                BlockVector3 pt = BlockVector3.at(x0, min.y(), z0);
                 BiomeType biome = clipboard.getBiome(pt);
 
-                String biomeKey = biome.getId();
+                String biomeKey = biome.id();
                 int biomeId;
                 if (palette.containsKey(biomeKey)) {
                     biomeId = palette.getInt(biomeKey);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/sponge/SpongeSchematicV3Writer.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/sponge/SpongeSchematicV3Writer.java
@@ -110,7 +110,7 @@ public class SpongeSchematicV3Writer implements ClipboardWriter {
             WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.WORLD_EDITING).getId()
         );
         worldEditSection.putIntArray("Origin", new int[] {
-            origin.getBlockX(), origin.getBlockY(), origin.getBlockZ()
+            origin.x(), origin.y(), origin.z()
         });
 
         LinCompoundTag.Builder platformsSection = LinCompoundTag.builder();
@@ -134,9 +134,9 @@ public class SpongeSchematicV3Writer implements ClipboardWriter {
         schematic.putShort("Length", (short) length);
 
         schematic.putIntArray("Offset", new int[] {
-            offset.getBlockX(),
-            offset.getBlockY(),
-            offset.getBlockZ(),
+            offset.x(),
+            offset.y(),
+            offset.z(),
         });
 
         schematic.put("Blocks", encodeBlocks(clipboard));
@@ -189,9 +189,9 @@ public class SpongeSchematicV3Writer implements ClipboardWriter {
                 builder.putString("Id", block.getNbtId());
                 BlockVector3 adjustedPos = point.subtract(clipboard.getMinimumPoint());
                 builder.putIntArray("Pos", new int[] {
-                    adjustedPos.getBlockX(),
-                    adjustedPos.getBlockY(),
-                    adjustedPos.getBlockZ()
+                    adjustedPos.x(),
+                    adjustedPos.y(),
+                    adjustedPos.z()
                 });
                 builder.put("Data", nbt);
 
@@ -206,7 +206,7 @@ public class SpongeSchematicV3Writer implements ClipboardWriter {
     }
 
     private LinCompoundTag encodeBiomes(Clipboard clipboard) {
-        return encodePalettedData(clipboard, point -> clipboard.getBiome(point).getId()).build();
+        return encodePalettedData(clipboard, point -> clipboard.getBiome(point).id()).build();
     }
 
     private LinCompoundTag.Builder encodePalettedData(Clipboard clipboard,

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/sponge/WriterUtil.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/sponge/WriterUtil.java
@@ -68,7 +68,7 @@ class WriterUtil {
         } else {
             fullTagBuilder.putAll(dataTagBuilder.build().value());
         }
-        fullTagBuilder.putString("Id", state.getType().getId());
+        fullTagBuilder.putString("Id", state.getType().id());
         fullTagBuilder.put("Pos", encodeVector(pos));
 
         return fullTagBuilder.build();
@@ -76,9 +76,9 @@ class WriterUtil {
 
     static LinListTag<LinDoubleTag> encodeVector(Vector3 vector) {
         return LinListTag.builder(LinTagType.doubleTag())
-            .add(LinDoubleTag.of(vector.getX()))
-            .add(LinDoubleTag.of(vector.getY()))
-            .add(LinDoubleTag.of(vector.getZ()))
+            .add(LinDoubleTag.of(vector.x()))
+            .add(LinDoubleTag.of(vector.y()))
+            .add(LinDoubleTag.of(vector.z()))
             .build();
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/validation/DataValidatorExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/validation/DataValidatorExtent.java
@@ -63,7 +63,7 @@ public class DataValidatorExtent extends AbstractDelegateExtent {
 
     @Override
     public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 location, B block) throws WorldEditException {
-        final int y = location.getBlockY();
+        final int y = location.y();
         final BlockType type = block.getBlockType();
         if (y < minY || y > maxY) {
             return false;
@@ -79,7 +79,7 @@ public class DataValidatorExtent extends AbstractDelegateExtent {
 
     @Override
     public boolean setBiome(BlockVector3 location, BiomeType biome) {
-        final int y = location.getBlockY();
+        final int y = location.y();
 
         if (y < minY || y > maxY) {
             return false;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/SideEffectExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/SideEffectExtent.java
@@ -90,7 +90,7 @@ public class SideEffectExtent extends AbstractDelegateExtent {
     @Override
     public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 location, B block) throws WorldEditException {
         if (sideEffectSet.getState(SideEffect.LIGHTING) == SideEffect.State.DELAYED) {
-            dirtyChunks.add(BlockVector2.at(location.getBlockX() >> 4, location.getBlockZ() >> 4));
+            dirtyChunks.add(BlockVector2.at(location.x() >> 4, location.z() >> 4));
         }
         if (postEditSimulation) {
             positions.put(location, world.getBlock(location));
@@ -101,7 +101,7 @@ public class SideEffectExtent extends AbstractDelegateExtent {
 
     @Override
     public boolean setBiome(BlockVector3 position, BiomeType biome) {
-        dirtyBiomes.add(BlockVector2.at(position.getBlockX() >> 4, position.getBlockZ() >> 4));
+        dirtyBiomes.add(BlockVector2.at(position.x() >> 4, position.z() >> 4));
         return world.setBiome(position, biome);
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/biome/BiomeReplace.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/biome/BiomeReplace.java
@@ -70,7 +70,7 @@ public class BiomeReplace implements FlatRegionFunction, RegionFunction {
     @Deprecated
     public boolean apply(BlockVector2 position) throws WorldEditException {
         boolean success = false;
-        for (int y = extent.getMinimumPoint().getY(); y <= extent.getMaximumPoint().getY(); y++) {
+        for (int y = extent.getMinimumPoint().y(); y <= extent.getMaximumPoint().y(); y++) {
             success |= apply(position.toBlockVector3(y));
         }
         return success;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/biome/ExtentBiomeCopy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/biome/ExtentBiomeCopy.java
@@ -102,7 +102,7 @@ public class ExtentBiomeCopy implements FlatRegionFunction, RegionFunction {
     @Deprecated
     public boolean apply(BlockVector2 position) throws WorldEditException {
         boolean success = false;
-        for (int y = destination.getMinimumPoint().getY(); y <= destination.getMaximumPoint().getY(); y++) {
+        for (int y = destination.getMinimumPoint().y(); y <= destination.getMaximumPoint().y(); y++) {
             success |= apply(position.toBlockVector3(y));
         }
         return success;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/block/SnowSimulator.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/block/SnowSimulator.java
@@ -100,7 +100,7 @@ public class SnowSimulator implements LayerFunction {
         }
 
         // Can't put snow this far up
-        if (position.getBlockY() == this.extent.getMaximumPoint().getBlockY()) {
+        if (position.y() == this.extent.getMaximumPoint().y()) {
             return false;
         }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/entity/ExtentEntityCopy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/entity/ExtentEntityCopy.java
@@ -163,9 +163,9 @@ public class ExtentEntityCopy implements EntityFunction {
                     BlockVector3 newLeash = transform.apply(tilePosition.subtract(from)).add(to).toBlockPoint();
                     return new BaseEntity(state.getType(), LazyReference.computed(tag.toBuilder()
                         .put("Leash", leashCompound.toBuilder()
-                            .putInt("X", newLeash.getBlockX())
-                            .putInt("Y", newLeash.getBlockY())
-                            .putInt("Z", newLeash.getBlockZ())
+                            .putInt("X", newLeash.x())
+                            .putInt("Y", newLeash.y())
+                            .putInt("Z", newLeash.z())
                             .build()
                         ).build()));
                 }
@@ -182,9 +182,9 @@ public class ExtentEntityCopy implements EntityFunction {
                 BlockVector3 newTilePosition = transform.apply(tilePosition.subtract(from)).add(to).toBlockPoint();
 
                 LinCompoundTag.Builder builder = tag.toBuilder()
-                    .putInt("TileX", newTilePosition.getBlockX())
-                    .putInt("TileY", newTilePosition.getBlockY())
-                    .putInt("TileZ", newTilePosition.getBlockZ());
+                    .putInt("TileX", newTilePosition.x())
+                    .putInt("TileY", newTilePosition.y())
+                    .putInt("TileZ", newTilePosition.z());
 
                 if (tag.value().get("Facing") instanceof LinNumberTag<?> tagFacing) {
                     boolean isPainting = state.getType() == EntityTypes.PAINTING; // Paintings have different facing values

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/factory/ApplyLayer.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/factory/ApplyLayer.java
@@ -52,8 +52,8 @@ public class ApplyLayer implements Contextual<Operation> {
         FlatRegion localRegion = Regions.asFlatRegion(firstNonNull(context.getRegion(), region));
 
         return new LayerVisitor(localRegion,
-            localRegion.getMinimumPoint().getY(),
-            localRegion.getMaximumPoint().getY(),
+            localRegion.getMinimumPoint().y(),
+            localRegion.getMaximumPoint().y(),
             function.createFromContext(context));
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/factory/Deform.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/factory/Deform.java
@@ -131,13 +131,13 @@ public class Deform implements Contextual<Operation> {
                 zero = max.add(min).multiply(0.5);
                 unit = max.subtract(zero);
 
-                if (unit.getX() == 0) {
+                if (unit.x() == 0) {
                     unit = unit.withX(1.0);
                 }
-                if (unit.getY() == 0) {
+                if (unit.y() == 0) {
                     unit = unit.withY(1.0);
                 }
-                if (unit.getZ() == 0) {
+                if (unit.z() == 0) {
                     unit = unit.withZ(1.0);
                 }
                 break;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/BoundedHeightMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/BoundedHeightMask.java
@@ -46,7 +46,7 @@ public class BoundedHeightMask extends AbstractMask {
 
     @Override
     public boolean test(BlockVector3 vector) {
-        return vector.getY() >= minY && vector.getY() <= maxY;
+        return vector.y() >= minY && vector.y() <= maxY;
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/ExpressionMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/ExpressionMask.java
@@ -73,9 +73,9 @@ public class ExpressionMask extends AbstractMask {
                 ((WorldEditExpressionEnvironment) expression.getEnvironment()).setCurrentBlock(vector.toVector3());
             }
             if (timeout == null) {
-                return expression.evaluate(vector.getX(), vector.getY(), vector.getZ()) > 0;
+                return expression.evaluate(vector.x(), vector.y(), vector.z()) > 0;
             } else {
-                return expression.evaluate(new double[]{vector.getX(), vector.getY(), vector.getZ()},
+                return expression.evaluate(new double[]{ vector.x(), vector.y(), vector.z() },
                         timeout.getAsInt()) > 0;
             }
         } catch (EvaluationException e) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/ExpressionMask2D.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/ExpressionMask2D.java
@@ -63,9 +63,9 @@ public class ExpressionMask2D extends AbstractMask2D {
     public boolean test(BlockVector2 vector) {
         try {
             if (timeout != null) {
-                return expression.evaluate(vector.getX(), 0, vector.getZ()) > 0;
+                return expression.evaluate(vector.x(), 0, vector.z()) > 0;
             } else {
-                return expression.evaluate(new double[]{vector.getX(), 0, vector.getZ()}, timeout.getAsInt()) > 0;
+                return expression.evaluate(new double[]{ vector.x(), 0, vector.z() }, timeout.getAsInt()) > 0;
             }
         } catch (EvaluationException e) {
             return false;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/RepeatingExtentPattern.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/RepeatingExtentPattern.java
@@ -88,9 +88,9 @@ public class RepeatingExtentPattern extends AbstractExtentPattern {
     @Override
     public BaseBlock applyBlock(BlockVector3 position) {
         BlockVector3 base = position.add(offset);
-        int x = Math.floorMod(base.getBlockX(), size.getBlockX());
-        int y = Math.floorMod(base.getBlockY(), size.getBlockY());
-        int z = Math.floorMod(base.getBlockZ(), size.getBlockZ());
+        int x = Math.floorMod(base.x(), size.x());
+        int y = Math.floorMod(base.y(), size.y());
+        int z = Math.floorMod(base.z(), size.z());
         return getExtent().getFullBlock(BlockVector3.at(x, y, z).add(origin));
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/visitor/DownwardVisitor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/visitor/DownwardVisitor.java
@@ -62,7 +62,7 @@ public class DownwardVisitor extends RecursiveVisitor {
 
     @Override
     protected boolean isVisitable(BlockVector3 from, BlockVector3 to) {
-        int fromY = from.getBlockY();
-        return (fromY == baseY || to.subtract(from).getBlockY() < 0) && super.isVisitable(from, to);
+        int fromY = from.y();
+        return (fromY == baseY || to.subtract(from).y() < 0) && super.isVisitable(from, to);
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/anvil/ChunkDeleter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/anvil/ChunkDeleter.java
@@ -55,7 +55,7 @@ public final class ChunkDeleter {
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     private static final Comparator<BlockVector2> chunkSorter = Comparator.comparing(
-        pos -> (pos.getBlockX() & 31) + (pos.getBlockZ() & 31) * 32
+        pos -> (pos.x() & 31) + (pos.z() & 31) * 32
     );
 
     private static final Gson chunkDeleterGson = new GsonBuilder()
@@ -180,14 +180,14 @@ public final class ChunkDeleter {
                     int startZ = regZ << 5;
                     int endZ = (regZ << 5) + 31;
 
-                    int minX = Math.max(Math.min(startX, endX), minChunk.getBlockX());
-                    int minZ = Math.max(Math.min(startZ, endZ), minChunk.getBlockZ());
-                    int maxX = Math.min(Math.max(startX, endX), maxChunk.getBlockX());
-                    int maxZ = Math.min(Math.max(startZ, endZ), maxChunk.getBlockZ());
+                    int minX = Math.max(Math.min(startX, endX), minChunk.x());
+                    int minZ = Math.max(Math.min(startZ, endZ), minChunk.z());
+                    int maxX = Math.min(Math.max(startX, endX), maxChunk.x());
+                    int maxZ = Math.min(Math.max(startZ, endZ), maxChunk.z());
                     Stream<BlockVector2> stream = Stream.iterate(BlockVector2.at(minX, minZ),
                         bv2 -> {
-                            int nextX = bv2.getBlockX();
-                            int nextZ = bv2.getBlockZ();
+                            int nextX = bv2.x();
+                            int nextZ = bv2.z();
                             if (++nextX > maxX) {
                                 nextX = minX;
                                 if (++nextZ > maxZ) {
@@ -286,8 +286,8 @@ public final class ChunkDeleter {
         @Override
         public void write(JsonWriter out, BlockVector2 value) throws IOException {
             out.beginArray();
-            out.value(value.getBlockX());
-            out.value(value.getBlockZ());
+            out.value(value.x());
+            out.value(value.z());
             out.endArray();
         }
 
@@ -306,8 +306,8 @@ public final class ChunkDeleter {
         private final int z;
 
         RegionFilePos(BlockVector2 chunk) {
-            this.x = chunk.getBlockX() >> 5;
-            this.z = chunk.getBlockZ() >> 5;
+            this.x = chunk.x() >> 5;
+            this.z = chunk.z() >> 5;
         }
 
         RegionFilePos(int regX, int regZ) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/anvil/ChunkDeletionInfo.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/anvil/ChunkDeletionInfo.java
@@ -44,7 +44,7 @@ public class ChunkDeletionInfo {
                 return chunks.size();
             }
             final BlockVector2 dist = maxChunk.subtract(minChunk).add(1, 1);
-            return dist.getBlockX() * dist.getBlockZ();
+            return dist.x() * dist.z();
         }
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/anvil/RegionAccess.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/anvil/RegionAccess.java
@@ -57,8 +57,8 @@ class RegionAccess implements AutoCloseable {
     }
 
     private static int indexChunk(BlockVector2 pos) {
-        int x = pos.getBlockX() & 31;
-        int z = pos.getBlockZ() & 31;
+        int x = pos.x() & 31;
+        int z = pos.z() & 31;
         return x + z * 32;
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/cui/SelectionCylinderEvent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/cui/SelectionCylinderEvent.java
@@ -42,11 +42,11 @@ public class SelectionCylinderEvent implements CUIEvent {
     @Override
     public String[] getParameters() {
         return new String[] {
-            String.valueOf(pos.getBlockX()),
-            String.valueOf(pos.getBlockY()),
-            String.valueOf(pos.getBlockZ()),
-            String.valueOf(radius.getX()),
-            String.valueOf(radius.getZ())
+            String.valueOf(pos.x()),
+            String.valueOf(pos.y()),
+            String.valueOf(pos.z()),
+            String.valueOf(radius.x()),
+            String.valueOf(radius.z())
         };
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/cui/SelectionEllipsoidPointEvent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/cui/SelectionEllipsoidPointEvent.java
@@ -40,9 +40,9 @@ public class SelectionEllipsoidPointEvent implements CUIEvent {
     public String[] getParameters() {
         return new String[] {
             String.valueOf(id),
-            String.valueOf(pos.getBlockX()),
-            String.valueOf(pos.getBlockY()),
-            String.valueOf(pos.getBlockZ())
+            String.valueOf(pos.x()),
+            String.valueOf(pos.y()),
+            String.valueOf(pos.z())
         };
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/cui/SelectionPoint2DEvent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/cui/SelectionPoint2DEvent.java
@@ -32,30 +32,30 @@ public class SelectionPoint2DEvent implements CUIEvent {
     @Deprecated
     public SelectionPoint2DEvent(int id, BlockVector2 pos, int area) {
         this.id = id;
-        this.blockX = pos.getX();
-        this.blockZ = pos.getZ();
+        this.blockX = pos.x();
+        this.blockZ = pos.z();
         this.area = area;
     }
 
     @Deprecated
     public SelectionPoint2DEvent(int id, BlockVector3 pos, int area) {
         this.id = id;
-        this.blockX = pos.getX();
-        this.blockZ = pos.getZ();
+        this.blockX = pos.x();
+        this.blockZ = pos.z();
         this.area = area;
     }
 
     public SelectionPoint2DEvent(int id, BlockVector2 pos, long area) {
         this.id = id;
-        this.blockX = pos.getX();
-        this.blockZ = pos.getZ();
+        this.blockX = pos.x();
+        this.blockZ = pos.z();
         this.area = area;
     }
 
     public SelectionPoint2DEvent(int id, BlockVector3 pos, long area) {
         this.id = id;
-        this.blockX = pos.getX();
-        this.blockZ = pos.getZ();
+        this.blockX = pos.x();
+        this.blockZ = pos.z();
         this.area = area;
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/cui/SelectionPointEvent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/cui/SelectionPointEvent.java
@@ -49,9 +49,9 @@ public class SelectionPointEvent implements CUIEvent {
     public String[] getParameters() {
         return new String[] {
             String.valueOf(id),
-            String.valueOf(pos.getBlockX()),
-            String.valueOf(pos.getBlockY()),
-            String.valueOf(pos.getBlockZ()),
+            String.valueOf(pos.x()),
+            String.valueOf(pos.y()),
+            String.valueOf(pos.z()),
             String.valueOf(area)
         };
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/cui/ServerCUIHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/cui/ServerCUIHandler.java
@@ -79,9 +79,9 @@ public class ServerCUIHandler {
                 try {
                     CuboidRegion region = ((CuboidRegionSelector) regionSelector).getRegion();
 
-                    posX = region.getMinimumPoint().getBlockX();
-                    posY = region.getMinimumPoint().getBlockY();
-                    posZ = region.getMinimumPoint().getBlockZ();
+                    posX = region.getMinimumPoint().x();
+                    posY = region.getMinimumPoint().y();
+                    posZ = region.getMinimumPoint().z();
 
                     width = region.getWidth();
                     height = region.getHeight();
@@ -104,9 +104,9 @@ public class ServerCUIHandler {
                 }
 
                 // Just select the point.
-                posX = point.getBlockX();
-                posY = point.getBlockY();
-                posZ = point.getBlockZ();
+                posX = point.x();
+                posY = point.y();
+                posZ = point.z();
                 width = 1;
                 height = 1;
                 length = 1;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/ClipboardTransformBaker.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/ClipboardTransformBaker.java
@@ -79,12 +79,12 @@ public class ClipboardTransformBaker {
         Vector3[] corners = new Vector3[] {
             minimum,
             maximum,
-            minimum.withX(maximum.getX()),
-            minimum.withY(maximum.getY()),
-            minimum.withZ(maximum.getZ()),
-            maximum.withX(minimum.getX()),
-            maximum.withY(minimum.getY()),
-            maximum.withZ(minimum.getZ())
+            minimum.withX(maximum.x()),
+            minimum.withY(maximum.y()),
+            minimum.withZ(maximum.z()),
+            maximum.withX(minimum.x()),
+            maximum.withY(minimum.y()),
+            maximum.withZ(minimum.z())
         };
 
         for (int i = 0; i < corners.length; i++) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/RegionOptimizedVectorSorter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/RegionOptimizedVectorSorter.java
@@ -62,13 +62,13 @@ public class RegionOptimizedVectorSorter {
     private static final long FLIP_REGION_Z_SIGN = 0x1_00_00L << REGION_Z_SHIFT;
 
     private static long key(BlockVector3 elem) {
-        long x = elem.getX();
-        long z = elem.getZ();
+        long x = elem.x();
+        long z = elem.z();
         return (((x << (REGION_X_SHIFT - 9)) & REGION_X_MASK) ^ FLIP_REGION_X_SIGN)
             | (((z << (REGION_Z_SHIFT - 9)) & REGION_Z_MASK) ^ FLIP_REGION_Z_SIGN)
             | ((x << (CHUNK_X_SHIFT - 4)) & CHUNK_X_MASK)
             | ((z << (CHUNK_Z_SHIFT - 4)) & CHUNK_Z_MASK)
-            | (Y_MAX - elem.getY());
+            | (Y_MAX - elem.y());
     }
 
     private static final int NUMBER_OF_BITS = 64;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/wna/WorldNativeAccess.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/wna/WorldNativeAccess.java
@@ -46,9 +46,9 @@ public interface WorldNativeAccess<NC, NBS, NP> {
         checkNotNull(block);
         setCurrentSideEffectSet(sideEffects);
 
-        int x = position.getBlockX();
-        int y = position.getBlockY();
-        int z = position.getBlockZ();
+        int x = position.x();
+        int y = position.y();
+        int z = position.z();
 
         // First set the block
         NC chunk = getChunk(x >> 4, z >> 4);
@@ -68,9 +68,9 @@ public interface WorldNativeAccess<NC, NBS, NP> {
                 LinCompoundTag tag = baseBlock.getNbt();
                 if (tag != null) {
                     LinCompoundTag.Builder tagBuilder = tag.toBuilder()
-                        .putInt("x", position.getX())
-                        .putInt("y", position.getY())
-                        .putInt("z", position.getZ());
+                        .putInt("x", position.x())
+                        .putInt("y", position.y())
+                        .putInt("z", position.z());
                     if (!baseBlock.getNbtId().isBlank()) {
                         tagBuilder.putString("id", baseBlock.getNbtId());
                     }
@@ -94,8 +94,8 @@ public interface WorldNativeAccess<NC, NBS, NP> {
 
     default void applySideEffects(BlockVector3 position, BlockState previousType, SideEffectSet sideEffectSet) {
         setCurrentSideEffectSet(sideEffectSet);
-        NP pos = getPosition(position.getX(), position.getY(), position.getZ());
-        NC chunk = getChunk(position.getX() >> 4, position.getZ() >> 4);
+        NP pos = getPosition(position.x(), position.y(), position.z());
+        NC chunk = getChunk(position.x() >> 4, position.z() >> 4);
         NBS oldData = toNative(previousType);
         NBS newData = getBlockState(chunk, pos);
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector2.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector2.java
@@ -50,7 +50,7 @@ public record BlockVector2(int x, int z) {
      * </pre>
      */
     public static final Comparator<BlockVector2> COMPARING_GRID_ARRANGEMENT =
-        Comparator.comparingInt(BlockVector2::getZ).thenComparingInt(BlockVector2::getX);
+        Comparator.comparingInt(BlockVector2::z).thenComparingInt(BlockVector2::x);
 
     public static BlockVector2 at(double x, double z) {
         return at((int) Math.floor(x), (int) Math.floor(z));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector3.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector3.java
@@ -76,9 +76,9 @@ public record BlockVector3(int x, int y, int z) {
     }
 
     public static boolean isLongPackable(BlockVector3 location) {
-        return isHorizontallyInBounds(location.getX())
-            && isHorizontallyInBounds(location.getZ())
-            && WORLD_Y_MIN <= location.getY() && location.getY() <= WORLD_Y_MAX;
+        return isHorizontallyInBounds(location.x)
+            && isHorizontallyInBounds(location.z)
+            && WORLD_Y_MIN <= location.y && location.y <= WORLD_Y_MAX;
     }
 
     public static void checkLongPackable(BlockVector3 location) {
@@ -96,9 +96,9 @@ public record BlockVector3(int x, int y, int z) {
     // thread-safe initialization idiom
     private static final class YzxOrderComparator {
         private static final Comparator<BlockVector3> YZX_ORDER =
-            Comparator.comparingInt(BlockVector3::getY)
-                .thenComparingInt(BlockVector3::getZ)
-                .thenComparingInt(BlockVector3::getX);
+            Comparator.comparingInt(BlockVector3::y)
+                .thenComparingInt(BlockVector3::z)
+                .thenComparingInt(BlockVector3::x);
     }
 
     /**
@@ -612,16 +612,16 @@ public record BlockVector3(int x, int y, int z) {
      * @return pitch in radians
      */
     public double toPitch() {
-        double x = getX();
-        double z = getZ();
+        double x = this.x;
+        double z = this.z;
 
         if (x == 0 && z == 0) {
-            return getY() > 0 ? -90 : 90;
+            return y > 0 ? -90 : 90;
         } else {
             double x2 = x * x;
             double z2 = z * z;
             double xz = Math.sqrt(x2 + z2);
-            return Math.toDegrees(Math.atan(-getY() / xz));
+            return Math.toDegrees(Math.atan(-y / xz));
         }
     }
 
@@ -631,8 +631,8 @@ public record BlockVector3(int x, int y, int z) {
      * @return yaw in radians
      */
     public double toYaw() {
-        double x = getX();
-        double z = getZ();
+        double x = this.x;
+        double z = this.z;
 
         double t = Math.atan2(-x, z);
         double tau = 2 * Math.PI;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/Vector3.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/Vector3.java
@@ -518,16 +518,16 @@ public record Vector3(double x, double y, double z) {
      * @return pitch in radians
      */
     public double toPitch() {
-        double x = getX();
-        double z = getZ();
+        double x = this.x;
+        double z = this.z;
 
         if (x == 0 && z == 0) {
-            return getY() > 0 ? -90 : 90;
+            return y > 0 ? -90 : 90;
         } else {
             double x2 = x * x;
             double z2 = z * z;
             double xz = Math.sqrt(x2 + z2);
-            return Math.toDegrees(Math.atan(-getY() / xz));
+            return Math.toDegrees(Math.atan(-y / xz));
         }
     }
 
@@ -537,8 +537,8 @@ public record Vector3(double x, double y, double z) {
      * @return yaw in radians
      */
     public double toYaw() {
-        double x = getX();
-        double z = getZ();
+        double x = this.x;
+        double z = this.z;
 
         double t = Math.atan2(-x, z);
         double tau = 2 * Math.PI;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/convolution/HeightMap.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/convolution/HeightMap.java
@@ -62,10 +62,10 @@ public class HeightMap {
         this.width = region.getWidth();
         this.height = region.getLength();
 
-        int minX = region.getMinimumPoint().getBlockX();
-        int minY = region.getMinimumPoint().getBlockY();
-        int minZ = region.getMinimumPoint().getBlockZ();
-        int maxY = region.getMaximumPoint().getBlockY();
+        int minX = region.getMinimumPoint().x();
+        int minY = region.getMinimumPoint().y();
+        int minZ = region.getMinimumPoint().z();
+        int maxY = region.getMaximumPoint().y();
 
         // Store current heightmap data
         data = new int[width * height];
@@ -108,11 +108,11 @@ public class HeightMap {
         checkNotNull(data);
 
         BlockVector3 minY = region.getMinimumPoint();
-        int originX = minY.getBlockX();
-        int originY = minY.getBlockY();
-        int originZ = minY.getBlockZ();
+        int originX = minY.x();
+        int originY = minY.y();
+        int originZ = minY.z();
 
-        int maxY = region.getMaximumPoint().getBlockY();
+        int maxY = region.getMaximumPoint().y();
         BlockState fillerAir = BlockTypes.AIR.getDefaultState();
 
         int blocksChanged = 0;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/convolution/SnowHeightMap.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/convolution/SnowHeightMap.java
@@ -67,10 +67,10 @@ public class SnowHeightMap {
 
         this.layers = BlockTypes.SNOW.getProperty("layers");
 
-        int minX = region.getMinimumPoint().getBlockX();
-        int minY = region.getMinimumPoint().getBlockY();
-        int minZ = region.getMinimumPoint().getBlockZ();
-        int maxY = region.getMaximumPoint().getBlockY();
+        int minX = region.getMinimumPoint().x();
+        int minY = region.getMinimumPoint().y();
+        int minZ = region.getMinimumPoint().z();
+        int maxY = region.getMaximumPoint().y();
 
         // Store current heightmap data
         data = new float[width * height];
@@ -127,11 +127,11 @@ public class SnowHeightMap {
         checkNotNull(data);
 
         BlockVector3 minY = region.getMinimumPoint();
-        int originX = minY.getBlockX();
-        int originY = minY.getBlockY();
-        int originZ = minY.getBlockZ();
+        int originX = minY.x();
+        int originY = minY.y();
+        int originZ = minY.z();
 
-        int maxY = region.getMaximumPoint().getBlockY();
+        int maxY = region.getMaximumPoint().y();
 
         BlockState fillerAir = BlockTypes.AIR.getDefaultState();
         BlockState fillerSnow = BlockTypes.SNOW_BLOCK.getDefaultState();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/noise/JLibNoiseGenerator.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/noise/JLibNoiseGenerator.java
@@ -47,12 +47,12 @@ abstract class JLibNoiseGenerator<V extends Module> implements NoiseGenerator {
 
     @Override
     public float noise(Vector2 position) {
-        return forceRange(module.GetValue(position.getX(), 0, position.getZ()));
+        return forceRange(module.GetValue(position.x(), 0, position.z()));
     }
 
     @Override
     public float noise(Vector3 position) {
-        return forceRange(module.GetValue(position.getX(), position.getY(), position.getZ()));
+        return forceRange(module.GetValue(position.x(), position.y(), position.z()));
     }
 
     private float forceRange(double value) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/transform/AffineTransform.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/transform/AffineTransform.java
@@ -213,11 +213,11 @@ public record AffineTransform(
     }
 
     public AffineTransform translate(Vector3 vec) {
-        return translate(vec.getX(), vec.getY(), vec.getZ());
+        return translate(vec.x(), vec.y(), vec.z());
     }
 
     public AffineTransform translate(BlockVector3 vec) {
-        return translate(vec.getX(), vec.getY(), vec.getZ());
+        return translate(vec.x(), vec.y(), vec.z());
     }
 
     public AffineTransform translate(double x, double y, double z) {
@@ -263,15 +263,15 @@ public record AffineTransform(
     }
 
     public AffineTransform scale(Vector3 vec) {
-        return scale(vec.getX(), vec.getY(), vec.getZ());
+        return scale(vec.x(), vec.y(), vec.z());
     }
 
     @Override
     public Vector3 apply(Vector3 vector) {
         return Vector3.at(
-                vector.getX() * m00 + vector.getY() * m01 + vector.getZ() * m02 + m03,
-                vector.getX() * m10 + vector.getY() * m11 + vector.getZ() * m12 + m13,
-                vector.getX() * m20 + vector.getY() * m21 + vector.getZ() * m22 + m23);
+                vector.x() * m00 + vector.y() * m01 + vector.z() * m02 + m03,
+                vector.x() * m10 + vector.y() * m11 + vector.z() * m12 + m13,
+                vector.x() * m20 + vector.y() * m21 + vector.z() * m22 + m23);
     }
 
     public AffineTransform combine(AffineTransform other) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/AbstractFlatRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/AbstractFlatRegion.java
@@ -29,12 +29,12 @@ public abstract class AbstractFlatRegion extends AbstractRegion implements FlatR
 
     @Override
     public int getMinimumY() {
-        return getMinimumPoint().getBlockY();
+        return getMinimumPoint().y();
     }
 
     @Override
     public int getMaximumY() {
-        return getMaximumPoint().getBlockY();
+        return getMaximumPoint().y();
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/AbstractRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/AbstractRegion.java
@@ -91,10 +91,10 @@ public abstract class AbstractRegion implements Region {
 
         final List<BlockVector2> points = new ArrayList<>(4);
 
-        points.add(BlockVector2.at(min.getX(), min.getZ()));
-        points.add(BlockVector2.at(min.getX(), max.getZ()));
-        points.add(BlockVector2.at(max.getX(), max.getZ()));
-        points.add(BlockVector2.at(max.getX(), min.getZ()));
+        points.add(BlockVector2.at(min.x(), min.z()));
+        points.add(BlockVector2.at(min.x(), max.z()));
+        points.add(BlockVector2.at(max.x(), max.z()));
+        points.add(BlockVector2.at(max.x(), min.z()));
 
         return points;
     }
@@ -104,9 +104,9 @@ public abstract class AbstractRegion implements Region {
         BlockVector3 min = getMinimumPoint();
         BlockVector3 max = getMaximumPoint();
 
-        return (max.getX() - min.getX() + 1L)
-            * (max.getY() - min.getY() + 1L)
-            * (max.getZ() - min.getZ() + 1L);
+        return (max.x() - min.x() + 1L)
+            * (max.y() - min.y() + 1L)
+            * (max.z() - min.z() + 1L);
     }
 
     /**
@@ -119,7 +119,7 @@ public abstract class AbstractRegion implements Region {
         BlockVector3 min = getMinimumPoint();
         BlockVector3 max = getMaximumPoint();
 
-        return max.getX() - min.getX() + 1;
+        return max.x() - min.x() + 1;
     }
 
     /**
@@ -132,7 +132,7 @@ public abstract class AbstractRegion implements Region {
         BlockVector3 min = getMinimumPoint();
         BlockVector3 max = getMaximumPoint();
 
-        return max.getY() - min.getY() + 1;
+        return max.y() - min.y() + 1;
     }
 
     /**
@@ -145,7 +145,7 @@ public abstract class AbstractRegion implements Region {
         BlockVector3 min = getMinimumPoint();
         BlockVector3 max = getMaximumPoint();
 
-        return max.getZ() - min.getZ() + 1;
+        return max.z() - min.z() + 1;
     }
 
     /**
@@ -160,10 +160,10 @@ public abstract class AbstractRegion implements Region {
         final BlockVector3 min = getMinimumPoint();
         final BlockVector3 max = getMaximumPoint();
 
-        final int minY = min.getBlockY();
+        final int minY = min.y();
 
-        for (int x = min.getBlockX(); x <= max.getBlockX(); ++x) {
-            for (int z = min.getBlockZ(); z <= max.getBlockZ(); ++z) {
+        for (int x = min.x(); x <= max.x(); ++x) {
+            for (int z = min.z(); z <= max.z(); ++z) {
                 if (!contains(BlockVector3.at(x, minY, z))) {
                     continue;
                 }
@@ -185,9 +185,9 @@ public abstract class AbstractRegion implements Region {
         final BlockVector3 min = getMinimumPoint();
         final BlockVector3 max = getMaximumPoint();
 
-        for (int x = min.getBlockX(); x <= max.getBlockX(); ++x) {
-            for (int y = min.getBlockY(); y <= max.getBlockY(); ++y) {
-                for (int z = min.getBlockZ(); z <= max.getBlockZ(); ++z) {
+        for (int x = min.x(); x <= max.x(); ++x) {
+            for (int y = min.y(); y <= max.y(); ++y) {
+                for (int z = min.z(); z <= max.z(); ++z) {
                     if (!contains(BlockVector3.at(x, y, z))) {
                         continue;
                     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CuboidRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CuboidRegion.java
@@ -121,16 +121,16 @@ public class CuboidRegion extends AbstractRegion implements FlatRegion {
 
         return new RegionIntersection(
                 // Project to Z-Y plane
-                new CuboidRegion(pos1.withX(min.getX()), pos2.withX(min.getX())),
-                new CuboidRegion(pos1.withX(max.getX()), pos2.withX(max.getX())),
+                new CuboidRegion(pos1.withX(min.x()), pos2.withX(min.x())),
+                new CuboidRegion(pos1.withX(max.x()), pos2.withX(max.x())),
 
                 // Project to X-Y plane
-                new CuboidRegion(pos1.withZ(min.getZ()), pos2.withZ(min.getZ())),
-                new CuboidRegion(pos1.withZ(max.getZ()), pos2.withZ(max.getZ())),
+                new CuboidRegion(pos1.withZ(min.z()), pos2.withZ(min.z())),
+                new CuboidRegion(pos1.withZ(max.z()), pos2.withZ(max.z())),
 
                 // Project to the X-Z plane
-                new CuboidRegion(pos1.withY(min.getY()), pos2.withY(min.getY())),
-                new CuboidRegion(pos1.withY(max.getY()), pos2.withY(max.getY())));
+                new CuboidRegion(pos1.withY(min.y()), pos2.withY(min.y())),
+                new CuboidRegion(pos1.withY(max.y()), pos2.withY(max.y())));
     }
 
     /**
@@ -145,12 +145,12 @@ public class CuboidRegion extends AbstractRegion implements FlatRegion {
 
         return new RegionIntersection(
                 // Project to Z-Y plane
-                new CuboidRegion(pos1.withX(min.getX()), pos2.withX(min.getX())),
-                new CuboidRegion(pos1.withX(max.getX()), pos2.withX(max.getX())),
+                new CuboidRegion(pos1.withX(min.x()), pos2.withX(min.x())),
+                new CuboidRegion(pos1.withX(max.x()), pos2.withX(max.x())),
 
                 // Project to X-Y plane
-                new CuboidRegion(pos1.withZ(min.getZ()), pos2.withZ(min.getZ())),
-                new CuboidRegion(pos1.withZ(max.getZ()), pos2.withZ(max.getZ())));
+                new CuboidRegion(pos1.withZ(min.z()), pos2.withZ(min.z())),
+                new CuboidRegion(pos1.withZ(max.z()), pos2.withZ(max.z())));
     }
 
     @Override
@@ -170,12 +170,12 @@ public class CuboidRegion extends AbstractRegion implements FlatRegion {
 
     @Override
     public int getMinimumY() {
-        return Math.min(pos1.getBlockY(), pos2.getBlockY());
+        return Math.min(pos1.y(), pos2.y());
     }
 
     @Override
     public int getMaximumY() {
-        return Math.max(pos1.getBlockY(), pos2.getBlockY());
+        return Math.max(pos1.y(), pos2.y());
     }
 
     @Override
@@ -183,45 +183,45 @@ public class CuboidRegion extends AbstractRegion implements FlatRegion {
         checkNotNull(changes);
 
         for (BlockVector3 change : changes) {
-            if (change.getX() > 0) {
-                if (Math.max(pos1.getX(), pos2.getX()) == pos1.getX()) {
-                    pos1 = pos1.add(change.getX(), 0, 0);
+            if (change.x() > 0) {
+                if (Math.max(pos1.x(), pos2.x()) == pos1.x()) {
+                    pos1 = pos1.add(change.x(), 0, 0);
                 } else {
-                    pos2 = pos2.add(change.getX(), 0, 0);
+                    pos2 = pos2.add(change.x(), 0, 0);
                 }
             } else {
-                if (Math.min(pos1.getX(), pos2.getX()) == pos1.getX()) {
-                    pos1 = pos1.add(change.getX(), 0, 0);
+                if (Math.min(pos1.x(), pos2.x()) == pos1.x()) {
+                    pos1 = pos1.add(change.x(), 0, 0);
                 } else {
-                    pos2 = pos2.add(change.getX(), 0, 0);
+                    pos2 = pos2.add(change.x(), 0, 0);
                 }
             }
 
-            if (change.getY() > 0) {
-                if (Math.max(pos1.getY(), pos2.getY()) == pos1.getY()) {
-                    pos1 = pos1.add(0, change.getY(), 0);
+            if (change.y() > 0) {
+                if (Math.max(pos1.y(), pos2.y()) == pos1.y()) {
+                    pos1 = pos1.add(0, change.y(), 0);
                 } else {
-                    pos2 = pos2.add(0, change.getY(), 0);
+                    pos2 = pos2.add(0, change.y(), 0);
                 }
             } else {
-                if (Math.min(pos1.getY(), pos2.getY()) == pos1.getY()) {
-                    pos1 = pos1.add(0, change.getY(), 0);
+                if (Math.min(pos1.y(), pos2.y()) == pos1.y()) {
+                    pos1 = pos1.add(0, change.y(), 0);
                 } else {
-                    pos2 = pos2.add(0, change.getY(), 0);
+                    pos2 = pos2.add(0, change.y(), 0);
                 }
             }
 
-            if (change.getZ() > 0) {
-                if (Math.max(pos1.getZ(), pos2.getZ()) == pos1.getZ()) {
-                    pos1 = pos1.add(0, 0, change.getZ());
+            if (change.z() > 0) {
+                if (Math.max(pos1.z(), pos2.z()) == pos1.z()) {
+                    pos1 = pos1.add(0, 0, change.z());
                 } else {
-                    pos2 = pos2.add(0, 0, change.getZ());
+                    pos2 = pos2.add(0, 0, change.z());
                 }
             } else {
-                if (Math.min(pos1.getZ(), pos2.getZ()) == pos1.getZ()) {
-                    pos1 = pos1.add(0, 0, change.getZ());
+                if (Math.min(pos1.z(), pos2.z()) == pos1.z()) {
+                    pos1 = pos1.add(0, 0, change.z());
                 } else {
-                    pos2 = pos2.add(0, 0, change.getZ());
+                    pos2 = pos2.add(0, 0, change.z());
                 }
             }
         }
@@ -234,45 +234,45 @@ public class CuboidRegion extends AbstractRegion implements FlatRegion {
         checkNotNull(changes);
 
         for (BlockVector3 change : changes) {
-            if (change.getX() < 0) {
-                if (Math.max(pos1.getX(), pos2.getX()) == pos1.getX()) {
-                    pos1 = pos1.add(change.getX(), 0, 0);
+            if (change.x() < 0) {
+                if (Math.max(pos1.x(), pos2.x()) == pos1.x()) {
+                    pos1 = pos1.add(change.x(), 0, 0);
                 } else {
-                    pos2 = pos2.add(change.getX(), 0, 0);
+                    pos2 = pos2.add(change.x(), 0, 0);
                 }
             } else {
-                if (Math.min(pos1.getX(), pos2.getX()) == pos1.getX()) {
-                    pos1 = pos1.add(change.getX(), 0, 0);
+                if (Math.min(pos1.x(), pos2.x()) == pos1.x()) {
+                    pos1 = pos1.add(change.x(), 0, 0);
                 } else {
-                    pos2 = pos2.add(change.getX(), 0, 0);
+                    pos2 = pos2.add(change.x(), 0, 0);
                 }
             }
 
-            if (change.getY() < 0) {
-                if (Math.max(pos1.getY(), pos2.getY()) == pos1.getY()) {
-                    pos1 = pos1.add(0, change.getY(), 0);
+            if (change.y() < 0) {
+                if (Math.max(pos1.y(), pos2.y()) == pos1.y()) {
+                    pos1 = pos1.add(0, change.y(), 0);
                 } else {
-                    pos2 = pos2.add(0, change.getY(), 0);
+                    pos2 = pos2.add(0, change.y(), 0);
                 }
             } else {
-                if (Math.min(pos1.getY(), pos2.getY()) == pos1.getY()) {
-                    pos1 = pos1.add(0, change.getY(), 0);
+                if (Math.min(pos1.y(), pos2.y()) == pos1.y()) {
+                    pos1 = pos1.add(0, change.y(), 0);
                 } else {
-                    pos2 = pos2.add(0, change.getY(), 0);
+                    pos2 = pos2.add(0, change.y(), 0);
                 }
             }
 
-            if (change.getZ() < 0) {
-                if (Math.max(pos1.getZ(), pos2.getZ()) == pos1.getZ()) {
-                    pos1 = pos1.add(0, 0, change.getZ());
+            if (change.z() < 0) {
+                if (Math.max(pos1.z(), pos2.z()) == pos1.z()) {
+                    pos1 = pos1.add(0, 0, change.z());
                 } else {
-                    pos2 = pos2.add(0, 0, change.getZ());
+                    pos2 = pos2.add(0, 0, change.z());
                 }
             } else {
-                if (Math.min(pos1.getZ(), pos2.getZ()) == pos1.getZ()) {
-                    pos1 = pos1.add(0, 0, change.getZ());
+                if (Math.min(pos1.z(), pos2.z()) == pos1.z()) {
+                    pos1 = pos1.add(0, 0, change.z());
                 } else {
-                    pos2 = pos2.add(0, 0, change.getZ());
+                    pos2 = pos2.add(0, 0, change.z());
                 }
             }
         }
@@ -295,8 +295,8 @@ public class CuboidRegion extends AbstractRegion implements FlatRegion {
         BlockVector3 min = getMinimumPoint();
         BlockVector3 max = getMaximumPoint();
 
-        for (int x = min.getBlockX() >> ChunkStore.CHUNK_SHIFTS; x <= max.getBlockX() >> ChunkStore.CHUNK_SHIFTS; ++x) {
-            for (int z = min.getBlockZ() >> ChunkStore.CHUNK_SHIFTS; z <= max.getBlockZ() >> ChunkStore.CHUNK_SHIFTS; ++z) {
+        for (int x = min.x() >> ChunkStore.CHUNK_SHIFTS; x <= max.x() >> ChunkStore.CHUNK_SHIFTS; ++x) {
+            for (int z = min.z() >> ChunkStore.CHUNK_SHIFTS; z <= max.z() >> ChunkStore.CHUNK_SHIFTS; ++z) {
                 chunks.add(BlockVector2.at(x, z));
             }
         }
@@ -311,9 +311,9 @@ public class CuboidRegion extends AbstractRegion implements FlatRegion {
         BlockVector3 min = getMinimumPoint();
         BlockVector3 max = getMaximumPoint();
 
-        for (int x = min.getBlockX() >> ChunkStore.CHUNK_SHIFTS; x <= max.getBlockX() >> ChunkStore.CHUNK_SHIFTS; ++x) {
-            for (int z = min.getBlockZ() >> ChunkStore.CHUNK_SHIFTS; z <= max.getBlockZ() >> ChunkStore.CHUNK_SHIFTS; ++z) {
-                for (int y = min.getBlockY() >> ChunkStore.CHUNK_SHIFTS; y <= max.getBlockY() >> ChunkStore.CHUNK_SHIFTS; ++y) {
+        for (int x = min.x() >> ChunkStore.CHUNK_SHIFTS; x <= max.x() >> ChunkStore.CHUNK_SHIFTS; ++x) {
+            for (int z = min.z() >> ChunkStore.CHUNK_SHIFTS; z <= max.z() >> ChunkStore.CHUNK_SHIFTS; ++z) {
+                for (int y = min.y() >> ChunkStore.CHUNK_SHIFTS; y <= max.y() >> ChunkStore.CHUNK_SHIFTS; ++y) {
                     chunks.add(BlockVector3.at(x, y, z));
                 }
             }
@@ -335,9 +335,9 @@ public class CuboidRegion extends AbstractRegion implements FlatRegion {
         return new Iterator<BlockVector3>() {
             private final BlockVector3 min = getMinimumPoint();
             private final BlockVector3 max = getMaximumPoint();
-            private int nextX = min.getBlockX();
-            private int nextY = min.getBlockY();
-            private int nextZ = min.getBlockZ();
+            private int nextX = min.x();
+            private int nextY = min.y();
+            private int nextZ = min.z();
 
             @Override
             public boolean hasNext() {
@@ -350,11 +350,11 @@ public class CuboidRegion extends AbstractRegion implements FlatRegion {
                     throw new NoSuchElementException();
                 }
                 BlockVector3 answer = BlockVector3.at(nextX, nextY, nextZ);
-                if (++nextX > max.getBlockX()) {
-                    nextX = min.getBlockX();
-                    if (++nextZ > max.getBlockZ()) {
-                        nextZ = min.getBlockZ();
-                        if (++nextY > max.getBlockY()) {
+                if (++nextX > max.x()) {
+                    nextX = min.x();
+                    if (++nextZ > max.z()) {
+                        nextZ = min.z();
+                        if (++nextY > max.y()) {
                             nextX = Integer.MIN_VALUE;
                         }
                     }
@@ -369,8 +369,8 @@ public class CuboidRegion extends AbstractRegion implements FlatRegion {
         return () -> new Iterator<BlockVector2>() {
             private final BlockVector3 min = getMinimumPoint();
             private final BlockVector3 max = getMaximumPoint();
-            private int nextX = min.getBlockX();
-            private int nextZ = min.getBlockZ();
+            private int nextX = min.x();
+            private int nextZ = min.z();
 
             @Override
             public boolean hasNext() {
@@ -383,9 +383,9 @@ public class CuboidRegion extends AbstractRegion implements FlatRegion {
                     throw new NoSuchElementException();
                 }
                 BlockVector2 answer = BlockVector2.at(nextX, nextZ);
-                if (++nextX > max.getBlockX()) {
-                    nextX = min.getBlockX();
-                    if (++nextZ > max.getBlockZ()) {
+                if (++nextX > max.x()) {
+                    nextX = min.x();
+                    if (++nextZ > max.z()) {
                         nextX = Integer.MIN_VALUE;
                     }
                 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CylinderRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CylinderRegion.java
@@ -190,8 +190,8 @@ public class CylinderRegion extends AbstractRegion implements FlatRegion {
 
     @Override
     public long getVolume() {
-        return BigDecimal.valueOf(radius.getX())
-                .multiply(BigDecimal.valueOf(radius.getZ()))
+        return BigDecimal.valueOf(radius.x())
+                .multiply(BigDecimal.valueOf(radius.z()))
                 .multiply(PI)
                 .multiply(BigDecimal.valueOf(getHeight()))
                 .setScale(0, RoundingMode.FLOOR)
@@ -200,7 +200,7 @@ public class CylinderRegion extends AbstractRegion implements FlatRegion {
 
     @Override
     public int getWidth() {
-        return (int) (2 * radius.getX());
+        return (int) (2 * radius.x());
     }
 
     @Override
@@ -210,7 +210,7 @@ public class CylinderRegion extends AbstractRegion implements FlatRegion {
 
     @Override
     public int getLength() {
-        return (int) (2 * radius.getZ());
+        return (int) (2 * radius.z());
     }
 
     private BlockVector2 calculateDiff2D(BlockVector3... changes) throws RegionOperationException {
@@ -219,7 +219,7 @@ public class CylinderRegion extends AbstractRegion implements FlatRegion {
             diff = diff.add(change.toBlockVector2());
         }
 
-        if ((diff.getBlockX() & 1) + (diff.getBlockZ() & 1) != 0) {
+        if ((diff.x() & 1) + (diff.z() & 1) != 0) {
             throw new RegionOperationException(TranslatableComponent.of("worldedit.selection.cylinder.error.even-horizontal"));
         }
 
@@ -240,7 +240,7 @@ public class CylinderRegion extends AbstractRegion implements FlatRegion {
         center = center.add(calculateDiff2D(changes));
         radius = radius.add(calculateChanges2D(changes).toVector2());
         for (BlockVector3 change : changes) {
-            int changeY = change.getBlockY();
+            int changeY = change.y();
             if (changeY > 0) {
                 maxY += changeY;
             } else {
@@ -256,7 +256,7 @@ public class CylinderRegion extends AbstractRegion implements FlatRegion {
         radius = Vector2.at(1.5, 1.5).getMaximum(newRadius);
         for (BlockVector3 change : changes) {
             int height = maxY - minY;
-            int changeY = change.getBlockY();
+            int changeY = change.y();
             if (changeY > 0) {
                 minY += Math.min(height, changeY);
             } else {
@@ -269,7 +269,7 @@ public class CylinderRegion extends AbstractRegion implements FlatRegion {
     public void shift(BlockVector3 change) throws RegionOperationException {
         center = center.add(change.toBlockVector2());
 
-        int changeY = change.getBlockY();
+        int changeY = change.y();
         maxY += changeY;
         minY += changeY;
     }
@@ -279,7 +279,7 @@ public class CylinderRegion extends AbstractRegion implements FlatRegion {
      */
     @Override
     public boolean contains(BlockVector3 position) {
-        final int blockY = position.getBlockY();
+        final int blockY = position.y();
         if (blockY < minY || blockY > maxY) {
             return false;
         }
@@ -350,8 +350,8 @@ public class CylinderRegion extends AbstractRegion implements FlatRegion {
         checkNotNull(extent);
         checkNotNull(center);
         Vector2 radiusVec = Vector2.at(radius, radius);
-        int minY = extent.getMinimumPoint().getBlockY();
-        int maxY = extent.getMaximumPoint().getBlockY();
+        int minY = extent.getMinimumPoint().y();
+        int maxY = extent.getMaximumPoint().y();
         return new CylinderRegion(center, radiusVec, minY, maxY);
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/EllipsoidRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/EllipsoidRegion.java
@@ -88,32 +88,32 @@ public class EllipsoidRegion extends AbstractRegion {
     @Override
     public long getVolume() {
         return ELLIPSOID_BASE_MULTIPLIER
-                .multiply(BigDecimal.valueOf(radius.getX()))
-                .multiply(BigDecimal.valueOf(radius.getY()))
-                .multiply(BigDecimal.valueOf(radius.getZ()))
+                .multiply(BigDecimal.valueOf(radius.x()))
+                .multiply(BigDecimal.valueOf(radius.y()))
+                .multiply(BigDecimal.valueOf(radius.z()))
                 .setScale(0, RoundingMode.FLOOR)
                 .longValue();
     }
 
     @Override
     public int getWidth() {
-        return (int) (2 * radius.getX());
+        return (int) (2 * radius.x());
     }
 
     @Override
     public int getHeight() {
-        return (int) (2 * radius.getY());
+        return (int) (2 * radius.y());
     }
 
     @Override
     public int getLength() {
-        return (int) (2 * radius.getZ());
+        return (int) (2 * radius.z());
     }
 
     private BlockVector3 calculateDiff(BlockVector3... changes) throws RegionOperationException {
         BlockVector3 diff = BlockVector3.ZERO.add(changes);
 
-        if ((diff.getBlockX() & 1) + (diff.getBlockY() & 1) + (diff.getBlockZ() & 1) != 0) {
+        if ((diff.x() & 1) + (diff.y() & 1) + (diff.z() & 1) != 0) {
             throw new RegionOperationException(TranslatableComponent.of("worldedit.selection.ellipsoid.error.even-horizontal"));
         }
 
@@ -190,10 +190,10 @@ public class EllipsoidRegion extends AbstractRegion {
 
         final BlockVector3 min = getMinimumPoint();
         final BlockVector3 max = getMaximumPoint();
-        final int centerY = center.getBlockY();
+        final int centerY = center.y();
 
-        for (int x = min.getBlockX(); x <= max.getBlockX(); ++x) {
-            for (int z = min.getBlockZ(); z <= max.getBlockZ(); ++z) {
+        for (int x = min.x(); x <= max.x(); ++x) {
+            for (int z = min.z(); z <= max.z(); ++z) {
                 if (!contains(BlockVector3.at(x, centerY, z))) {
                     continue;
                 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegion.java
@@ -111,14 +111,14 @@ public class Polygonal2DRegion extends AbstractRegion implements FlatRegion {
             return;
         }
 
-        int minX = points.get(0).getBlockX();
-        int minZ = points.get(0).getBlockZ();
-        int maxX = points.get(0).getBlockX();
-        int maxZ = points.get(0).getBlockZ();
+        int minX = points.get(0).x();
+        int minZ = points.get(0).z();
+        int maxX = points.get(0).x();
+        int maxZ = points.get(0).z();
 
         for (BlockVector2 v : points) {
-            int x = v.getBlockX();
-            int z = v.getBlockZ();
+            int x = v.x();
+            int z = v.z();
             if (x < minX) {
                 minX = x;
             }
@@ -161,7 +161,7 @@ public class Polygonal2DRegion extends AbstractRegion implements FlatRegion {
      * @param position the position
      */
     public void addPoint(BlockVector3 position) {
-        points.add(BlockVector2.at(position.getBlockX(), position.getBlockZ()));
+        points.add(BlockVector2.at(position.x(), position.z()));
         recalculate();
     }
 
@@ -214,8 +214,8 @@ public class Polygonal2DRegion extends AbstractRegion implements FlatRegion {
         int j = points.size() - 1;
 
         for (i = 0; i < points.size(); ++i) {
-            long x = points.get(j).getBlockX() + points.get(i).getBlockX();
-            long z = points.get(j).getBlockZ() - points.get(i).getBlockZ();
+            long x = points.get(j).x() + points.get(i).x();
+            long z = points.get(j).z() - points.get(i).z();
             area += x * z;
             j = i;
         }
@@ -229,7 +229,7 @@ public class Polygonal2DRegion extends AbstractRegion implements FlatRegion {
 
     @Override
     public int getWidth() {
-        return max.getBlockX() - min.getBlockX() + 1;
+        return max.x() - min.x() + 1;
     }
 
     @Override
@@ -239,16 +239,16 @@ public class Polygonal2DRegion extends AbstractRegion implements FlatRegion {
 
     @Override
     public int getLength() {
-        return max.getBlockZ() - min.getBlockZ() + 1;
+        return max.z() - min.z() + 1;
     }
 
     @Override
     public void expand(BlockVector3... changes) throws RegionOperationException {
         for (BlockVector3 change : changes) {
-            if (change.getBlockX() != 0 || change.getBlockZ() != 0) {
+            if (change.x() != 0 || change.z() != 0) {
                 throw new RegionOperationException(TranslatableComponent.of("worldedit.selection.polygon2d.error.expand-only-vertical"));
             }
-            int changeY = change.getBlockY();
+            int changeY = change.y();
             if (changeY > 0) {
                 maxY += changeY;
             } else {
@@ -261,10 +261,10 @@ public class Polygonal2DRegion extends AbstractRegion implements FlatRegion {
     @Override
     public void contract(BlockVector3... changes) throws RegionOperationException {
         for (BlockVector3 change : changes) {
-            if (change.getBlockX() != 0 || change.getBlockZ() != 0) {
+            if (change.x() != 0 || change.z() != 0) {
                 throw new RegionOperationException(TranslatableComponent.of("worldedit.selection.polygon2d.error.contract-only-vertical"));
             }
-            int changeY = change.getBlockY();
+            int changeY = change.y();
             if (changeY > 0) {
                 minY += changeY;
             } else {
@@ -276,13 +276,13 @@ public class Polygonal2DRegion extends AbstractRegion implements FlatRegion {
 
     @Override
     public void shift(BlockVector3 change) throws RegionOperationException {
-        final double changeX = change.getX();
-        final double changeY = change.getY();
-        final double changeZ = change.getZ();
+        final double changeX = change.x();
+        final double changeY = change.y();
+        final double changeZ = change.z();
 
         for (int i = 0; i < points.size(); ++i) {
             BlockVector2 point = points.get(i);
-            points.set(i, BlockVector2.at(point.getX() + changeX, point.getZ() + changeZ));
+            points.set(i, BlockVector2.at(point.x() + changeX, point.z() + changeZ));
         }
 
         minY += changeY;
@@ -309,9 +309,9 @@ public class Polygonal2DRegion extends AbstractRegion implements FlatRegion {
         if (points.size() < 3) {
             return false;
         }
-        int targetX = pt.getBlockX(); //wide
-        int targetY = pt.getBlockY(); //height
-        int targetZ = pt.getBlockZ(); //depth
+        int targetX = pt.x(); //wide
+        int targetY = pt.y(); //height
+        int targetZ = pt.z(); //depth
 
         if (targetY < minY || targetY > maxY) {
             return false;
@@ -328,12 +328,12 @@ public class Polygonal2DRegion extends AbstractRegion implements FlatRegion {
         long crossproduct;
         int i;
 
-        int xOld = points.get(npoints - 1).getBlockX();
-        int zOld = points.get(npoints - 1).getBlockZ();
+        int xOld = points.get(npoints - 1).x();
+        int zOld = points.get(npoints - 1).z();
 
         for (i = 0; i < npoints; ++i) {
-            xNew = points.get(i).getBlockX();
-            zNew = points.get(i).getBlockZ();
+            xNew = points.get(i).x();
+            zNew = points.get(i).z();
             //Check for corner
             if (xNew == targetX && zNew == targetZ) {
                 return true;
@@ -422,7 +422,7 @@ public class Polygonal2DRegion extends AbstractRegion implements FlatRegion {
         Iterator<BlockVector2> it = pts.iterator();
         while (it.hasNext()) {
             BlockVector2 current = it.next();
-            sb.append("(").append(current.getBlockX()).append(", ").append(current.getBlockZ()).append(")");
+            sb.append("(").append(current.x()).append(", ").append(current.z()).append(")");
             if (it.hasNext()) {
                 sb.append(" - ");
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Regions.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Regions.java
@@ -35,7 +35,7 @@ public final class Regions {
      * @return the Y coordinate
      */
     public static double minimumY(Region region) {
-        return region.getMinimumPoint().getY();
+        return region.getMinimumPoint().y();
     }
 
     /**
@@ -46,7 +46,7 @@ public final class Regions {
      * @return the Y coordinate
      */
     public static double maximumY(Region region) {
-        return region.getMaximumPoint().getY();
+        return region.getMaximumPoint().y();
     }
 
     /**
@@ -57,7 +57,7 @@ public final class Regions {
      * @return the Y coordinate
      */
     public static int minimumBlockY(Region region) {
-        return region.getMinimumPoint().getBlockY();
+        return region.getMinimumPoint().y();
     }
 
     /**
@@ -68,7 +68,7 @@ public final class Regions {
      * @return the Y coordinate
      */
     public static int maximumBlockY(Region region) {
-        return region.getMaximumPoint().getBlockY();
+        return region.getMaximumPoint().y();
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/TransformRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/TransformRegion.java
@@ -119,17 +119,17 @@ public class TransformRegion extends AbstractRegion {
 
     @Override
     public int getWidth() {
-        return getMaximumPoint().subtract(getMinimumPoint()).getBlockX() + 1;
+        return getMaximumPoint().subtract(getMinimumPoint()).x() + 1;
     }
 
     @Override
     public int getHeight() {
-        return getMaximumPoint().subtract(getMinimumPoint()).getBlockY() + 1;
+        return getMaximumPoint().subtract(getMinimumPoint()).y() + 1;
     }
 
     @Override
     public int getLength() {
-        return getMaximumPoint().subtract(getMinimumPoint()).getBlockZ() + 1;
+        return getMaximumPoint().subtract(getMinimumPoint()).z() + 1;
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/factory/CylinderRegionFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/factory/CylinderRegionFactory.java
@@ -34,7 +34,7 @@ public class CylinderRegionFactory implements RegionFactory {
 
     @Override
     public Region createCenteredAt(BlockVector3 position, double size) {
-        return new CylinderRegion(position, Vector2.at(size, size), position.getBlockY() - (int) (height / 2), position.getBlockY() + (int) (height / 2));
+        return new CylinderRegion(position, Vector2.at(size, size), position.y() - (int) (height / 2), position.y() + (int) (height / 2));
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/iterator/FlatRegion3DIterator.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/iterator/FlatRegion3DIterator.java
@@ -68,7 +68,7 @@ public class FlatRegion3DIterator implements Iterator<BlockVector3> {
             throw new NoSuchElementException();
         }
 
-        BlockVector3 current = BlockVector3.at(next2D.getBlockX(), nextY, next2D.getBlockZ());
+        BlockVector3 current = BlockVector3.at(next2D.x(), nextY, next2D.z());
         if (nextY < maxY) {
             nextY++;
         } else if (flatIterator.hasNext()) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/iterator/FlatRegionIterator.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/iterator/FlatRegionIterator.java
@@ -46,15 +46,15 @@ public class FlatRegionIterator implements Iterator<BlockVector2>  {
         BlockVector3 min = region.getMinimumPoint();
         BlockVector3 max = region.getMaximumPoint();
 
-        this.y = min.getBlockY();
+        this.y = min.y();
 
-        this.minX = min.getBlockX();
+        this.minX = min.x();
 
         this.nextX = minX;
-        this.nextZ = min.getBlockZ();
+        this.nextZ = min.z();
 
-        this.maxX = max.getBlockX();
-        this.maxZ = max.getBlockZ();
+        this.maxX = max.x();
+        this.maxZ = max.z();
 
         forward();
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/iterator/RegionIterator.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/iterator/RegionIterator.java
@@ -43,14 +43,14 @@ public class RegionIterator implements Iterator<BlockVector3> {
         this.region = region;
 
         BlockVector3 max = region.getMaximumPoint();
-        this.maxX = max.getBlockX();
-        this.maxY = max.getBlockY();
-        this.maxZ = max.getBlockZ();
+        this.maxX = max.x();
+        this.maxY = max.y();
+        this.maxZ = max.z();
 
         this.min = region.getMinimumPoint();
-        this.nextX = min.getBlockX();
-        this.nextY = min.getBlockY();
-        this.nextZ = min.getBlockZ();
+        this.nextX = min.x();
+        this.nextY = min.y();
+        this.nextZ = min.z();
 
         forward();
     }
@@ -84,12 +84,12 @@ public class RegionIterator implements Iterator<BlockVector3> {
         if (++nextX <= maxX) {
             return;
         }
-        nextX = min.getBlockX();
+        nextX = min.x();
 
         if (++nextY <= maxY) {
             return;
         }
-        nextY = min.getBlockY();
+        nextY = min.y();
 
         if (++nextZ <= maxZ) {
             return;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/ConvexPolyhedralRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/ConvexPolyhedralRegionSelector.java
@@ -92,8 +92,8 @@ public class ConvexPolyhedralRegionSelector implements RegionSelector, CUIRegion
                 return;
             }
 
-            final int minY = oldRegion.getMinimumPoint().getBlockY();
-            final int maxY = oldRegion.getMaximumPoint().getBlockY();
+            final int minY = oldRegion.getMinimumPoint().y();
+            final int maxY = oldRegion.getMaximumPoint().y();
 
             region = new ConvexPolyhedralRegion(oldRegion.getWorld());
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/CylinderRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/CylinderRegionSelector.java
@@ -106,8 +106,8 @@ public class CylinderRegionSelector implements RegionSelector, CUIRegion {
             region.setCenter(center.toBlockVector2());
             region.setRadius(pos2.toBlockVector2().subtract(center.toBlockVector2()).toVector2());
 
-            region.setMaximumY(Math.max(pos1.getBlockY(), pos2.getBlockY()));
-            region.setMinimumY(Math.min(pos1.getBlockY(), pos2.getBlockY()));
+            region.setMaximumY(Math.max(pos1.y(), pos2.y()));
+            region.setMinimumY(Math.min(pos1.y(), pos2.y()));
 
             selectedCenter = true;
             selectedRadius = true;
@@ -155,7 +155,7 @@ public class CylinderRegionSelector implements RegionSelector, CUIRegion {
 
         region = new CylinderRegion(region.getWorld());
         region.setCenter(position.toBlockVector2());
-        region.setY(position.getBlockY());
+        region.setY(position.y());
 
         selectedCenter = true;
         selectedRadius = false;
@@ -173,7 +173,7 @@ public class CylinderRegionSelector implements RegionSelector, CUIRegion {
         final Vector2 minRadius = diff.getMaximum(diff.multiply(-1.0));
         region.extendRadius(minRadius);
 
-        region.setY(position.getBlockY());
+        region.setY(position.y());
 
         selectedRadius = true;
 
@@ -192,8 +192,8 @@ public class CylinderRegionSelector implements RegionSelector, CUIRegion {
         if (selectedCenter) {
             player.printInfo(TranslatableComponent.of(
                     "worldedit.selection.cylinder.explain.secondary",
-                    TextComponent.of(NUMBER_FORMAT.format(region.getRadius().getX())),
-                    TextComponent.of(NUMBER_FORMAT.format(region.getRadius().getZ())),
+                    TextComponent.of(NUMBER_FORMAT.format(region.getRadius().x())),
+                    TextComponent.of(NUMBER_FORMAT.format(region.getRadius().z())),
                     TextComponent.of(region.getVolume())
             ));
         } else {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/ExtendingCuboidRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/ExtendingCuboidRegionSelector.java
@@ -107,13 +107,13 @@ public class ExtendingCuboidRegionSelector extends CuboidRegionSelector {
             return false;
         }
 
-        double x1 = Math.min(position.getX(), position1.getX());
-        double y1 = Math.min(position.getY(), position1.getY());
-        double z1 = Math.min(position.getZ(), position1.getZ());
+        double x1 = Math.min(position.x(), position1.x());
+        double y1 = Math.min(position.y(), position1.y());
+        double z1 = Math.min(position.z(), position1.z());
 
-        double x2 = Math.max(position.getX(), position2.getX());
-        double y2 = Math.max(position.getY(), position2.getY());
-        double z2 = Math.max(position.getZ(), position2.getZ());
+        double x2 = Math.max(position.x(), position2.x());
+        double y2 = Math.max(position.y(), position2.y());
+        double z2 = Math.max(position.z(), position2.z());
 
         final BlockVector3 o1 = position1;
         final BlockVector3 o2 = position2;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/Polygonal2DRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/Polygonal2DRegionSelector.java
@@ -87,8 +87,8 @@ public class Polygonal2DRegionSelector implements RegionSelector, CUIRegion {
                 return;
             }
 
-            final int minY = oldRegion.getMinimumPoint().getBlockY();
-            final int maxY = oldRegion.getMaximumPoint().getBlockY();
+            final int minY = oldRegion.getMinimumPoint().y();
+            final int maxY = oldRegion.getMaximumPoint().y();
 
             List<BlockVector2> points = oldRegion.polygonize(Integer.MAX_VALUE);
 
@@ -109,7 +109,7 @@ public class Polygonal2DRegionSelector implements RegionSelector, CUIRegion {
         checkNotNull(points);
 
         final BlockVector2 pos2D = points.get(0);
-        pos1 = BlockVector3.at(pos2D.getX(), minY, pos2D.getZ());
+        pos1 = BlockVector3.at(pos2D.x(), minY, pos2D.z());
         region = new Polygonal2DRegion(world, points, minY, maxY);
     }
 
@@ -133,7 +133,7 @@ public class Polygonal2DRegionSelector implements RegionSelector, CUIRegion {
         pos1 = position;
         region = new Polygonal2DRegion(region.getWorld());
         region.addPoint(position);
-        region.expandY(position.getBlockY());
+        region.expandY(position.y());
 
         return true;
     }
@@ -144,7 +144,7 @@ public class Polygonal2DRegionSelector implements RegionSelector, CUIRegion {
             final List<BlockVector2> points = region.getPoints();
 
             final BlockVector2 lastPoint = points.get(region.size() - 1);
-            if (lastPoint.getBlockX() == position.getBlockX() && lastPoint.getBlockZ() == position.getBlockZ()) {
+            if (lastPoint.x() == position.x() && lastPoint.z() == position.z()) {
                 return false;
             }
 
@@ -156,7 +156,7 @@ public class Polygonal2DRegionSelector implements RegionSelector, CUIRegion {
         }
 
         region.addPoint(position);
-        region.expandY(position.getBlockY());
+        region.expandY(position.y());
 
         return true;
     }
@@ -219,7 +219,7 @@ public class Polygonal2DRegionSelector implements RegionSelector, CUIRegion {
     @Override
     public void learnChanges() {
         BlockVector2 pt = region.getPoints().get(0);
-        pos1 = BlockVector3.at(pt.getBlockX(), region.getMinimumPoint().getBlockY(), pt.getBlockZ());
+        pos1 = BlockVector3.at(pt.x(), region.getMinimumPoint().y(), pt.z());
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/SphereRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/SphereRegionSelector.java
@@ -61,7 +61,7 @@ public class SphereRegionSelector extends EllipsoidRegionSelector {
         super(oldSelector);
         if (selectedRadius) {
             final Vector3 radius = region.getRadius();
-            final double radiusScalar = Math.max(Math.max(radius.getX(), radius.getY()), radius.getZ());
+            final double radiusScalar = Math.max(Math.max(radius.x(), radius.y()), radius.z());
             region.setRadius(Vector3.at(radiusScalar, radiusScalar, radiusScalar));
         }
     }
@@ -96,11 +96,11 @@ public class SphereRegionSelector extends EllipsoidRegionSelector {
         if (isDefined()) {
             player.printInfo(TranslatableComponent.of(
                     "worldedit.selection.sphere.explain.secondary-defined",
-                    TextComponent.of(region.getRadius().getX()),
+                    TextComponent.of(region.getRadius().x()),
                     TextComponent.of(region.getVolume())
             ));
         } else {
-            player.printInfo(TranslatableComponent.of("worldedit.selection.sphere.explain.secondary", TextComponent.of(region.getRadius().getX())));
+            player.printInfo(TranslatableComponent.of("worldedit.selection.sphere.explain.secondary", TextComponent.of(region.getRadius().x())));
         }
 
         session.describeCUI(player);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/ArbitraryBiomeShape.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/ArbitraryBiomeShape.java
@@ -49,13 +49,13 @@ public abstract class ArbitraryBiomeShape {
         BlockVector3 min = extent.getMinimumPoint();
         BlockVector3 max = extent.getMaximumPoint();
 
-        cacheOffsetX = min.getBlockX() - 1;
-        cacheOffsetY = min.getBlockY() - 1;
-        cacheOffsetZ = min.getBlockZ() - 1;
+        cacheOffsetX = min.x() - 1;
+        cacheOffsetY = min.y() - 1;
+        cacheOffsetZ = min.z() - 1;
 
-        cacheSizeX = max.getX() - cacheOffsetX + 2;
-        cacheSizeY = max.getY() - cacheOffsetY + 2;
-        cacheSizeZ = max.getZ() - cacheOffsetZ + 2;
+        cacheSizeX = max.x() - cacheOffsetX + 2;
+        cacheSizeY = max.y() - cacheOffsetY + 2;
+        cacheSizeZ = max.z() - cacheOffsetZ + 2;
 
         cache = new BiomeType[cacheSizeX * cacheSizeY * cacheSizeZ];
         isCached = new BitSet(cache.length);
@@ -104,9 +104,9 @@ public abstract class ArbitraryBiomeShape {
         int affected = 0;
 
         for (BlockVector3 position : getExtent()) {
-            int x = position.getBlockX();
-            int y = position.getBlockY();
-            int z = position.getBlockZ();
+            int x = position.x();
+            int y = position.y();
+            int z = position.z();
 
             if (!hollow) {
                 final BiomeType material = getBiome(x, y, z, baseBiome);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/ArbitraryShape.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/ArbitraryShape.java
@@ -65,13 +65,13 @@ public abstract class ArbitraryShape {
         BlockVector3 min = extent.getMinimumPoint();
         BlockVector3 max = extent.getMaximumPoint();
 
-        cacheOffsetX = min.getBlockX() - 1;
-        cacheOffsetY = min.getBlockY() - 1;
-        cacheOffsetZ = min.getBlockZ() - 1;
+        cacheOffsetX = min.x() - 1;
+        cacheOffsetY = min.y() - 1;
+        cacheOffsetZ = min.z() - 1;
 
-        cacheSizeX = max.getX() - cacheOffsetX + 2;
-        cacheSizeY = max.getY() - cacheOffsetY + 2;
-        cacheSizeZ = max.getZ() - cacheOffsetZ + 2;
+        cacheSizeX = max.x() - cacheOffsetX + 2;
+        cacheSizeY = max.y() - cacheOffsetY + 2;
+        cacheSizeZ = max.z() - cacheOffsetZ + 2;
     }
 
     protected Region getExtent() {
@@ -117,9 +117,9 @@ public abstract class ArbitraryShape {
     }
 
     private BaseBlock getMaterial(BlockVector3 position, Pattern pattern, boolean hollow) {
-        int x = position.getBlockX();
-        int y = position.getBlockY();
-        int z = position.getBlockZ();
+        int x = position.x();
+        int y = position.y();
+        int z = position.z();
 
         if (!hollow) {
             return getMaterial(x, y, z, pattern.applyBlock(position));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/Placement.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/Placement.java
@@ -42,9 +42,9 @@ public record Placement(PlacementType placementType, BlockVector3 offset) {
         } else {
             return TranslatableComponent.of(
                     placementType.getTranslationKeyWithOffset(),
-                    TextComponent.of(offset.getX()),
-                    TextComponent.of(offset.getY()),
-                    TextComponent.of(offset.getZ())
+                    TextComponent.of(offset.x()),
+                    TextComponent.of(offset.y()),
+                    TextComponent.of(offset.z())
             );
         }
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/Location.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/Location.java
@@ -254,7 +254,7 @@ public class Location {
      * @return the X component
      */
     public double getX() {
-        return position.getX();
+        return position.x();
     }
 
     /**
@@ -263,7 +263,7 @@ public class Location {
      * @return the rounded X component
      */
     public int getBlockX() {
-        return (int) Math.floor(position.getX());
+        return position.blockX();
     }
 
     /**
@@ -283,7 +283,7 @@ public class Location {
      * @return the Y component
      */
     public double getY() {
-        return position.getY();
+        return position.y();
     }
 
     /**
@@ -292,7 +292,7 @@ public class Location {
      * @return the rounded Y component
      */
     public int getBlockY() {
-        return (int) Math.floor(position.getY());
+        return position.blockY();
     }
 
     /**
@@ -312,7 +312,7 @@ public class Location {
      * @return the Z component
      */
     public double getZ() {
-        return position.getZ();
+        return position.z();
     }
 
     /**
@@ -321,7 +321,7 @@ public class Location {
      * @return the rounded Z component
      */
     public int getBlockZ() {
-        return (int) Math.floor(position.getZ());
+        return position.blockY();
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/Location.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/Location.java
@@ -321,7 +321,7 @@ public class Location {
      * @return the rounded Z component
      */
     public int getBlockZ() {
-        return position.blockY();
+        return position.blockZ();
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/TargetBlock.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/TargetBlock.java
@@ -195,14 +195,14 @@ public class TargetBlock {
         do {
             curDistance += checkDistance;
 
-            targetPosDouble = offset.add(targetPosDouble.getX(),
-                                         targetPosDouble.getY(),
-                                         targetPosDouble.getZ());
+            targetPosDouble = offset.add(targetPosDouble.x(),
+                targetPosDouble.y(),
+                targetPosDouble.z());
             targetPos = targetPosDouble.toBlockPoint();
         } while (curDistance <= maxDistance
-                && targetPos.getBlockX() == prevPos.getBlockX()
-                && targetPos.getBlockY() == prevPos.getBlockY()
-                && targetPos.getBlockZ() == prevPos.getBlockZ());
+                && targetPos.x() == prevPos.x()
+                && targetPos.y() == prevPos.y()
+                && targetPos.z() == prevPos.z());
 
         if (curDistance > maxDistance) {
             return null;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/collection/BlockMap.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/collection/BlockMap.java
@@ -85,15 +85,15 @@ public class BlockMap<V> extends AbstractMap<BlockVector3, V> {
     private static final int BITS_6 = mask(6);
 
     private static long toGroupKey(BlockVector3 location) {
-        return ((location.getX() >>> 6) & BITS_20)
-            | (((location.getZ() >>> 6) & BITS_20) << 20)
-            | (((location.getY() >>> 8) & BITS_24) << (20 + 20));
+        return ((location.x() >>> 6) & BITS_20)
+            | (((location.z() >>> 6) & BITS_20) << 20)
+            | (((location.y() >>> 8) & BITS_24) << (20 + 20));
     }
 
     private static int toInnerKey(BlockVector3 location) {
-        return (location.getX() & BITS_6)
-            | ((location.getZ() & BITS_6) << 6)
-            | ((location.getY() & BITS_8) << (6 + 6));
+        return (location.x() & BITS_6)
+            | ((location.z() & BITS_6) << 6)
+            | ((location.y() & BITS_8) << (6 + 6));
     }
 
     private static final long GROUP_X = BITS_20;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/collection/VectorPositionList.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/collection/VectorPositionList.java
@@ -44,9 +44,9 @@ class VectorPositionList implements PositionList {
 
     @Override
     public void add(BlockVector3 vector) {
-        delegateX.add(vector.getX());
-        delegateY.add(vector.getY());
-        delegateZ.add(vector.getZ());
+        delegateX.add(vector.x());
+        delegateY.add(vector.y());
+        delegateZ.add(vector.z());
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/AnvilChunk.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/AnvilChunk.java
@@ -125,9 +125,9 @@ public class AnvilChunk implements Chunk {
     }
 
     private int getBlockID(BlockVector3 position) throws DataException {
-        int x = position.getX() - rootX * 16;
-        int y = position.getY();
-        int z = position.getZ() - rootZ * 16;
+        int x = position.x() - rootX * 16;
+        int y = position.y();
+        int z = position.z() - rootZ * 16;
 
         int section = y >> 4;
         if (section < 0 || section >= blocks.length) {
@@ -153,9 +153,9 @@ public class AnvilChunk implements Chunk {
     }
 
     private int getBlockData(BlockVector3 position) throws DataException {
-        int x = position.getX() - rootX * 16;
-        int y = position.getY();
-        int z = position.getZ() - rootZ * 16;
+        int x = position.x() - rootX * 16;
+        int y = position.y();
+        int z = position.z() - rootZ * 16;
 
         int section = y >> 4;
         int yIndex = y & 0x0F;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/AnvilChunk13.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/AnvilChunk13.java
@@ -216,9 +216,9 @@ public class AnvilChunk13 implements Chunk {
 
     @Override
     public BaseBlock getBlock(BlockVector3 position) throws DataException {
-        int x = position.getX() - rootX * 16;
-        int y = position.getY();
-        int z = position.getZ() - rootZ * 16;
+        int x = position.x() - rootX * 16;
+        int y = position.y();
+        int z = position.z() - rootZ * 16;
 
         int section = y >> 4;
         int yIndex = y & 0x0F;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/AnvilChunk18.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/AnvilChunk18.java
@@ -189,9 +189,9 @@ public class AnvilChunk18 implements Chunk {
 
     @Override
     public BaseBlock getBlock(BlockVector3 position) throws DataException {
-        int x = position.getX() - rootX * 16;
-        int y = position.getY();
-        int z = position.getZ() - rootZ * 16;
+        int x = position.x() - rootX * 16;
+        int y = position.y();
+        int z = position.z() - rootZ * 16;
 
         int section = y >> 4;
         int yIndex = y & 0x0F;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/OldChunk.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/OldChunk.java
@@ -156,15 +156,15 @@ public class OldChunk implements Chunk {
 
     @Override
     public BaseBlock getBlock(BlockVector3 position) throws DataException {
-        if (position.getY() >= 128) {
+        if (position.y() >= 128) {
             return BlockTypes.VOID_AIR.getDefaultState().toBaseBlock();
         }
         int id;
         int dataVal;
 
-        int x = position.getX() - rootX * 16;
-        int y = position.getY();
-        int z = position.getZ() - rootZ * 16;
+        int x = position.x() - rootX * 16;
+        int y = position.y();
+        int z = position.z() - rootZ * 16;
         int index = y + (z * 128 + (x * 128 * 16));
         try {
             id = blocks[index];

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/snapshot/SnapshotRestore.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/snapshot/SnapshotRestore.java
@@ -77,9 +77,9 @@ public class SnapshotRestore {
 
         // First, we need to group points by chunk so that we only need
         // to keep one chunk in memory at any given moment
-        for (int x = min.getBlockX(); x <= max.getBlockX(); ++x) {
-            for (int y = min.getBlockY(); y <= max.getBlockY(); ++y) {
-                for (int z = min.getBlockZ(); z <= max.getBlockZ(); ++z) {
+        for (int x = min.x(); x <= max.x(); ++x) {
+            for (int y = min.y(); y <= max.y(); ++y) {
+                for (int z = min.z(); z <= max.z(); ++z) {
                     BlockVector3 pos = BlockVector3.at(x, y, z);
                     checkAndAddBlock(pos);
                 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/snapshot/experimental/SnapshotRestore.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/snapshot/experimental/SnapshotRestore.java
@@ -77,9 +77,9 @@ public class SnapshotRestore {
 
         // First, we need to group points by chunk so that we only need
         // to keep one chunk in memory at any given moment
-        for (int x = min.getBlockX(); x <= max.getBlockX(); ++x) {
-            for (int y = min.getBlockY(); y <= max.getBlockY(); ++y) {
-                for (int z = min.getBlockZ(); z <= max.getBlockZ(); ++z) {
+        for (int x = min.x(); x <= max.x(); ++x) {
+            for (int y = min.y(); y <= max.y(); ++y) {
+                for (int z = min.z(); z <= max.z(); ++z) {
                     BlockVector3 pos = BlockVector3.at(x, y, z);
                     checkAndAddBlock(pos);
                 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/ChunkStore.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/ChunkStore.java
@@ -74,7 +74,7 @@ public abstract class ChunkStore implements Closeable {
      * @return chunk coordinates
      */
     public static BlockVector2 toChunk(BlockVector3 position) {
-        return BlockVector2.at(position.getX() >> CHUNK_SHIFTS, position.getZ() >> CHUNK_SHIFTS);
+        return BlockVector2.at(position.x() >> CHUNK_SHIFTS, position.z() >> CHUNK_SHIFTS);
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/LegacyChunkStore.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/LegacyChunkStore.java
@@ -47,8 +47,8 @@ public abstract class LegacyChunkStore extends ChunkStore {
      * @return pathname
      */
     public static String getFilename(BlockVector2 position, String separator) {
-        int x = position.getBlockX();
-        int z = position.getBlockZ();
+        int x = position.x();
+        int z = position.z();
 
         String folder1 = Integer.toString(divisorMod(x, 64), 36);
         String folder2 = Integer.toString(divisorMod(z, 64), 36);
@@ -71,8 +71,8 @@ public abstract class LegacyChunkStore extends ChunkStore {
 
     @Override
     public LinCompoundTag getChunkData(BlockVector2 position, World world) throws DataException, IOException {
-        int x = position.getBlockX();
-        int z = position.getBlockZ();
+        int x = position.x();
+        int z = position.z();
 
         String folder1 = Integer.toString(divisorMod(x, 64), 36);
         String folder2 = Integer.toString(divisorMod(z, 64), 36);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/McRegionChunkStore.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/McRegionChunkStore.java
@@ -42,8 +42,8 @@ public abstract class McRegionChunkStore extends ChunkStore {
      * @return the filename
      */
     public static String getFilename(BlockVector2 position) {
-        int x = position.getBlockX();
-        int z = position.getBlockZ();
+        int x = position.x();
+        int z = position.z();
 
         return "r." + (x >> 5) + "." + (z >> 5) + ".mca";
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/McRegionReader.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/McRegionReader.java
@@ -119,8 +119,8 @@ public class McRegionReader {
      * @throws DataException if there is an error getting the chunk data
      */
     public synchronized InputStream getChunkInputStream(BlockVector2 position) throws IOException, DataException {
-        int x = position.getBlockX() & 31;
-        int z = position.getBlockZ() & 31;
+        int x = position.x() & 31;
+        int z = position.z() & 31;
 
         int offset = getOffset(x, z);
 

--- a/worldedit-core/src/test/java/com/sk89q/worldedit/internal/expression/RealExpressionTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/worldedit/internal/expression/RealExpressionTest.java
@@ -72,7 +72,7 @@ class RealExpressionTest extends BaseExpressionTest {
         Expression compiled = compile(expr, "x", "y", "z");
         for (TestCase aCase : cases) {
             Vector3 loc = aCase.loc;
-            assertEquals(aCase.result, compiled.evaluate(loc.getX(), loc.getY(), loc.getZ()), 0,
+            assertEquals(aCase.result, compiled.evaluate(loc.x(), loc.y(), loc.z()), 0,
                 "Test case " + aCase + " failed (result)");
             aCase.postChecks.accept(compiled);
         }

--- a/worldedit-core/src/test/java/com/sk89q/worldedit/internal/util/RegionOptimizedVectorSorterTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/worldedit/internal/util/RegionOptimizedVectorSorterTest.java
@@ -93,10 +93,10 @@ public class RegionOptimizedVectorSorterTest {
         for (int i = 0; i < toSort.size() - 1; i++) {
             BlockVector3 curr = toSort.get(i);
             BlockVector3 next = toSort.get(i + 1);
-            int currChunkX = curr.getX() >> 4;
-            int nextChunkX = next.getX() >> 4;
-            int currChunkZ = curr.getZ() >> 4;
-            int nextChunkZ = next.getZ() >> 4;
+            int currChunkX = curr.x() >> 4;
+            int nextChunkX = next.x() >> 4;
+            int currChunkZ = curr.z() >> 4;
+            int nextChunkZ = next.z() >> 4;
             int currRegionX = currChunkX >> 5;
             int nextRegionX = nextChunkX >> 5;
             int currRegionZ = currChunkZ >> 5;
@@ -118,7 +118,7 @@ public class RegionOptimizedVectorSorterTest {
                             fail(spaceship + " "
                                 + currChunkZ + " chunk z should be less than or equal to " + nextChunkZ);
                         } else if (currChunkZ == nextChunkZ) {
-                            if (curr.getY() < next.getY()) {
+                            if (curr.y() < next.y()) {
                                 fail(spaceship + " "
                                     + curr + " y should be greater than or equal to " + next);
                             }

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricAdapter.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricAdapter.java
@@ -88,7 +88,7 @@ public final class FabricAdapter {
 
     public static Biome adapt(BiomeType biomeType) {
         return FabricWorldEdit.getRegistry(Registries.BIOME)
-            .get(new ResourceLocation(biomeType.getId()));
+            .get(new ResourceLocation(biomeType.id()));
     }
 
     public static BiomeType adapt(Biome biome) {
@@ -106,7 +106,7 @@ public final class FabricAdapter {
     }
 
     public static Vec3 toVec3(BlockVector3 vector) {
-        return new Vec3(vector.getBlockX(), vector.getBlockY(), vector.getBlockZ());
+        return new Vec3(vector.x(), vector.y(), vector.z());
     }
 
     public static net.minecraft.core.Direction adapt(Direction face) {
@@ -149,7 +149,7 @@ public final class FabricAdapter {
     }
 
     public static BlockPos toBlockPos(BlockVector3 vector) {
-        return new BlockPos(vector.getBlockX(), vector.getBlockY(), vector.getBlockZ());
+        return new BlockPos(vector.x(), vector.y(), vector.z());
     }
 
     /**

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricPlayer.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricPlayer.java
@@ -186,7 +186,7 @@ public class FabricPlayer extends AbstractPlayerActor {
 
     @Override
     public boolean trySetPosition(Vector3 pos, float pitch, float yaw) {
-        this.player.connection.teleport(pos.getX(), pos.getY(), pos.getZ(), yaw, pitch);
+        this.player.connection.teleport(pos.x(), pos.y(), pos.z(), yaw, pitch);
         return true;
     }
 
@@ -244,7 +244,7 @@ public class FabricPlayer extends AbstractPlayerActor {
                 final LinCompoundTag nbtData = ((BaseBlock) block).getNbt();
                 if (nbtData != null) {
                     player.connection.send(new ClientboundBlockEntityDataPacket(
-                        new BlockPos(pos.getBlockX(), pos.getBlockY(), pos.getBlockZ()),
+                        new BlockPos(pos.x(), pos.y(), pos.z()),
                         BlockEntityType.STRUCTURE_BLOCK,
                         NBTConverter.toNative(nbtData))
                     );

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/internal/FabricServerLevelDelegateProxy.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/internal/FabricServerLevelDelegateProxy.java
@@ -90,7 +90,7 @@ public class FabricServerLevelDelegateProxy implements InvocationHandler {
 
     private boolean addEntity(Entity entity) {
         Vector3 pos = FabricAdapter.adapt(entity.getPosition(0.0f));
-        Location location = new Location(FabricAdapter.adapt(serverLevel), pos.getX(), pos.getY(), pos.getZ());
+        Location location = new Location(FabricAdapter.adapt(serverLevel), pos.x(), pos.y(), pos.z());
         BaseEntity baseEntity = new FabricEntity(entity).getState();
         return editSession.createEntity(location, baseEntity) != null;
     }

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeAdapter.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeAdapter.java
@@ -91,8 +91,8 @@ public final class ForgeAdapter {
         return ServerLifecycleHooks.getCurrentServer()
             .registryAccess()
             .registryOrThrow(Registries.BIOME)
-            .getOptional(new ResourceLocation(biomeType.getId()))
-            .orElseThrow(() -> new IllegalStateException("No biome for " + biomeType.getId()));
+            .getOptional(new ResourceLocation(biomeType.id()))
+            .orElseThrow(() -> new IllegalStateException("No biome for " + biomeType.id()));
     }
 
     public static BiomeType adapt(Biome biome) {
@@ -113,7 +113,7 @@ public final class ForgeAdapter {
     }
 
     public static Vec3 toVec3(BlockVector3 vector) {
-        return new Vec3(vector.getBlockX(), vector.getBlockY(), vector.getBlockZ());
+        return new Vec3(vector.x(), vector.y(), vector.z());
     }
 
     public static net.minecraft.core.Direction adapt(Direction face) {
@@ -146,7 +146,7 @@ public final class ForgeAdapter {
     }
 
     public static BlockPos toBlockPos(BlockVector3 vector) {
-        return new BlockPos(vector.getBlockX(), vector.getBlockY(), vector.getBlockZ());
+        return new BlockPos(vector.x(), vector.y(), vector.z());
     }
 
     /**

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePlayer.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePlayer.java
@@ -182,7 +182,7 @@ public class ForgePlayer extends AbstractPlayerActor {
 
     @Override
     public boolean trySetPosition(Vector3 pos, float pitch, float yaw) {
-        this.player.connection.teleport(pos.getX(), pos.getY(), pos.getZ(), yaw, pitch);
+        this.player.connection.teleport(pos.x(), pos.y(), pos.z(), yaw, pitch);
         return true;
     }
 
@@ -246,7 +246,7 @@ public class ForgePlayer extends AbstractPlayerActor {
                 final LinCompoundTag nbtData = baseBlock.getNbt();
                 if (nbtData != null) {
                     player.connection.send(new ClientboundBlockEntityDataPacket(
-                        new BlockPos(pos.getBlockX(), pos.getBlockY(), pos.getBlockZ()),
+                        new BlockPos(pos.x(), pos.y(), pos.z()),
                         BlockEntityType.STRUCTURE_BLOCK,
                         NBTConverter.toNative(nbtData)
                     ));

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/internal/ForgeServerLevelDelegateProxy.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/internal/ForgeServerLevelDelegateProxy.java
@@ -90,7 +90,7 @@ public class ForgeServerLevelDelegateProxy implements InvocationHandler {
 
     private boolean addEntity(Entity entity) {
         Vector3 pos = ForgeAdapter.adapt(entity.getPosition(0.0f));
-        Location location = new Location(ForgeAdapter.adapt(serverLevel), pos.getX(), pos.getY(), pos.getZ());
+        Location location = new Location(ForgeAdapter.adapt(serverLevel), pos.x(), pos.y(), pos.z());
         BaseEntity baseEntity = new ForgeEntity(entity).getState();
         return editSession.createEntity(location, baseEntity) != null;
     }

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeAdapter.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeAdapter.java
@@ -132,7 +132,7 @@ public class SpongeAdapter {
     }
 
     public static RegistryReference<Biome> adapt(BiomeType biomeType) {
-        return RegistryKey.of(RegistryTypes.BIOME, ResourceKey.resolve(biomeType.getId()))
+        return RegistryKey.of(RegistryTypes.BIOME, ResourceKey.resolve(biomeType.id()))
             .asReference();
     }
 
@@ -168,7 +168,7 @@ public class SpongeAdapter {
         Vector3 position = location.toVector();
         return ServerLocation.of(
             adapt((World) location.getExtent()),
-            position.getX(), position.getY(), position.getZ()
+            position.x(), position.y(), position.z()
         );
     }
 
@@ -236,7 +236,7 @@ public class SpongeAdapter {
     }
 
     public static Vector3i adaptVector3i(BlockVector3 bv3) {
-        return new Vector3i(bv3.getX(), bv3.getY(), bv3.getZ());
+        return new Vector3i(bv3.x(), bv3.y(), bv3.z());
     }
 
     public static BlockVector3 adaptVector3i(Vector3i vec3i) {

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongePlayer.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongePlayer.java
@@ -178,7 +178,7 @@ public class SpongePlayer extends AbstractPlayerActor {
     @Override
     public boolean trySetPosition(Vector3 pos, float pitch, float yaw) {
         ServerLocation loc = ServerLocation.of(
-            this.player.world(), pos.getX(), pos.getY(), pos.getZ()
+            this.player.world(), pos.x(), pos.y(), pos.z()
         );
 
         return this.player.setLocationAndRotation(loc, new Vector3d(pitch, yaw, 0));
@@ -214,7 +214,7 @@ public class SpongePlayer extends AbstractPlayerActor {
     public void setGameMode(GameMode gameMode) {
         player.gameMode().set(
             Sponge.game().registry(RegistryTypes.GAME_MODE).value(
-                ResourceKey.resolve(gameMode.getId())
+                ResourceKey.resolve(gameMode.id())
             )
         );
     }
@@ -232,10 +232,10 @@ public class SpongePlayer extends AbstractPlayerActor {
     @Override
     public <B extends BlockStateHolder<B>> void sendFakeBlock(BlockVector3 pos, B block) {
         if (block == null) {
-            player.resetBlockChange(pos.getX(), pos.getY(), pos.getZ());
+            player.resetBlockChange(pos.x(), pos.y(), pos.z());
         } else {
             BlockState spongeBlock = SpongeAdapter.adapt(block.toImmutableState());
-            player.sendBlockChange(pos.getX(), pos.getY(), pos.getZ(), spongeBlock);
+            player.sendBlockChange(pos.x(), pos.y(), pos.z(), spongeBlock);
             if (block instanceof final BaseBlock baseBlock
                 && block.getBlockType().equals(com.sk89q.worldedit.world.block.BlockTypes.STRUCTURE_BLOCK)) {
                 final LinCompoundTag nbtData = baseBlock.getNbt();
@@ -247,7 +247,7 @@ public class SpongePlayer extends AbstractPlayerActor {
                         ((net.minecraft.server.level.ServerPlayer) player);
 
                     StructureBlockEntity structureBlockEntity =
-                        new StructureBlockEntity(new BlockPos(pos.getX(), pos.getY(), pos.getZ()), nativeBlock);
+                        new StructureBlockEntity(new BlockPos(pos.x(), pos.y(), pos.z()), nativeBlock);
                     structureBlockEntity.load(nativeNbtData);
                     nativePlayer.connection.send(
                         ClientboundBlockEntityDataPacket.create(structureBlockEntity, it -> nativeNbtData));

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorld.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorld.java
@@ -151,14 +151,14 @@ public final class SpongeWorld extends AbstractWorld {
     @Override
     public BlockState getBlock(BlockVector3 position) {
         return SpongeAdapter.adapt(getWorld().block(
-            position.getX(), position.getY(), position.getZ()
+            position.x(), position.y(), position.z()
         ));
     }
 
     @Override
     public BaseBlock getFullBlock(BlockVector3 position) {
         BlockEntity blockEntity = getWorld().blockEntity(
-                position.getX(), position.getY(), position.getZ()
+            position.x(), position.y(), position.z()
         ).orElse(null);
         LinCompoundTag blockEntityData = null;
         if (blockEntity != null) {
@@ -170,9 +170,9 @@ public final class SpongeWorld extends AbstractWorld {
             // Add ID and position since Sponge's #blockEntityData does not save metadata
             LinCompoundTag.Builder fullBlockEntityDataBuilder = blockEntityData.toBuilder();
             fullBlockEntityDataBuilder.put("id", LinStringTag.of(blockEntityId.formatted()));
-            fullBlockEntityDataBuilder.put("x", LinIntTag.of(position.getX()));
-            fullBlockEntityDataBuilder.put("y", LinIntTag.of(position.getY()));
-            fullBlockEntityDataBuilder.put("z", LinIntTag.of(position.getZ()));
+            fullBlockEntityDataBuilder.put("x", LinIntTag.of(position.x()));
+            fullBlockEntityDataBuilder.put("y", LinIntTag.of(position.y()));
+            fullBlockEntityDataBuilder.put("z", LinIntTag.of(position.z()));
             blockEntityData = fullBlockEntityDataBuilder.build();
         }
         return getBlock(position).toBaseBlock(blockEntityData);
@@ -188,7 +188,7 @@ public final class SpongeWorld extends AbstractWorld {
         org.spongepowered.api.block.BlockState newState = SpongeAdapter.adapt(block.toImmutableState());
 
         boolean didSet = world.setBlock(
-            position.getX(), position.getY(), position.getZ(),
+            position.x(), position.y(), position.z(),
             newState,
             BlockChangeFlags.NONE
                 .withUpdateNeighbors(sideEffects.shouldApply(SideEffect.NEIGHBORS))
@@ -204,7 +204,7 @@ public final class SpongeWorld extends AbstractWorld {
         );
         if (!didSet) {
             // still update NBT if the block is the same
-            if (world.block(position.getX(), position.getY(), position.getZ()) == newState) {
+            if (world.block(position.x(), position.y(), position.z()) == newState) {
                 didSet = block.toBaseBlock().getNbt() != null;
             }
         }
@@ -221,7 +221,7 @@ public final class SpongeWorld extends AbstractWorld {
                     .blockEntityData(NbtAdapter.adaptFromWorldEdit(nbt))
                     .state(newState)
                     .build()
-                    .apply(ServerLocation.of(world, position.getX(), position.getY(), position.getZ()));
+                    .apply(ServerLocation.of(world, position.x(), position.y(), position.z()));
             }
         }
 
@@ -242,7 +242,7 @@ public final class SpongeWorld extends AbstractWorld {
 
     @Override
     public boolean clearContainerBlockContents(BlockVector3 position) {
-        getWorld().removeBlockEntity(position.getX(), position.getY(), position.getZ());
+        getWorld().removeBlockEntity(position.x(), position.y(), position.z());
         return true;
     }
 
@@ -272,7 +272,7 @@ public final class SpongeWorld extends AbstractWorld {
             // We need to also pull one more chunk in every direction
             CuboidRegion expandedPreGen = new CuboidRegion(region.getMinimumPoint().subtract(16, 16, 16), region.getMaximumPoint().add(16, 16, 16));
             for (BlockVector3 chunk : expandedPreGen.getChunkCubes()) {
-                tempWorld.loadChunk(chunk.getBlockX(), chunk.getBlockY(), chunk.getBlockZ(), true);
+                tempWorld.loadChunk(chunk.x(), chunk.y(), chunk.z(), true);
             }
 
             World from = SpongeAdapter.adapt(tempWorld);
@@ -332,7 +332,7 @@ public final class SpongeWorld extends AbstractWorld {
             .orElse(null);
         return generator != null && generator.place(
             world, world.getChunkSource().getGenerator(), random,
-            new BlockPos(position.getX(), position.getY(), position.getZ())
+            new BlockPos(position.x(), position.y(), position.z())
         );
     }
 
@@ -340,8 +340,8 @@ public final class SpongeWorld extends AbstractWorld {
     public int getBlockLightLevel(BlockVector3 position) {
         checkNotNull(position);
 
-        int skyLight = getWorld().light(LightTypes.SKY, position.getX(), position.getY(), position.getZ());
-        int groundLight = getWorld().light(LightTypes.BLOCK, position.getX(), position.getY(), position.getZ());
+        int skyLight = getWorld().light(LightTypes.SKY, position.x(), position.y(), position.z());
+        int groundLight = getWorld().light(LightTypes.BLOCK, position.x(), position.y(), position.z());
 
         return Math.max(skyLight, groundLight);
 
@@ -352,7 +352,7 @@ public final class SpongeWorld extends AbstractWorld {
         checkNotNull(position);
         return BiomeType.REGISTRY.get(
             getWorld().registry(RegistryTypes.BIOME)
-                .valueKey(getWorld().biome(position.getBlockX(), position.getBlockY(), position.getBlockZ()))
+                .valueKey(getWorld().biome(position.x(), position.y(), position.z()))
                 .asString()
         );
     }
@@ -363,9 +363,9 @@ public final class SpongeWorld extends AbstractWorld {
         checkNotNull(biome);
 
         getWorld().setBiome(
-            position.getBlockX(), position.getY(), position.getBlockZ(),
+            position.x(), position.y(), position.z(),
             getWorld().registry(RegistryTypes.BIOME).value(
-                ResourceKey.resolve(biome.getId())
+                ResourceKey.resolve(biome.id())
             )
         );
         return true;
@@ -382,7 +382,7 @@ public final class SpongeWorld extends AbstractWorld {
 
         Item itemEntity = getWorld().createEntity(
             EntityTypes.ITEM,
-            new Vector3d(position.getX(), position.getY(), position.getZ())
+            new Vector3d(position.x(), position.y(), position.z())
         );
 
         itemEntity.item().set(
@@ -394,7 +394,7 @@ public final class SpongeWorld extends AbstractWorld {
     @Override
     public void simulateBlockMine(BlockVector3 position) {
         getWorld().destroyBlock(
-            new Vector3i(position.getX(), position.getY(), position.getZ()),
+            new Vector3i(position.x(), position.y(), position.z()),
             true
         );
     }
@@ -404,7 +404,7 @@ public final class SpongeWorld extends AbstractWorld {
         return ((net.minecraft.world.level.block.state.BlockState) SpongeAdapter.adapt(blockState))
             .canSurvive(
                 ((LevelReader) getWorld()),
-                new BlockPos(position.getX(), position.getY(), position.getZ())
+                new BlockPos(position.x(), position.y(), position.z())
             );
     }
 
@@ -455,7 +455,7 @@ public final class SpongeWorld extends AbstractWorld {
     @Override
     public Entity createEntity(Location location, BaseEntity entity) {
         Optional<EntityType<?>> entityType = Sponge.game().registry(RegistryTypes.ENTITY_TYPE)
-                .findValue(ResourceKey.resolve(entity.getType().getId()));
+                .findValue(ResourceKey.resolve(entity.getType().id()));
         if (entityType.isEmpty()) {
             return null;
         }
@@ -483,7 +483,7 @@ public final class SpongeWorld extends AbstractWorld {
     public void setWeather(WeatherType weatherType) {
         getWorld().setWeather(
             Sponge.game().registry(RegistryTypes.WEATHER_TYPE).value(
-                ResourceKey.resolve(weatherType.getId())
+                ResourceKey.resolve(weatherType.id())
             )
         );
     }
@@ -492,7 +492,7 @@ public final class SpongeWorld extends AbstractWorld {
     public void setWeather(WeatherType weatherType, long duration) {
         getWorld().setWeather(
             Sponge.game().registry(RegistryTypes.WEATHER_TYPE).value(
-                ResourceKey.resolve(weatherType.getId())
+                ResourceKey.resolve(weatherType.id())
             ),
             Ticks.of(duration)
         );


### PR DESCRIPTION
This cleans up all found usages of the deprecated getters for the Vector/BlockVector classes. Files containing those had all recent deprecations cleaned up, as I used an IntelliJ auto-thing to do it