### PR TITLE
Set clipboard after regen to prevent unnecessary clipboard loss on failure

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -32,6 +32,7 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.extent.clipboard.BlockArrayClipboard;
+import com.sk89q.worldedit.extent.clipboard.Clipboard;
 import com.sk89q.worldedit.function.GroundFunction;
 import com.sk89q.worldedit.function.RegionFunction;
 import com.sk89q.worldedit.function.block.BlockReplace;
@@ -462,10 +463,13 @@ public class RegionCommands {
             if (toClipboard) {
                 var clipboard = new BlockArrayClipboard(region);
                 clipboard.setOrigin(session.getPlacementPosition(actor));
-                session.setClipboard(new ClipboardHolder(clipboard));
                 outputExtent = clipboard;
             }
             success = world.regenerate(region, outputExtent, options);
+            if (success && toClipboard) {
+                Clipboard clipboard = (Clipboard) outputExtent;
+                session.setClipboard(new ClipboardHolder(clipboard));
+            }
         } finally {
             session.setMask(mask);
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -32,7 +32,6 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.extent.clipboard.BlockArrayClipboard;
-import com.sk89q.worldedit.extent.clipboard.Clipboard;
 import com.sk89q.worldedit.function.GroundFunction;
 import com.sk89q.worldedit.function.RegionFunction;
 import com.sk89q.worldedit.function.block.BlockReplace;
@@ -460,14 +459,14 @@ public class RegionCommands {
                 .regenBiomes(regenBiomes)
                 .build();
             Extent outputExtent = editSession;
+            BlockArrayClipboard clipboard = null;
             if (toClipboard) {
-                var clipboard = new BlockArrayClipboard(region);
+                clipboard = new BlockArrayClipboard(region);
                 clipboard.setOrigin(session.getPlacementPosition(actor));
                 outputExtent = clipboard;
             }
             success = world.regenerate(region, outputExtent, options);
             if (success && toClipboard) {
-                Clipboard clipboard = (Clipboard) outputExtent;
                 session.setClipboard(new ClipboardHolder(clipboard));
             }
         } finally {


### PR DESCRIPTION
Moves the clipboard set on the session to after success, to prevent unnecessary loss of the clipboard.