### PR TITLE
Refactor PlatformManager to use locks

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformManager.java
@@ -251,16 +251,7 @@ public class PlatformManager {
         Platform preferred = null;
         Preference highest = null;
 
-        List<Platform> availablePlatforms;
-        platformsLock.readLock().lock();
-
-        try {
-            availablePlatforms = getPlatforms();
-        } finally {
-            platformsLock.readLock().unlock();
-        }
-
-        for (Platform platform : availablePlatforms) {
+        for (Platform platform : getPlatforms()) {
             Preference preference = platform.getCapabilities().get(capability);
             if (preference != null && (highest == null || preference.isPreferredOver(highest))) {
                 preferred = platform;


### PR DESCRIPTION
This is mostly a test to see if we can replace the synchronized methods in this class with two locks, one for the platforms and one for the capability preferences.

Theoretically this should improve performance due to the overhead of synchronization, and the fact that platforms & capabilities are independent systems that can be locked separately. 