### PR TITLE
Lazily compute BlockState#getAsString

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitAdapter.java
@@ -491,7 +491,7 @@ public class BukkitAdapter {
         if (cacheKey == BlockStateIdAccess.invalidId()) {
             cacheKey = block.hashCode();
         }
-        return blockDataCache.computeIfAbsent(cacheKey, input -> Bukkit.createBlockData(block.getAsString())).clone();
+        return blockDataCache.computeIfAbsent(cacheKey, input -> Bukkit.createBlockData(block.toImmutableState().getAsString())).clone();
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BaseBlock.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BaseBlock.java
@@ -193,7 +193,7 @@ public class BaseBlock implements BlockStateHolder<BaseBlock>, TileEntityBlock {
     }
 
     /**
-     * Gets a string representation of this BaseBlock, in the format expected WorldEdit's block parsers.
+     * Gets a string representation of this BaseBlock, in the format expected by WorldEdit's block parsers.
      *
      * <p>
      * If NBT data is present, it will be included in the string. If you only want the underlying block state, call

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BaseBlock.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BaseBlock.java
@@ -193,7 +193,7 @@ public class BaseBlock implements BlockStateHolder<BaseBlock>, TileEntityBlock {
     }
 
     /**
-     * Gets a string representation of this BaseBlock.
+     * Gets a string representation of this BaseBlock, in the format expected by the block parser.
      *
      * <p>
      * If NBT data is present, it will be included in the string. If you only want the underlying block state, call

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BaseBlock.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BaseBlock.java
@@ -193,7 +193,7 @@ public class BaseBlock implements BlockStateHolder<BaseBlock>, TileEntityBlock {
     }
 
     /**
-     * Gets a string representation of this BaseBlock, in the format expected by the block parser.
+     * Gets a string representation of this BaseBlock, in the format expected WorldEdit's block parsers.
      *
      * <p>
      * If NBT data is present, it will be included in the string. If you only want the underlying block state, call

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BaseBlock.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BaseBlock.java
@@ -192,14 +192,29 @@ public class BaseBlock implements BlockStateHolder<BaseBlock>, TileEntityBlock {
         return ret;
     }
 
+    /**
+     * Gets a string representation of this BaseBlock.
+     *
+     * <p>
+     * If NBT data is present, it will be included in the string. If you only want the underlying block state, call
+     * this method on the return value from {@link #toImmutableState()} instead.
+     * </p>
+     *
+     * @return The string representation
+     */
     @Override
-    public String toString() {
+    public String getAsString() {
         String nbtString = "";
         if (nbtData != null) {
             nbtString = LinStringIO.writeToString(nbtData.getValue());
         }
 
         return blockState.getAsString() + nbtString;
+    }
+
+    @Override
+    public String toString() {
+        return getAsString();
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockState.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockState.java
@@ -66,6 +66,7 @@ public class BlockState implements BlockStateHolder<BlockState> {
     private final Map<Property<?>, Object> values;
 
     private final BaseBlock emptyBaseBlock;
+    private final LazyReference<String> lazyStringRepresentation;
 
     // Neighbouring state table.
     private Table<Property<?>, Object, BlockState> states;
@@ -79,6 +80,7 @@ public class BlockState implements BlockStateHolder<BlockState> {
         this.blockType = blockType;
         this.values = new LinkedHashMap<>();
         this.emptyBaseBlock = new BaseBlock(this);
+        this.lazyStringRepresentation = LazyReference.from(BlockStateHolder.super::getAsString);
     }
 
     /**
@@ -268,6 +270,11 @@ public class BlockState implements BlockStateHolder<BlockState> {
     BlockState setState(final Property<?> property, final Object value) {
         this.values.put(property, value);
         return this;
+    }
+
+    @Override
+    public String getAsString() {
+        return lazyStringRepresentation.getValue();
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockStateHolder.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockStateHolder.java
@@ -134,7 +134,7 @@ public interface BlockStateHolder<B extends BlockStateHolder<B>> extends Pattern
     }
 
     /**
-     * Gets a String representation of this BlockStateHolder.
+     * Gets a String representation of this BlockStateHolder, in the format expected by the block parser.
      *
      * @return a string representation
      */

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockStateHolder.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockStateHolder.java
@@ -134,7 +134,7 @@ public interface BlockStateHolder<B extends BlockStateHolder<B>> extends Pattern
     }
 
     /**
-     * Gets a String representation of this BlockStateHolder, in the format expected by the block parser.
+     * Gets a String representation of this BlockStateHolder, in the format expected by WorldEdit's block parsers.
      *
      * @return a string representation
      */

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockStateHolder.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockStateHolder.java
@@ -133,6 +133,11 @@ public interface BlockStateHolder<B extends BlockStateHolder<B>> extends Pattern
         return toBaseBlock();
     }
 
+    /**
+     * Gets a String representation of this BlockStateHolder.
+     *
+     * @return a string representation
+     */
     default String getAsString() {
         if (getStates().isEmpty()) {
             return this.getBlockType().id();


### PR DESCRIPTION
This PR adds lazy computation of the BlockState#getAsString (and therefore toString) method, allowing this to be computed once rather than calculated every time it's called.

This also partially benefits BaseBlock#toString, as it delegates to this method for the BlockState portion of the string, with NBT data appended to the end.