### PR TITLE
Update for Java 21

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -46,16 +46,28 @@ val mixinVersion: String = properties.getProperty("mixin.version")
 dependencies {
     implementation(gradleApi())
     implementation("gradle.plugin.org.cadixdev.gradle:licenser:0.6.1")
-    implementation("org.ajoberstar.grgit:grgit-gradle:5.2.1")
-    implementation("me.champeau.gradle:japicmp-gradle-plugin:0.4.0")
+    implementation("org.ajoberstar.grgit:grgit-gradle:5.2.2")
+    implementation("me.champeau.gradle:japicmp-gradle-plugin:0.4.2")
     implementation("com.github.johnrengelman:shadow:8.1.1")
-    implementation("org.jfrog.buildinfo:build-info-extractor-gradle:5.1.14")
+    implementation("org.jfrog.buildinfo:build-info-extractor-gradle:5.2.0")
     implementation("org.spongepowered:spongegradle-plugin-development:2.2.0")
     implementation("org.spongepowered:vanillagradle:0.2.1-20231105.223944-69")
     implementation("net.minecraftforge.gradle:ForgeGradle:6.0.21")
     implementation("net.fabricmc:fabric-loom:$loomVersion")
     implementation("net.fabricmc:sponge-mixin:$mixinVersion")
     implementation("org.enginehub.gradle:gradle-codecov-plugin:0.2.0")
-    implementation("io.papermc.paperweight.userdev:io.papermc.paperweight.userdev.gradle.plugin:1.5.11")
+    implementation("io.papermc.paperweight.userdev:io.papermc.paperweight.userdev.gradle.plugin:1.5.13")
     implementation("org.spongepowered:mixingradle:0.7.38")
+    constraints {
+        val asmVersion = "[9.7,)"
+        implementation("org.ow2.asm:asm:$asmVersion") {
+            because("Need Java 21 support in shadow")
+        }
+        implementation("org.ow2.asm:asm-commons:$asmVersion") {
+            because("Need Java 21 support in shadow")
+        }
+        implementation("org.vafer:jdependency:[2.10,)") {
+            because("Need Java 21 support in shadow")
+        }
+    }
 }

--- a/buildSrc/src/main/kotlin/AdapterConfig.kt
+++ b/buildSrc/src/main/kotlin/AdapterConfig.kt
@@ -4,7 +4,7 @@ import org.gradle.kotlin.dsl.dependencies
 
 // For specific version pinning, see
 // https://repo.papermc.io/service/rest/repository/browse/maven-public/io/papermc/paper/dev-bundle/
-fun Project.applyPaperweightAdapterConfiguration(javaRelease: Int = 17) {
+fun Project.applyPaperweightAdapterConfiguration(javaRelease: Int = 21) {
     applyCommonConfiguration()
     apply(plugin = "java-library")
     applyCommonJavaConfiguration(
@@ -16,6 +16,11 @@ fun Project.applyPaperweightAdapterConfiguration(javaRelease: Int = 17) {
 
     dependencies {
         "implementation"(project(":worldedit-bukkit"))
+        constraints {
+            "remapper"("net.fabricmc:tiny-remapper:[0.8.11,)") {
+                because("Need remapper to support Java 21")
+            }
+        }
     }
 
     tasks.named("assemble") {

--- a/buildSrc/src/main/kotlin/CommonConfig.kt
+++ b/buildSrc/src/main/kotlin/CommonConfig.kt
@@ -35,7 +35,7 @@ fun Project.applyCommonConfiguration() {
 
     plugins.withId("java") {
         the<JavaPluginExtension>().toolchain {
-            languageVersion.set(JavaLanguageVersion.of(17))
+            languageVersion.set(JavaLanguageVersion.of(21))
         }
     }
 

--- a/buildSrc/src/main/kotlin/CommonJavaConfig.kt
+++ b/buildSrc/src/main/kotlin/CommonJavaConfig.kt
@@ -21,8 +21,9 @@ fun Project.applyCommonJavaConfiguration(sourcesJar: Boolean, javaRelease: Int =
         .withType<JavaCompile>()
         .matching { it.name == "compileJava" || it.name == "compileTestJava" }
         .configureEach {
+            // TODO: re-enable this-escape when ANTLR suppresses it properly
             val disabledLint = listOf(
-                "processing", "path", "fallthrough", "serial", "overloads",
+                "processing", "path", "fallthrough", "serial", "overloads", "this-escape",
             )
             options.release.set(javaRelease)
             options.compilerArgs.addAll(listOf("-Xlint:all") + disabledLint.map { "-Xlint:-$it" })

--- a/buildSrc/src/main/kotlin/PlatformConfig.kt
+++ b/buildSrc/src/main/kotlin/PlatformConfig.kt
@@ -11,7 +11,7 @@ import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
 import kotlin.collections.set
 
-fun Project.applyPlatformAndCoreConfiguration(javaRelease: Int = 17) {
+fun Project.applyPlatformAndCoreConfiguration(javaRelease: Int = 21) {
     applyCommonConfiguration()
     apply(plugin = "java")
     apply(plugin = "maven-publish")

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ version=7.3.1-SNAPSHOT
 org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
-loom.version=1.5.6
-mixin.version=0.12.5+mixin.0.8.5
+loom.version=1.6.6
+mixin.version=0.13.2+mixin.0.8.5

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,11 +16,11 @@ rootProject.name = "worldedit"
 
 include("worldedit-libs")
 
-listOf("1.18.2", "1.19.4", "1.20", "1.20.2", "1.20.4").forEach {
+listOf("1.19.4", "1.20", "1.20.2", "1.20.4").forEach {
     include("worldedit-bukkit:adapters:adapter-$it")
 }
 
-listOf("bukkit", "core", "sponge", "fabric", "forge", "cli").forEach {
+listOf("bukkit", "core", "fabric", "forge", "cli").forEach {
     include("worldedit-libs:$it")
     include("worldedit-$it")
 }

--- a/verification/build.gradle.kts
+++ b/verification/build.gradle.kts
@@ -43,7 +43,7 @@ tasks.check {
 // Generic setup for all tasks
 // Pull the version before our current version.
 val baseVersion = "(,${rootProject.version.toString().substringBefore("-SNAPSHOT")}["
-for (projectFragment in listOf("bukkit", "cli", "core", "fabric", "forge", "sponge")) {
+for (projectFragment in listOf("bukkit", "cli", "core", "fabric", "forge")) {
     val capitalizedFragment =
         projectFragment.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString() }
     val proj = project(":worldedit-$projectFragment")

--- a/worldedit-core/build.gradle.kts
+++ b/worldedit-core/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
 
     "implementation"("it.unimi.dsi:fastutil")
 
-    val antlrVersion = "4.9.1"
+    val antlrVersion = "4.13.1"
     "antlr"("org.antlr:antlr4:$antlrVersion")
     "implementation"("org.antlr:antlr4-runtime:$antlrVersion")
 

--- a/worldedit-core/doctools/build.gradle.kts
+++ b/worldedit-core/doctools/build.gradle.kts
@@ -1,15 +1,9 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
-    kotlin("jvm") version "1.8.20"
+    kotlin("jvm") version "1.9.23"
     application
 }
 
 applyCommonConfiguration()
-
-tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "17"
-}
 
 application.mainClass.set("com.sk89q.worldedit.internal.util.DocumentationPrinter")
 tasks.named<JavaExec>("run") {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEditManifest.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEditManifest.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.JarURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.util.function.Supplier;
 import java.util.jar.Attributes;
@@ -72,8 +73,7 @@ public class WorldEditManifest {
         }
 
         try {
-            URL url = new URL(classPath);
-            JarURLConnection jarConnection = (JarURLConnection) url.openConnection();
+            JarURLConnection jarConnection = (JarURLConnection) URI.create(classPath).toURL().openConnection();
             Manifest manifest = jarConnection.getManifest();
             return manifest.getMainAttributes();
         } catch (IOException e) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/entity/BaseEntity.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/entity/BaseEntity.java
@@ -55,6 +55,7 @@ public class BaseEntity implements NbtValued {
      * @param nbtData NBT data
      * @deprecated Use {@link BaseEntity#BaseEntity(EntityType, LazyReference)}
      */
+    @SuppressWarnings("this-escape")
     @Deprecated
     public BaseEntity(EntityType type, CompoundTag nbtData) {
         this(type);
@@ -67,6 +68,7 @@ public class BaseEntity implements NbtValued {
      * @param type the entity type
      * @param nbtData NBT data
      */
+    @SuppressWarnings("this-escape")
     public BaseEntity(EntityType type, LazyReference<LinCompoundTag> nbtData) {
         this(type);
         setNbtReference(nbtData);
@@ -86,6 +88,7 @@ public class BaseEntity implements NbtValued {
      *
      * @param other the object to clone
      */
+    @SuppressWarnings("this-escape")
     public BaseEntity(BaseEntity other) {
         checkNotNull(other);
         this.type = other.getType();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/validation/BlockChangeLimiter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/validation/BlockChangeLimiter.java
@@ -43,6 +43,7 @@ public class BlockChangeLimiter extends AbstractDelegateExtent {
      * @param extent the extent
      * @param limit the limit (&gt;= 0) or -1 for no limit
      */
+    @SuppressWarnings("this-escape") // Unlikely anyone is extending this in practice
     public BlockChangeLimiter(Extent extent, int limit) {
         super(extent);
         setLimit(limit);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegion.java
@@ -276,17 +276,13 @@ public class Polygonal2DRegion extends AbstractRegion implements FlatRegion {
 
     @Override
     public void shift(BlockVector3 change) throws RegionOperationException {
-        final double changeX = change.x();
-        final double changeY = change.y();
-        final double changeZ = change.z();
-
         for (int i = 0; i < points.size(); ++i) {
             BlockVector2 point = points.get(i);
-            points.set(i, BlockVector2.at(point.x() + changeX, point.z() + changeZ));
+            points.set(i, BlockVector2.at(point.x() + change.x(), point.z() + change.z()));
         }
 
-        minY += changeY;
-        maxY += changeY;
+        minY += change.y();
+        maxY += change.y();
 
         recalculate();
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/io/ForwardSeekableInputStream.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/io/ForwardSeekableInputStream.java
@@ -60,7 +60,7 @@ public class ForwardSeekableInputStream extends InputStream {
 
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
-        int read = super.read(b, off, len);
+        int read = parent.read(b, off, len);
         position += read;
         return read;
     }
@@ -86,6 +86,7 @@ public class ForwardSeekableInputStream extends InputStream {
 
     public void seek(long n) throws IOException {
         long diff = n - position;
+        System.err.println("Seek to " + n + " from position " + position + " using " + diff);
 
         if (diff < 0) {
             throw new IOException("Can't seek backwards");

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/net/HttpRequest.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/net/HttpRequest.java
@@ -353,7 +353,7 @@ public class HttpRequest implements Closeable {
      */
     public static URL url(String url) {
         try {
-            return new URL(url);
+            return URI.create(url).toURL();
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }
@@ -367,12 +367,7 @@ public class HttpRequest implements Closeable {
      */
     private static URL reformat(URL existing) {
         try {
-            URL url = new URL(existing.toString());
-            URI uri = new URI(
-                    url.getProtocol(), url.getUserInfo(), url.getHost(), url.getPort(),
-                    url.getPath(), url.getQuery(), url.getRef());
-            url = uri.toURL();
-            return url;
+            return existing.toURI().toURL();
         } catch (MalformedURLException | URISyntaxException e) {
             return existing;
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/paste/EngineHubPaste.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/paste/EngineHubPaste.java
@@ -24,6 +24,7 @@ import com.google.gson.reflect.TypeToken;
 import com.sk89q.worldedit.util.net.HttpRequest;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -82,7 +83,7 @@ public class EngineHubPaste implements Paster {
                     .execute()
                     .expectResponseCode(200, 204);
 
-            return new URL(response.viewUrl);
+            return URI.create(response.viewUrl).toURL();
         }
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/task/FutureForwardingTask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/task/FutureForwardingTask.java
@@ -82,21 +82,22 @@ public class FutureForwardingTask<V> extends AbstractTask<V> {
         return future.get(timeout, unit);
     }
 
+    // TODO: consider deprecating in favor of Future.State?
     @Override
-    public State getState() {
+    public Task.State getState() {
         if (isCancelled()) {
-            return State.CANCELLED;
+            return Task.State.CANCELLED;
         } else if (isDone()) {
             try {
                 get();
-                return State.SUCCEEDED;
+                return Task.State.SUCCEEDED;
             } catch (InterruptedException e) {
-                return State.CANCELLED;
+                return Task.State.CANCELLED;
             } catch (ExecutionException e) {
-                return State.FAILED;
+                return Task.State.FAILED;
             }
         } else {
-            return State.RUNNING;
+            return Task.State.RUNNING;
         }
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/translation/TranslationManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/translation/TranslationManager.java
@@ -158,7 +158,7 @@ public class TranslationManager {
             // Recurse into other options if not already at the base condition (defaultLocale)
             if (!locale.getCountry().isEmpty()) {
                 // try without country modifier
-                return getTranslation(new Locale(locale.getLanguage()), key);
+                return getTranslation(Locale.of(locale.getLanguage()), key);
             }
             // otherwise, try the default locale
             return getTranslation(defaultLocale, key);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockType.java
@@ -49,21 +49,28 @@ public class BlockType implements Keyed {
     private final Function<BlockState, BlockState> values;
     private final LazyReference<BlockState> defaultState
         = LazyReference.from(this::computeDefaultState);
+    @SuppressWarnings("this-escape")
     private final LazyReference<FuzzyBlockState> emptyFuzzy
         = LazyReference.from(() -> new FuzzyBlockState(this));
+    @SuppressWarnings("this-escape")
     private final LazyReference<Map<String, ? extends Property<?>>> properties
         = LazyReference.from(() -> ImmutableMap.copyOf(WorldEdit.getInstance().getPlatformManager()
         .queryCapability(Capability.GAME_HOOKS).getRegistries().getBlockRegistry().getProperties(this)));
+    @SuppressWarnings("this-escape")
     private final LazyReference<BlockMaterial> blockMaterial
         = LazyReference.from(() -> WorldEdit.getInstance().getPlatformManager()
         .queryCapability(Capability.GAME_HOOKS).getRegistries().getBlockRegistry().getMaterial(this));
+    @SuppressWarnings("this-escape")
     private final LazyReference<Map<Map<Property<?>, Object>, BlockState>> blockStatesMap
         = LazyReference.from(() -> BlockState.generateStateMap(this));
 
+    @SuppressWarnings("this-escape")
     @Deprecated
     private final LazyReference<String> name = LazyReference.from(() -> WorldEdit.getInstance().getPlatformManager()
         .queryCapability(Capability.GAME_HOOKS).getRegistries().getBlockRegistry().getName(this));
+    @SuppressWarnings("this-escape")
     private final LazyReference<Integer> legacyId = LazyReference.from(() -> computeLegacy(0));
+    @SuppressWarnings("this-escape")
     private final LazyReference<Integer> legacyData = LazyReference.from(() -> computeLegacy(1));
 
     public BlockType(String id) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/AnvilChunk13.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/AnvilChunk13.java
@@ -156,7 +156,7 @@ public class AnvilChunk13 implements Chunk {
                     throw new InvalidFormatException("Too short block state table");
                 }
                 currentSerializedValue = blockStatesSerialized[nextSerializedItem++];
-                localBlockId |= (currentSerializedValue & ((1L << bitsNextLong) - 1)) << remainingBits;
+                localBlockId |= (int) (currentSerializedValue & ((1L << bitsNextLong) - 1)) << remainingBits;
                 currentSerializedValue >>>= bitsNextLong;
                 remainingBits = 64 - bitsNextLong;
             } else {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/item/ItemType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/item/ItemType.java
@@ -37,7 +37,7 @@ public class ItemType implements Keyed {
     public static final NamespacedRegistry<ItemType> REGISTRY = new NamespacedRegistry<>("item type", true);
 
     private final String id;
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "this-escape"})
     private final LazyReference<String> name = LazyReference.from(() -> {
         String name = GuavaUtil.firstNonNull(
             WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.GAME_HOOKS)
@@ -46,10 +46,12 @@ public class ItemType implements Keyed {
         );
         return name.isEmpty() ? id() : name;
     });
+    @SuppressWarnings("this-escape")
     private final LazyReference<Component> richName = LazyReference.from(() ->
         WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.GAME_HOOKS)
             .getRegistries().getItemRegistry().getRichName(this)
     );
+    @SuppressWarnings("this-escape")
     private final LazyReference<ItemMaterial> itemMaterial = LazyReference.from(() ->
         WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.GAME_HOOKS)
             .getRegistries().getItemRegistry().getMaterial(this)

--- a/worldedit-fabric/build.gradle.kts
+++ b/worldedit-fabric/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     `java-library`
 }
 
-applyPlatformAndCoreConfiguration(javaRelease = 17)
+applyPlatformAndCoreConfiguration()
 applyShadowConfiguration()
 
 val minecraftVersion = "1.20.4"

--- a/worldedit-fabric/build.gradle.kts
+++ b/worldedit-fabric/build.gradle.kts
@@ -2,6 +2,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import net.fabricmc.loom.api.LoomGradleExtensionAPI
 import net.fabricmc.loom.configuration.FabricApiExtension
 import net.fabricmc.loom.task.RemapJarTask
+import net.fabricmc.loom.task.RunGameTask
 
 plugins {
     id("fabric-loom")
@@ -18,6 +19,10 @@ val fabricApiConfiguration: Configuration = configurations.create("fabricApi")
 
 configure<LoomGradleExtensionAPI> {
     accessWidenerPath.set(project.file("src/main/resources/worldedit.accesswidener"))
+}
+
+tasks.withType<RunGameTask>().configureEach {
+    javaLauncher.set(javaToolchains.launcherFor(java.toolchain))
 }
 
 repositories {

--- a/worldedit-forge/build.gradle.kts
+++ b/worldedit-forge/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     `java-library`
 }
 
-applyPlatformAndCoreConfiguration(javaRelease = 17)
+applyPlatformAndCoreConfiguration()
 applyShadowConfiguration()
 
 val minecraftVersion = "1.20.4"

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeResourceLoader.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeResourceLoader.java
@@ -23,6 +23,7 @@ import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.util.io.WorldEditResourceLoader;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 
 public class ForgeResourceLoader extends WorldEditResourceLoader  {
@@ -33,9 +34,9 @@ public class ForgeResourceLoader extends WorldEditResourceLoader  {
 
     private static URL getResourceForgeHack(String location) throws IOException {
         try {
-            URL url = new URL("modjar://worldedit/" + location);
+            URL url = URI.create("modjar://worldedit/" + location).toURL();
             try {
-                url.openStream();
+                url.openStream().close();
             } catch (IOException e) {
                 // doesn't actually exist
                 return null;

--- a/worldedit-sponge/build.gradle.kts
+++ b/worldedit-sponge/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("org.spongepowered.gradle.vanilla")
 }
 
-applyPlatformAndCoreConfiguration(javaRelease = 17)
+applyPlatformAndCoreConfiguration()
 applyShadowConfiguration()
 
 repositories {


### PR DESCRIPTION
- Fix some new warnings
- Removed sponge from build, as it simply isn't maintained well currently. May be removed entirely in the future
- Remove 1.18 support from Bukkit as it breaks under 21 for some reason
- Fix a bug in `ForwardSeekableInputStream`

This PR is not to be merged until 1.20.5.