### PR TITLE
Remove <1.16 //drawsel max size handling

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/cui/ServerCUIHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/cui/ServerCUIHandler.java
@@ -47,10 +47,7 @@ public class ServerCUIHandler {
     }
 
     public static int getMaxServerCuiSize() {
-        int dataVersion = WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.GAME_HOOKS).getDataVersion();
-
-        // 1.16 increased maxSize to 48.
-        return dataVersion >= 2566 ? 48 : 32;
+        return 48;
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/cui/ServerCUIHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/cui/ServerCUIHandler.java
@@ -23,7 +23,6 @@ import com.sk89q.worldedit.IncompleteRegionException;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.entity.Player;
-import com.sk89q.worldedit.extension.platform.Capability;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.regions.RegionSelector;


### PR DESCRIPTION
We'd previously had compatibility for <1.16 here, which we can remove as we do not support versions that old. This removes a queryCapability call that happens on selections.