### PR TITLE
Forward `getBlock` and `getFullBlock` to extents chain

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -699,12 +699,12 @@ public class EditSession implements Extent, AutoCloseable {
 
     @Override
     public BlockState getBlock(BlockVector3 position) {
-        return world.getBlock(position);
+        return bypassNone.getBlock(position);
     }
 
     @Override
     public BaseBlock getFullBlock(BlockVector3 position) {
-        return world.getFullBlock(position);
+        return bypassNone.getFullBlock(position);
     }
 
     /**


### PR DESCRIPTION
Forward `getBlock` and `getFullBlock` to the extents chain. I don't see the reason why it must directly access world extent. For example the `getBiome` already passes its call to extents chain:
https://github.com/EngineHub/WorldEdit/blob/00148305cea5fe99187b5b30912349a5c4c8b8b7/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java#L690-L693

After this change, people can override `getBlock` and `getFullBlock` in `AbstractDelegateExtent` to make some modifications in getting blocks. For example in plugins that adds custom blocks and they need to modify block nbt a bit.