### PR TITLE
Shutdown executor service on disable

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -327,6 +327,7 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
             config.unload();
         }
         this.getServer().getScheduler().cancelTasks(this);
+        worldEdit.getExecutorService().shutdown();
     }
 
     /**

--- a/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIWorldEdit.java
+++ b/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIWorldEdit.java
@@ -205,6 +205,7 @@ public class CLIWorldEdit {
         WorldEdit worldEdit = WorldEdit.getInstance();
         worldEdit.getSessionManager().unload();
         worldEdit.getPlatformManager().unregister(platform);
+        WorldEdit.getInstance().getExecutorService().shutdown();
     }
 
     public FileRegistries getFileRegistries() {

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorldEdit.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorldEdit.java
@@ -299,6 +299,7 @@ public class FabricWorldEdit implements ModInitializer {
         WorldEdit worldEdit = WorldEdit.getInstance();
         worldEdit.getSessionManager().unload();
         WorldEdit.getInstance().getEventBus().post(new PlatformUnreadyEvent(platform));
+        WorldEdit.getInstance().getExecutorService().shutdown();
     }
 
     private boolean skipEvents() {

--- a/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgeWorldEdit.java
+++ b/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgeWorldEdit.java
@@ -257,6 +257,7 @@ public class NeoForgeWorldEdit {
         WorldEdit worldEdit = WorldEdit.getInstance();
         worldEdit.getSessionManager().unload();
         WorldEdit.getInstance().getEventBus().post(new PlatformUnreadyEvent(platform));
+        WorldEdit.getInstance().getExecutorService().shutdown();
     }
 
     @SubscribeEvent

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorldEdit.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorldEdit.java
@@ -244,6 +244,7 @@ public class SpongeWorldEdit {
         WorldEdit worldEdit = WorldEdit.getInstance();
         worldEdit.getSessionManager().unload();
         WorldEdit.getInstance().getEventBus().post(new PlatformUnreadyEvent(platform));
+        WorldEdit.getInstance().getExecutorService().shutdown();
     }
 
     @Listener


### PR DESCRIPTION
Continuation of https://github.com/EngineHub/WorldEdit/pull/2460 that purely shuts down the executor service, but does it for all platforms.