### PR TITLE
Deprecate fullySupports3DBiomes and BiomeQuirkExtent

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -39,7 +39,6 @@ import com.sk89q.worldedit.extent.reorder.ChunkBatchingExtent;
 import com.sk89q.worldedit.extent.reorder.MultiStageReorder;
 import com.sk89q.worldedit.extent.validation.BlockChangeLimiter;
 import com.sk89q.worldedit.extent.validation.DataValidatorExtent;
-import com.sk89q.worldedit.extent.world.BiomeQuirkExtent;
 import com.sk89q.worldedit.extent.world.ChunkLoadingExtent;
 import com.sk89q.worldedit.extent.world.SideEffectExtent;
 import com.sk89q.worldedit.extent.world.SurvivalModeExtent;
@@ -261,7 +260,6 @@ public class EditSession implements Extent, AutoCloseable {
                 watchdogExtents.add(watchdogExtent);
             }
             extent = traceIfNeeded(survivalExtent = new SurvivalModeExtent(extent, world));
-            extent = traceIfNeeded(new BiomeQuirkExtent(extent));
             extent = traceIfNeeded(new ChunkLoadingExtent(extent, world));
             extent = traceIfNeeded(new LastAccessExtentCache(extent));
             extent = traceIfNeeded(blockBagExtent = new BlockBagExtent(extent, blockBag));
@@ -680,11 +678,6 @@ public class EditSession implements Extent, AutoCloseable {
      */
     public int getBlockChangeCount() {
         return changeSet.size();
-    }
-
-    @Override
-    public boolean fullySupports3DBiomes() {
-        return bypassNone.fullySupports3DBiomes();
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/AbstractDelegateExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/AbstractDelegateExtent.java
@@ -95,11 +95,6 @@ public abstract class AbstractDelegateExtent implements Extent {
     }
 
     @Override
-    public boolean fullySupports3DBiomes() {
-        return extent.fullySupports3DBiomes();
-    }
-
-    @Override
     public BiomeType getBiome(BlockVector3 position) {
         return extent.getBiome(position);
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/NullExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/NullExtent.java
@@ -90,11 +90,6 @@ public class NullExtent implements Extent {
     }
 
     @Override
-    public boolean fullySupports3DBiomes() {
-        return false;
-    }
-
-    @Override
     public boolean setBiome(BlockVector3 position, BiomeType biome) {
         return false;
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/OutputExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/OutputExtent.java
@@ -65,7 +65,9 @@ public interface OutputExtent {
      * </p>
      *
      * @return if the extent fully supports 3D biomes
+     * @deprecated All supported platforms now support this, the check is no longer necessary
      */
+    @Deprecated
     default boolean fullySupports3DBiomes() {
         return true;
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/BiomeQuirkExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/BiomeQuirkExtent.java
@@ -26,7 +26,10 @@ import com.sk89q.worldedit.world.biome.BiomeType;
 
 /**
  * Handles quirks when placing biomes.
+ *
+ * @deprecated This extent currently performs no functions.
  */
+@Deprecated
 public class BiomeQuirkExtent extends AbstractDelegateExtent {
 
     /**
@@ -40,11 +43,6 @@ public class BiomeQuirkExtent extends AbstractDelegateExtent {
 
     @Override
     public boolean setBiome(BlockVector3 position, BiomeType biome) {
-        boolean success = false;
-        if (!fullySupports3DBiomes()) {
-            // Also place at Y = 0 for proper handling
-            success = super.setBiome(position.withY(0), biome);
-        }
-        return super.setBiome(position, biome) || success;
+        return super.setBiome(position, biome);
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/request/RequestExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/request/RequestExtent.java
@@ -95,11 +95,6 @@ public class RequestExtent implements Extent {
     }
 
     @Override
-    public boolean fullySupports3DBiomes() {
-        return getExtent().fullySupports3DBiomes();
-    }
-
-    @Override
     public boolean setBiome(BlockVector3 position, BiomeType biome) {
         return getExtent().setBiome(position, biome);
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/NullWorld.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/NullWorld.java
@@ -91,11 +91,6 @@ public class NullWorld extends AbstractWorld {
     }
 
     @Override
-    public boolean fullySupports3DBiomes() {
-        return false;
-    }
-
-    @Override
     public BiomeType getBiome(BlockVector3 position) {
         return BiomeTypes.THE_VOID;
     }


### PR DESCRIPTION
This PR deprecates the "fullySupports3DBiomes" check, as no platform lacks support for this now.

The BiomeQuirkExtent has also been deprecated and removed from the EditSession stack, as it now does nothing.