### PR TITLE
Fix queryRel for //deform and //brush deform

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -2440,9 +2440,12 @@ public class EditSession implements Extent, AutoCloseable {
 
         final DoubleArrayList<BlockVector3, BaseBlock> queue = new DoubleArrayList<>(false);
 
-        for (BlockVector3 position : region) {
+        for (BlockVector3 targetBlockPosition : region) {
+            final Vector3 targetPosition = targetBlockPosition.toVector3();
+            environment.setCurrentBlock(targetPosition);
+
             // offset, scale
-            final Vector3 scaled = position.toVector3().subtract(zero).divide(unit);
+            final Vector3 scaled = targetPosition.subtract(zero).divide(unit);
 
             // transform
             expression.evaluate(new double[]{ scaled.x(), scaled.y(), scaled.z() }, timeout);
@@ -2453,7 +2456,7 @@ public class EditSession implements Extent, AutoCloseable {
             final BaseBlock material = world.getFullBlock(sourcePosition);
 
             // queue operation
-            queue.put(position, material);
+            queue.put(targetBlockPosition, material);
         }
 
         int affected = 0;


### PR DESCRIPTION
Without knowing the current block, queryRel can't address a block relative to it and will address relative to the world origin.