### PR TITLE
Deprecate bundled item data

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitItemRegistry.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitItemRegistry.java
@@ -24,7 +24,7 @@ import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BundledItemRegistry;
 
-@SuppressWarnings("deprecation")
+@SuppressWarnings("removal")
 class BukkitItemRegistry extends BundledItemRegistry {
     @Override
     public Component getRichName(ItemType itemType) {

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitItemRegistry.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitItemRegistry.java
@@ -24,6 +24,7 @@ import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BundledItemRegistry;
 
+@SuppressWarnings("deprecation")
 class BukkitItemRegistry extends BundledItemRegistry {
     @Override
     public Component getRichName(ItemType itemType) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -71,7 +71,6 @@ import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.registry.BundledBlockData;
-import com.sk89q.worldedit.world.registry.BundledItemData;
 import com.sk89q.worldedit.world.registry.LegacyMapper;
 import org.apache.logging.log4j.Logger;
 
@@ -405,8 +404,7 @@ public final class WorldEdit {
      */
     public void loadMappings() {
         BundledBlockData.getInstance(); // Load block registry
-        BundledItemData.getInstance(); // Load item registry
-        LegacyMapper.getInstance(); // Load item registry
+        LegacyMapper.getInstance(); // Load legacy mappings
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/item/ItemType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/item/ItemType.java
@@ -111,7 +111,7 @@ public class ItemType implements Keyed {
      * @return The material
      * @deprecated Deprecated without alternative
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     @SuppressWarnings("removal")
     public ItemMaterial getMaterial() {
         return itemMaterial.getValue();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/item/ItemType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/item/ItemType.java
@@ -51,7 +51,7 @@ public class ItemType implements Keyed {
         WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.GAME_HOOKS)
             .getRegistries().getItemRegistry().getRichName(this)
     );
-    @SuppressWarnings("this-escape")
+    @SuppressWarnings("removal")
     private final LazyReference<ItemMaterial> itemMaterial = LazyReference.from(() ->
         WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.GAME_HOOKS)
             .getRegistries().getItemRegistry().getMaterial(this)
@@ -109,7 +109,10 @@ public class ItemType implements Keyed {
      * Get the material for this ItemType.
      *
      * @return The material
+     * @deprecated Deprecated without alternative
      */
+    @Deprecated
+    @SuppressWarnings("removal")
     public ItemMaterial getMaterial() {
         return itemMaterial.getValue();
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledItemData.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledItemData.java
@@ -49,7 +49,7 @@ import javax.annotation.Nullable;
  *
  * @deprecated Deprecated without replacement.
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public final class BundledItemData {
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
@@ -111,7 +111,7 @@ public final class BundledItemData {
      * @deprecated Deprecated without alternative
      */
     @Nullable
-    @Deprecated
+    @Deprecated(forRemoval = true)
     @SuppressWarnings("removal")
     public ItemMaterial getMaterialById(String id) {
         ItemEntry entry = findById(id);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledItemData.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledItemData.java
@@ -46,7 +46,10 @@ import javax.annotation.Nullable;
  * <p>The data is read from a JSON file that is bundled with WorldEdit. If
  * reading fails (which occurs when this class is first instantiated), then
  * the methods will return {@code null}s for all items.</p>
+ *
+ * @deprecated Deprecated without replacement.
  */
+@Deprecated
 public final class BundledItemData {
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
@@ -91,6 +94,7 @@ public final class BundledItemData {
      * @return the entry, or null
      */
     @Nullable
+    @Deprecated
     public ItemEntry findById(String id) {
         // If it has no namespace, assume minecraft.
         if (!id.contains(":")) {
@@ -104,8 +108,11 @@ public final class BundledItemData {
      *
      * @param id the string ID
      * @return the material's properties, or null
+     * @deprecated Deprecated without alternative
      */
     @Nullable
+    @Deprecated
+    @SuppressWarnings("removal")
     public ItemMaterial getMaterialById(String id) {
         ItemEntry entry = findById(id);
         if (entry != null) {
@@ -121,6 +128,7 @@ public final class BundledItemData {
      *
      * @return the instance
      */
+    @Deprecated
     public static BundledItemData getInstance() {
         if (INSTANCE == null) {
             INSTANCE = new BundledItemData();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledItemRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledItemRegistry.java
@@ -33,14 +33,16 @@ import javax.annotation.Nullable;
  *
  * @deprecated Use the platform Item Registries
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class BundledItemRegistry implements ItemRegistry {
 
+    @SuppressWarnings("removal")
     private BundledItemData.ItemEntry getEntryById(ItemType itemType) {
         return BundledItemData.getInstance().findById(itemType.id());
     }
 
     @Override
+    @SuppressWarnings("removal")
     public Component getRichName(ItemType itemType) {
         BundledItemData.ItemEntry itemEntry = getEntryById(itemType);
         if (itemEntry != null && !itemEntry.localizedName.equals("Air")) {
@@ -59,7 +61,7 @@ public class BundledItemRegistry implements ItemRegistry {
     @Override
     @Deprecated
     // dumb_intellij.jpg
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     public String getName(ItemType itemType) {
         BundledItemData.ItemEntry itemEntry = getEntryById(itemType);
         if (itemEntry != null) {
@@ -76,7 +78,7 @@ public class BundledItemRegistry implements ItemRegistry {
 
     @Nullable
     @Override
-    @Deprecated
+    @Deprecated(forRemoval = true)
     @SuppressWarnings("removal")
     public ItemMaterial getMaterial(ItemType itemType) {
         return new PassthroughItemMaterial(BundledItemData.getInstance().getMaterialById(itemType.id()));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledItemRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledItemRegistry.java
@@ -30,7 +30,10 @@ import javax.annotation.Nullable;
 /**
  * A item registry that uses {@link BundledItemRegistry} to serve information
  * about items.
+ *
+ * @deprecated Use the platform Item Registries
  */
+@Deprecated
 public class BundledItemRegistry implements ItemRegistry {
 
     private BundledItemData.ItemEntry getEntryById(ItemType itemType) {
@@ -73,6 +76,8 @@ public class BundledItemRegistry implements ItemRegistry {
 
     @Nullable
     @Override
+    @Deprecated
+    @SuppressWarnings("removal")
     public ItemMaterial getMaterial(ItemType itemType) {
         return new PassthroughItemMaterial(BundledItemData.getInstance().getMaterialById(itemType.id()));
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledRegistries.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledRegistries.java
@@ -65,6 +65,7 @@ public class BundledRegistries implements Registries {
     }
 
     private final BundledBlockRegistry blockRegistry = new BundledBlockRegistry();
+    @SuppressWarnings("deprecation")
     private final BundledItemRegistry itemRegistry = new BundledItemRegistry();
     private final NullEntityRegistry entityRegistry = new NullEntityRegistry();
     private final NullBiomeRegistry biomeRegistry = new NullBiomeRegistry();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledRegistries.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledRegistries.java
@@ -65,7 +65,7 @@ public class BundledRegistries implements Registries {
     }
 
     private final BundledBlockRegistry blockRegistry = new BundledBlockRegistry();
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     private final BundledItemRegistry itemRegistry = new BundledItemRegistry();
     private final NullEntityRegistry entityRegistry = new NullEntityRegistry();
     private final NullBiomeRegistry biomeRegistry = new NullBiomeRegistry();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/ItemMaterial.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/ItemMaterial.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit.world.registry;
 import com.sk89q.worldedit.internal.util.DeprecationUtil;
 import com.sk89q.worldedit.internal.util.NonAbstractForCompatibility;
 
+@Deprecated(forRemoval = true)
 public interface ItemMaterial {
     /**
      * Gets the the maximum quantity of this item that can be in a single stack.
@@ -38,7 +39,9 @@ public interface ItemMaterial {
      * Gets the the maximum quantity of this item that can be in a single stack.
      *
      * @return the maximum quantity
+     * @deprecated Deprecated with no alternative
      */
+    @Deprecated(forRemoval = true)
     @NonAbstractForCompatibility(delegateName = "getMaxStackSize", delegateParams = {})
     default int maxStackSize() {
         DeprecationUtil.checkDelegatingOverride(getClass());
@@ -60,7 +63,9 @@ public interface ItemMaterial {
      * Gets the the maximum damage this item can take before being broken.
      *
      * @return the maximum damage, or 0 if not applicable
+     * @deprecated Deprecated with no alternative
      */
+    @Deprecated(forRemoval = true)
     @NonAbstractForCompatibility(delegateName = "getMaxDamage", delegateParams = {})
     default int maxDamage() {
         DeprecationUtil.checkDelegatingOverride(getClass());

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/ItemRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/ItemRegistry.java
@@ -63,7 +63,10 @@ public interface ItemRegistry {
      *
      * @param itemType the item
      * @return the material, or null if the material information is not known
+     * @deprecated ItemMaterial is deprecated with no alternative.
      */
+    @Deprecated(forRemoval = true)
     @Nullable
+    @SuppressWarnings("removal")
     ItemMaterial getMaterial(ItemType itemType);
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/PassthroughItemMaterial.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/PassthroughItemMaterial.java
@@ -23,6 +23,8 @@ import javax.annotation.Nullable;
 
 import static com.sk89q.worldedit.util.GuavaUtil.firstNonNull;
 
+@Deprecated(forRemoval = true)
+@SuppressWarnings("removal")
 public class PassthroughItemMaterial implements ItemMaterial {
 
     private static final ItemMaterial DEFAULT_MATERIAL = new SimpleItemMaterial(0, 0);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/SimpleItemMaterial.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/SimpleItemMaterial.java
@@ -19,5 +19,7 @@
 
 package com.sk89q.worldedit.world.registry;
 
+@Deprecated(forRemoval = true)
+@SuppressWarnings("removal")
 public record SimpleItemMaterial(int maxStackSize, int maxDamage) implements ItemMaterial {
 }

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricItemRegistry.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricItemRegistry.java
@@ -25,6 +25,7 @@ import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BundledItemRegistry;
 
+@SuppressWarnings("deprecation")
 public class FabricItemRegistry extends BundledItemRegistry {
 
     @Override

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricItemRegistry.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricItemRegistry.java
@@ -25,7 +25,7 @@ import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BundledItemRegistry;
 
-@SuppressWarnings("deprecation")
+@SuppressWarnings("removal")
 public class FabricItemRegistry extends BundledItemRegistry {
 
     @Override

--- a/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgeItemRegistry.java
+++ b/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgeItemRegistry.java
@@ -25,6 +25,7 @@ import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BundledItemRegistry;
 
+@SuppressWarnings("deprecation")
 public class NeoForgeItemRegistry extends BundledItemRegistry {
 
     @Override

--- a/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgeItemRegistry.java
+++ b/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgeItemRegistry.java
@@ -25,7 +25,7 @@ import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BundledItemRegistry;
 
-@SuppressWarnings("deprecation")
+@SuppressWarnings("removal")
 public class NeoForgeItemRegistry extends BundledItemRegistry {
 
     @Override

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeItemRegistry.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeItemRegistry.java
@@ -29,7 +29,7 @@ import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.registry.RegistryTypes;
 
-@SuppressWarnings("deprecation")
+@SuppressWarnings("removal")
 public class SpongeItemRegistry extends BundledItemRegistry {
 
     @Override

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeItemRegistry.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeItemRegistry.java
@@ -29,6 +29,7 @@ import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.registry.RegistryTypes;
 
+@SuppressWarnings("deprecation")
 public class SpongeItemRegistry extends BundledItemRegistry {
 
     @Override


### PR DESCRIPTION
This PR deprecates the concept of bundled item data, as well as the concept of "item material". This was added but never actually used. It's not very mod-compatible, and also requires storing increasingly large numbers of JSON files within the repo and jar files.

Due to the fact that WorldEdit never uses these at all, and that the bundled item registry is loaded when first accessed, this means we can remove the call to actually load it from WorldEdit. If something does happen to be using this deprecated API, it'll trigger it to be loaded upon first access.