### PR TITLE
Cleanup registry init

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitAdapter.java
@@ -82,6 +82,7 @@ public class BukkitAdapter {
 
     static {
         TO_BLOCK_CONTEXT.setRestricted(false);
+        TO_BLOCK_CONTEXT.setTryLegacy(false);
     }
 
     /**
@@ -334,7 +335,8 @@ public class BukkitAdapter {
      */
     public static Material adapt(ItemType itemType) {
         checkNotNull(itemType);
-        return Material.matchMaterial(itemType.id());
+        var key = checkNotNull(NamespacedKey.fromString(itemType.id()), "Item type key is invalid");
+        return Registry.MATERIAL.get(key);
     }
 
     /**
@@ -345,7 +347,8 @@ public class BukkitAdapter {
      */
     public static Material adapt(BlockType blockType) {
         checkNotNull(blockType);
-        return Material.matchMaterial(blockType.id());
+        var key = checkNotNull(NamespacedKey.fromString(blockType.id()), "Item type key is invalid");
+        return Registry.MATERIAL.get(key);
     }
 
     /**

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitAdapter.java
@@ -335,7 +335,7 @@ public class BukkitAdapter {
      */
     public static Material adapt(ItemType itemType) {
         checkNotNull(itemType);
-        var key = checkNotNull(NamespacedKey.fromString(itemType.id()), "Item type key is invalid");
+        NamespacedKey key = checkNotNull(NamespacedKey.fromString(itemType.id()), "Item type key is invalid");
         return Registry.MATERIAL.get(key);
     }
 
@@ -347,7 +347,7 @@ public class BukkitAdapter {
      */
     public static Material adapt(BlockType blockType) {
         checkNotNull(blockType);
-        var key = checkNotNull(NamespacedKey.fromString(blockType.id()), "Item type key is invalid");
+        NamespacedKey key = checkNotNull(NamespacedKey.fromString(blockType.id()), "Block type key is invalid");
         return Registry.MATERIAL.get(key);
     }
 

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -216,8 +216,9 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
         });
         // Block & Item
         Registry.MATERIAL.forEach(material -> {
+            String key = material.getKey().toString();
             if (material.isBlock()) {
-                BlockType.REGISTRY.register(material.getKey().toString(), new BlockType(material.getKey().toString(), blockState -> {
+                BlockType.REGISTRY.register(key, new BlockType(key, blockState -> {
                     // TODO Use something way less hacky than this.
                     ParserContext context = new ParserContext();
                     context.setPreferringWildcard(true);
@@ -234,13 +235,13 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
                         }
                         return defaultState;
                     } catch (InputParseException e) {
-                        getLogger().log(Level.WARNING, "Error loading block state for " + material.getKey(), e);
+                        getLogger().log(Level.WARNING, "Error loading block state for " + key, e);
                         return blockState;
                     }
                 }));
             }
             if (material.isItem()) {
-                ItemType.REGISTRY.register(material.getKey().toString(), new ItemType(material.getKey().toString()));
+                ItemType.REGISTRY.register(key, new ItemType(key));
             }
         });
         // Entity
@@ -262,10 +263,12 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
     private void setupTags() {
         // Tags
         for (Tag<Material> blockTag : Bukkit.getTags(Tag.REGISTRY_BLOCKS, Material.class)) {
-            BlockCategory.REGISTRY.register(blockTag.getKey().toString(), new BlockCategory(blockTag.getKey().toString()));
+            String key = blockTag.getKey().toString();
+            BlockCategory.REGISTRY.register(key, new BlockCategory(key));
         }
         for (Tag<Material> itemTag : Bukkit.getTags(Tag.REGISTRY_ITEMS, Material.class)) {
-            ItemCategory.REGISTRY.register(itemTag.getKey().toString(), new ItemCategory(itemTag.getKey().toString()));
+            String key = itemTag.getKey().toString();
+            ItemCategory.REGISTRY.register(key, new ItemCategory(key));
         }
     }
 

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorldEdit.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorldEdit.java
@@ -218,38 +218,44 @@ public class FabricWorldEdit implements ModInitializer {
     private void setupRegistries(MinecraftServer server) {
         // Blocks
         for (ResourceLocation name : server.registryAccess().registryOrThrow(Registries.BLOCK).keySet()) {
-            if (BlockType.REGISTRY.get(name.toString()) == null) {
-                BlockType.REGISTRY.register(name.toString(), new BlockType(name.toString(),
+            String key = name.toString();
+            if (BlockType.REGISTRY.get(key) == null) {
+                BlockType.REGISTRY.register(key, new BlockType(key,
                     input -> FabricAdapter.adapt(FabricAdapter.adapt(input.getBlockType()).defaultBlockState())));
             }
         }
         // Items
         for (ResourceLocation name : server.registryAccess().registryOrThrow(Registries.ITEM).keySet()) {
-            if (ItemType.REGISTRY.get(name.toString()) == null) {
-                ItemType.REGISTRY.register(name.toString(), new ItemType(name.toString()));
+            String key = name.toString();
+            if (ItemType.REGISTRY.get(key) == null) {
+                ItemType.REGISTRY.register(key, new ItemType(key));
             }
         }
         // Entities
         for (ResourceLocation name : server.registryAccess().registryOrThrow(Registries.ENTITY_TYPE).keySet()) {
-            if (EntityType.REGISTRY.get(name.toString()) == null) {
-                EntityType.REGISTRY.register(name.toString(), new EntityType(name.toString()));
+            String key = name.toString();
+            if (EntityType.REGISTRY.get(key) == null) {
+                EntityType.REGISTRY.register(key, new EntityType(key));
             }
         }
         // Biomes
         for (ResourceLocation name : server.registryAccess().registryOrThrow(Registries.BIOME).keySet()) {
-            if (BiomeType.REGISTRY.get(name.toString()) == null) {
-                BiomeType.REGISTRY.register(name.toString(), new BiomeType(name.toString()));
+            String key = name.toString();
+            if (BiomeType.REGISTRY.get(key) == null) {
+                BiomeType.REGISTRY.register(key, new BiomeType(key));
             }
         }
         // Tags
         server.registryAccess().registryOrThrow(Registries.BLOCK).getTagNames().map(TagKey::location).forEach(name -> {
-            if (BlockCategory.REGISTRY.get(name.toString()) == null) {
-                BlockCategory.REGISTRY.register(name.toString(), new BlockCategory(name.toString()));
+            String key = name.toString();
+            if (BlockCategory.REGISTRY.get(key) == null) {
+                BlockCategory.REGISTRY.register(key, new BlockCategory(key));
             }
         });
         server.registryAccess().registryOrThrow(Registries.ITEM).getTagNames().map(TagKey::location).forEach(name -> {
-            if (ItemCategory.REGISTRY.get(name.toString()) == null) {
-                ItemCategory.REGISTRY.register(name.toString(), new ItemCategory(name.toString()));
+            String key = name.toString();
+            if (ItemCategory.REGISTRY.get(key) == null) {
+                ItemCategory.REGISTRY.register(key, new ItemCategory(key));
             }
         });
         Registry<Biome> biomeRegistry = server.registryAccess().registryOrThrow(Registries.BIOME);
@@ -269,14 +275,16 @@ public class FabricWorldEdit implements ModInitializer {
         });
         // Features
         for (ResourceLocation name : server.registryAccess().registryOrThrow(Registries.CONFIGURED_FEATURE).keySet()) {
-            if (ConfiguredFeatureType.REGISTRY.get(name.toString()) == null) {
-                ConfiguredFeatureType.REGISTRY.register(name.toString(), new ConfiguredFeatureType(name.toString()));
+            String key = name.toString();
+            if (ConfiguredFeatureType.REGISTRY.get(key) == null) {
+                ConfiguredFeatureType.REGISTRY.register(key, new ConfiguredFeatureType(key));
             }
         }
         // Structures
         for (ResourceLocation name : server.registryAccess().registryOrThrow(Registries.STRUCTURE).keySet()) {
-            if (StructureType.REGISTRY.get(name.toString()) == null) {
-                StructureType.REGISTRY.register(name.toString(), new StructureType(name.toString()));
+            String key = name.toString();
+            if (StructureType.REGISTRY.get(key) == null) {
+                StructureType.REGISTRY.register(key, new StructureType(key));
             }
         }
     }

--- a/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgeWorldEdit.java
+++ b/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgeWorldEdit.java
@@ -157,38 +157,44 @@ public class NeoForgeWorldEdit {
     private void setupRegistries(MinecraftServer server) {
         // Blocks
         for (ResourceLocation name : BuiltInRegistries.BLOCK.keySet()) {
-            if (BlockType.REGISTRY.get(name.toString()) == null) {
-                BlockType.REGISTRY.register(name.toString(), new BlockType(name.toString(),
+            String key = name.toString();
+            if (BlockType.REGISTRY.get(key) == null) {
+                BlockType.REGISTRY.register(key, new BlockType(key,
                     input -> NeoForgeAdapter.adapt(NeoForgeAdapter.adapt(input.getBlockType()).defaultBlockState())));
             }
         }
         // Items
         for (ResourceLocation name : BuiltInRegistries.ITEM.keySet()) {
-            if (ItemType.REGISTRY.get(name.toString()) == null) {
-                ItemType.REGISTRY.register(name.toString(), new ItemType(name.toString()));
+            String key = name.toString();
+            if (ItemType.REGISTRY.get(key) == null) {
+                ItemType.REGISTRY.register(key, new ItemType(key));
             }
         }
         // Entities
         for (ResourceLocation name : BuiltInRegistries.ENTITY_TYPE.keySet()) {
-            if (EntityType.REGISTRY.get(name.toString()) == null) {
-                EntityType.REGISTRY.register(name.toString(), new EntityType(name.toString()));
+            String key = name.toString();
+            if (EntityType.REGISTRY.get(key) == null) {
+                EntityType.REGISTRY.register(key, new EntityType(key));
             }
         }
         // Biomes
         for (ResourceLocation name : server.registryAccess().registryOrThrow(Registries.BIOME).keySet()) {
-            if (BiomeType.REGISTRY.get(name.toString()) == null) {
-                BiomeType.REGISTRY.register(name.toString(), new BiomeType(name.toString()));
+            String key = name.toString();
+            if (BiomeType.REGISTRY.get(key) == null) {
+                BiomeType.REGISTRY.register(key, new BiomeType(key));
             }
         }
         // Tags
         server.registryAccess().registryOrThrow(Registries.BLOCK).getTagNames().map(TagKey::location).forEach(name -> {
-            if (BlockCategory.REGISTRY.get(name.toString()) == null) {
-                BlockCategory.REGISTRY.register(name.toString(), new BlockCategory(name.toString()));
+            String key = name.toString();
+            if (BlockCategory.REGISTRY.get(key) == null) {
+                BlockCategory.REGISTRY.register(key, new BlockCategory(key));
             }
         });
         server.registryAccess().registryOrThrow(Registries.ITEM).getTagNames().map(TagKey::location).forEach(name -> {
-            if (ItemCategory.REGISTRY.get(name.toString()) == null) {
-                ItemCategory.REGISTRY.register(name.toString(), new ItemCategory(name.toString()));
+            String key = name.toString();
+            if (ItemCategory.REGISTRY.get(key) == null) {
+                ItemCategory.REGISTRY.register(key, new ItemCategory(key));
             }
         });
         Registry<Biome> biomeRegistry = server.registryAccess().registryOrThrow(Registries.BIOME);
@@ -208,14 +214,16 @@ public class NeoForgeWorldEdit {
         });
         // Features
         for (ResourceLocation name : server.registryAccess().registryOrThrow(Registries.CONFIGURED_FEATURE).keySet()) {
-            if (ConfiguredFeatureType.REGISTRY.get(name.toString()) == null) {
-                ConfiguredFeatureType.REGISTRY.register(name.toString(), new ConfiguredFeatureType(name.toString()));
+            String key = name.toString();
+            if (ConfiguredFeatureType.REGISTRY.get(key) == null) {
+                ConfiguredFeatureType.REGISTRY.register(key, new ConfiguredFeatureType(key));
             }
         }
         // Structures
         for (ResourceLocation name : server.registryAccess().registryOrThrow(Registries.STRUCTURE).keySet()) {
-            if (StructureType.REGISTRY.get(name.toString()) == null) {
-                StructureType.REGISTRY.register(name.toString(), new StructureType(name.toString()));
+            String key = name.toString();
+            if (StructureType.REGISTRY.get(key) == null) {
+                StructureType.REGISTRY.register(key, new StructureType(key));
             }
         }
     }


### PR DESCRIPTION
Pretty minor PR that cleans up a few of the Bukkit Material API usages to be a bit cleaner / use more modern APIs, as well as reduces calls to `toString` of NamespacedKey/ResourceLocation. Also disables legacy ID conversions for the internal parser used for adapters in Bukkit, which should theoretically speed it up a little bit given it doesn't need to do legacy parsing