### PR TITLE
Disable chunk batching by default

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -272,7 +272,7 @@ public class EditSession implements Extent, AutoCloseable {
             @SuppressWarnings("deprecation")
             MultiStageReorder reorder = new MultiStageReorder(extent, false);
             extent = traceIfNeeded(reorderExtent = reorder);
-            extent = traceIfNeeded(chunkBatchingExtent = new ChunkBatchingExtent(extent));
+            extent = traceIfNeeded(chunkBatchingExtent = new ChunkBatchingExtent(extent, false));
             extent = wrapExtent(extent, eventBus, event, Stage.BEFORE_REORDER);
             if (watchdog != null) {
                 // reset before buffering extents, since they may buffer all changes
@@ -360,9 +360,6 @@ public class EditSession implements Extent, AutoCloseable {
      * chunk batching}.
      */
     public void enableStandardMode() {
-        if (chunkBatchingExtent != null) {
-            setBatchingChunks(true);
-        }
     }
 
     /**


### PR DESCRIPTION
This disables chunk batching by default in edit sessions, unless batching is explicitly enabled.

In modern versions, it doesn't feel like this makes sense for most use cases, with the memory and overhead outweighing the benefits.