### PR TITLE
Fix structure block CUI resetting selections cross-world.

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/cui/ServerCUIHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/cui/ServerCUIHandler.java
@@ -29,6 +29,7 @@ import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.regions.RegionSelector;
 import com.sk89q.worldedit.regions.selector.CuboidRegionSelector;
 import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockTypes;
 import org.enginehub.linbus.tree.LinCompoundTag;
@@ -65,7 +66,11 @@ public class ServerCUIHandler {
     @Nullable
     public static BaseBlock createStructureBlock(Player player) {
         LocalSession session = WorldEdit.getInstance().getSessionManager().get(player);
-        RegionSelector regionSelector = session.getRegionSelector(player.getWorld());
+        World selectionWorld = session.getSelectionWorld();
+        if (!player.getWorld().equals(selectionWorld)) {
+            return null;
+        }
+        RegionSelector regionSelector = session.getRegionSelector(selectionWorld);
 
         int posX;
         int posY;


### PR DESCRIPTION
Previously, if a world override was active (e.g. via //world), createStructureBlock would always attempt to check the player (entity) world rather than their selection world. This led to the selection getting reset immediately. Now, we first check if there's anything to render (i.e. if the selection is in the current world) before attempting to get the selection from the player's session.