### PR TITLE
Workaround verification jar build failure

### DIFF
--- a/verification/build.gradle.kts
+++ b/verification/build.gradle.kts
@@ -16,6 +16,13 @@ repositories {
         name = "EngineHub Repository (Releases Only)"
         url = uri("https://maven.enginehub.org/artifactory/libs-release-local/")
     }
+    maven {
+        name = "EngineHub Repository (Snapshots Only)"
+        url = uri("https://maven.enginehub.org/artifactory/libs-snapshot-local/")
+        content {
+            excludeGroup("com.sk89q.worldedit")
+        }
+    }
     mavenCentral()
 }
 


### PR DESCRIPTION
This PR adds the snapshot repo to the verification system, but excludes the WorldEdit group to prevent any oddities in the future. It appeared to work fine without it, but given what this system does I feel excluding it is a good idea either way.