### PR TITLE
[WIP] Add a //registry command to search registries

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
@@ -40,10 +40,13 @@ import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.operation.Operations;
 import com.sk89q.worldedit.function.visitor.RegionVisitor;
 import com.sk89q.worldedit.internal.annotation.Offset;
+import com.sk89q.worldedit.internal.annotation.RegistryType;
 import com.sk89q.worldedit.internal.command.CommandRegistrationHandler;
 import com.sk89q.worldedit.internal.command.CommandUtil;
 import com.sk89q.worldedit.internal.cui.ServerCUIHandler;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.registry.Keyed;
+import com.sk89q.worldedit.registry.Registry;
 import com.sk89q.worldedit.session.Placement;
 import com.sk89q.worldedit.session.PlacementType;
 import com.sk89q.worldedit.util.SideEffect;
@@ -54,8 +57,11 @@ import com.sk89q.worldedit.util.formatting.component.SideEffectBox;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
 import com.sk89q.worldedit.util.formatting.text.format.TextColor;
 import com.sk89q.worldedit.world.World;
+import com.sk89q.worldedit.world.biome.BiomeType;
+import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.item.ItemType;
 import org.enginehub.piston.CommandManager;
 import org.enginehub.piston.CommandManagerService;
@@ -539,6 +545,61 @@ public class GeneralCommands {
                         .append(name)
                         .append(" (" + id + ")")
                         .build());
+                }
+            }
+            List<Component> list = new ArrayList<>(results.values());
+            return PaginationBox.fromComponents("Search results for '" + search + "'", command, list)
+                .create(page);
+        }
+    }
+
+    @Command(
+        name = "/registry",
+        desc = "Search through the given registry"
+    )
+    @CommandPermissions("worldedit.registry")
+    public void registry(Actor actor,
+                           @RegistryType
+                           Registry<?> registry,
+                           @ArgFlag(name = 'p', desc = "Page of results to return", def = "1")
+                           int page,
+                           @Arg(desc = "Search query", variable = true)
+                           List<String> query) {
+        String search = String.join(" ", query);
+
+        WorldEditAsyncCommandBuilder.createAndSendMessage(actor, new RegistrySearcher(registry, search, page),
+            TranslatableComponent.of("worldedit.registry.searching"));
+    }
+
+    private static class RegistrySearcher implements Callable<Component> {
+        private final Registry<?> registry;
+        private final String search;
+        private final int page;
+
+        RegistrySearcher(Registry<?> registry, String search, int page) {
+            this.registry = registry;
+            this.search = search;
+            this.page = page;
+        }
+
+        @Override
+        public Component call() throws Exception {
+            String command = "//registry " + registry.id() + "-p %page% " + search;
+            Map<String, Component> results = new TreeMap<>();
+            String idMatch = search.replace(' ', '_');
+            for (Keyed searchType : registry) {
+                final String id = searchType.id();
+                if (id.contains(idMatch)) {
+                    var builder = TextComponent.builder()
+                        .append(searchType.id());
+                    switch (searchType) {
+                        case ItemType itemType -> builder.hoverEvent(HoverEvent.showText(itemType.getRichName()));
+                        case BlockType blockType -> builder.hoverEvent(HoverEvent.showText(blockType.getRichName()));
+                        case BiomeType biomeType -> builder.hoverEvent(HoverEvent.showText(biomeType.getRichName()));
+                        default -> {
+                        }
+                    }
+                    results.put(id, builder.build());
                 }
             }
             List<Component> list = new ArrayList<>(results.values());

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/RegistryConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/RegistryConverter.java
@@ -20,7 +20,9 @@
 package com.sk89q.worldedit.command.argument;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.reflect.TypeToken;
 import com.sk89q.worldedit.command.util.SuggestionHelper;
+import com.sk89q.worldedit.internal.annotation.RegistryType;
 import com.sk89q.worldedit.registry.Keyed;
 import com.sk89q.worldedit.registry.Registry;
 import com.sk89q.worldedit.util.formatting.text.Component;
@@ -48,7 +50,6 @@ import org.enginehub.piston.inject.Key;
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Locale;
-import java.util.stream.Collectors;
 
 public final class RegistryConverter<V extends Keyed> implements ArgumentConverter<V> {
 
@@ -73,6 +74,9 @@ public final class RegistryConverter<V extends Keyed> implements ArgumentConvert
             .forEach(registryType ->
                 commandManager.registerConverter(Key.of(registryType), from(registryType))
             );
+
+        // This must be separate as it has a generic type
+        commandManager.registerConverter(Key.of(new TypeToken<>() {}, RegistryType.class), new RegistryConverter<>(Registry.REGISTRY));
     }
 
     @SuppressWarnings("unchecked")
@@ -112,6 +116,6 @@ public final class RegistryConverter<V extends Keyed> implements ArgumentConvert
 
     @Override
     public List<String> getSuggestions(String input, InjectedValueAccess context) {
-        return SuggestionHelper.getRegistrySuggestions(registry, input).collect(Collectors.toList());
+        return SuggestionHelper.getRegistrySuggestions(registry, input).toList();
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/annotation/RegistryType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/annotation/RegistryType.java
@@ -17,25 +17,17 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.sk89q.worldedit.world.weather;
+package com.sk89q.worldedit.internal.annotation;
 
-import com.sk89q.worldedit.registry.Keyed;
-import com.sk89q.worldedit.registry.Registry;
+import org.enginehub.piston.inject.InjectAnnotation;
 
-public record WeatherType(String id) implements Keyed {
-    public static final Registry<WeatherType> REGISTRY = new Registry<>("weather type", "weather_type");
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-    /**
-     * Gets the name of this weather, or the ID if the name cannot be found.
-     *
-     * @return The name, or ID
-     */
-    public String getName() {
-        return id();
-    }
-
-    @Override
-    public String toString() {
-        return id();
-    }
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@InjectAnnotation
+public @interface RegistryType {
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/registry/NamespacedRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/registry/NamespacedRegistry.java
@@ -32,20 +32,33 @@ public final class NamespacedRegistry<V extends Keyed> extends Registry<V> {
     private final Set<String> knownNamespaces = new HashSet<>();
     private final String defaultNamespace;
 
+    @Deprecated
     public NamespacedRegistry(final String name) {
         this(name, MINECRAFT_NAMESPACE);
     }
 
+    @Deprecated
     public NamespacedRegistry(final String name, final boolean checkInitialized) {
         this(name, MINECRAFT_NAMESPACE, checkInitialized);
     }
 
+    @Deprecated
     public NamespacedRegistry(final String name, final String defaultNamespace) {
         this(name, defaultNamespace, false);
     }
 
+    @Deprecated
     public NamespacedRegistry(final String name, final String defaultNamespace, final boolean checkInitialized) {
         super(name, checkInitialized);
+        this.defaultNamespace = defaultNamespace;
+    }
+
+    public NamespacedRegistry(final String name, final String id, final String defaultNamespace) {
+        this(name, id, defaultNamespace, false);
+    }
+
+    public NamespacedRegistry(final String name, final String id, final String defaultNamespace, final boolean checkInitialized) {
+        super(name, id, checkInitialized);
         this.defaultNamespace = defaultNamespace;
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/registry/Registries.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/registry/Registries.java
@@ -1,0 +1,55 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.registry;
+
+import com.sk89q.worldedit.world.biome.BiomeCategory;
+import com.sk89q.worldedit.world.biome.BiomeType;
+import com.sk89q.worldedit.world.block.BlockCategory;
+import com.sk89q.worldedit.world.block.BlockType;
+import com.sk89q.worldedit.world.entity.EntityType;
+import com.sk89q.worldedit.world.fluid.FluidCategory;
+import com.sk89q.worldedit.world.fluid.FluidType;
+import com.sk89q.worldedit.world.gamemode.GameMode;
+import com.sk89q.worldedit.world.generation.ConfiguredFeatureType;
+import com.sk89q.worldedit.world.generation.StructureType;
+import com.sk89q.worldedit.world.item.ItemCategory;
+import com.sk89q.worldedit.world.item.ItemType;
+import com.sk89q.worldedit.world.weather.WeatherType;
+
+public class Registries {
+    public static final Registry<BlockType> BLOCK_TYPE = addRegistry(BlockType.REGISTRY);
+    public static final Registry<BlockCategory> BLOCK_CATEGORY = addRegistry(BlockCategory.REGISTRY);
+    public static final Registry<ItemType> ITEM_TYPE = addRegistry(ItemType.REGISTRY);
+    public static final Registry<ItemCategory> ITEM_CATEGORY = addRegistry(ItemCategory.REGISTRY);
+    public static final Registry<GameMode> GAME_MODE = addRegistry(GameMode.REGISTRY);
+    public static final Registry<WeatherType> WEATHER_TYPE = addRegistry(WeatherType.REGISTRY);
+    public static final Registry<BiomeType> BIOME_TYPE = addRegistry(BiomeType.REGISTRY);
+    public static final Registry<BiomeCategory> BIOME_CATEGORY = addRegistry(BiomeCategory.REGISTRY);
+    public static final Registry<EntityType> ENTITY_TYPE = addRegistry(EntityType.REGISTRY);
+    public static final Registry<FluidType> FLUID_TYPE = addRegistry(FluidType.REGISTRY);
+    public static final Registry<FluidCategory> FLUID_CATEGORY = addRegistry(FluidCategory.REGISTRY);
+    public static final Registry<ConfiguredFeatureType> CONFIGURED_FEATURE_TYPE = addRegistry(ConfiguredFeatureType.REGISTRY);
+    public static final Registry<StructureType> STRUCTURE_TYPE = addRegistry(StructureType.REGISTRY);
+
+    private static <T extends Keyed> Registry<T> addRegistry(Registry<T> registry) {
+        Registry.REGISTRY.register(registry.id(), registry);
+        return registry;
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/registry/Registry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/registry/Registry.java
@@ -33,22 +33,71 @@ import javax.annotation.Nullable;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
-public class Registry<V extends Keyed> implements Iterable<V> {
+public class Registry<V extends Keyed> implements Iterable<V>, Keyed {
+    public static final Registry<Registry<?>> REGISTRY = new Registry<>("registry", "registry");
+
     private final Map<String, V> map = new HashMap<>();
     private final String name;
+    private final String id;
     private final boolean checkInitialized;
 
+    private static String nameToId(String name) {
+        return name.toLowerCase(Locale.ROOT).replace(' ', '_');
+    }
+
+    /**
+     * Creates a new Registry.
+     *
+     * @param name The name of the registry
+     * @deprecated Use {@link #Registry(String, String)} instead to provide an ID
+     */
+    @Deprecated
     public Registry(final String name) {
         this(name, false);
     }
 
+    /**
+     * Creates a new Registry.
+     *
+     * @param name The name of the registry
+     * @param checkInitialized Whether to check if WorldEdit is initialized
+     * @deprecated Use {@link #Registry(String, String, boolean)} instead to provide an ID
+     */
+    @Deprecated
     public Registry(final String name, final boolean checkInitialized) {
+        this(name, nameToId(name), checkInitialized);
+    }
+
+    /**
+     * Creates a new Registry.
+     *
+     * @param name The name of the registry
+     * @param id The ID of the registry
+     */
+    public Registry(final String name, final String id) {
+        this(name, id, false);
+    }
+
+    /**
+     * Creates a new Registry.
+     *
+     * @param name The name of the registry
+     * @param id The ID of the registry
+     * @param checkInitialized Whether to check if WorldEdit is initialized
+     */
+    public Registry(final String name, final String id, final boolean checkInitialized) {
         this.name = name;
+        this.id = id;
         this.checkInitialized = checkInitialized;
     }
 
     public String getName() {
         return name;
+    }
+
+    @Override
+    public String id() {
+        return this.id;
     }
 
     @Nullable

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/biome/BiomeCategory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/biome/BiomeCategory.java
@@ -31,7 +31,7 @@ import java.util.function.Supplier;
  */
 public class BiomeCategory extends Category<BiomeType> implements Keyed {
 
-    public static final NamespacedRegistry<BiomeCategory> REGISTRY = new NamespacedRegistry<>("biome tag", true);
+    public static final NamespacedRegistry<BiomeCategory> REGISTRY = new NamespacedRegistry<>("biome tag", "biome_tag", "minecraft", true);
 
     public BiomeCategory(final String id) {
         super(id, Set::of);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/biome/BiomeType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/biome/BiomeType.java
@@ -19,10 +19,13 @@
 
 package com.sk89q.worldedit.world.biome;
 
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.extension.platform.Capability;
 import com.sk89q.worldedit.function.pattern.BiomePattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.registry.Keyed;
 import com.sk89q.worldedit.registry.NamespacedRegistry;
+import com.sk89q.worldedit.util.formatting.text.Component;
 
 /**
  * All the types of biomes in the game.
@@ -31,7 +34,7 @@ import com.sk89q.worldedit.registry.NamespacedRegistry;
  */
 public record BiomeType(String id) implements Keyed, BiomePattern {
 
-    public static final NamespacedRegistry<BiomeType> REGISTRY = new NamespacedRegistry<>("biome type", true);
+    public static final NamespacedRegistry<BiomeType> REGISTRY = new NamespacedRegistry<>("biome type", "biome_type", "minecraft", true);
 
     @Override
     public String toString() {
@@ -41,5 +44,10 @@ public record BiomeType(String id) implements Keyed, BiomePattern {
     @Override
     public BiomeType applyBiome(BlockVector3 position) {
         return this;
+    }
+
+    public Component getRichName() {
+        return WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.GAME_HOOKS)
+            .getRegistries().getBiomeRegistry().getRichName(this);
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockCategory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockCategory.java
@@ -31,7 +31,7 @@ import com.sk89q.worldedit.registry.NamespacedRegistry;
  */
 public class BlockCategory extends Category<BlockType> implements Keyed {
 
-    public static final NamespacedRegistry<BlockCategory> REGISTRY = new NamespacedRegistry<>("block tag", true);
+    public static final NamespacedRegistry<BlockCategory> REGISTRY = new NamespacedRegistry<>("block tag", "block_tag", "minecraft", true);
 
     public BlockCategory(final String id) {
         super(id, () -> WorldEdit.getInstance().getPlatformManager()

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockType.java
@@ -43,7 +43,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 public class BlockType implements Keyed {
 
-    public static final NamespacedRegistry<BlockType> REGISTRY = new NamespacedRegistry<>("block type", true);
+    public static final NamespacedRegistry<BlockType> REGISTRY = new NamespacedRegistry<>("block type", "block_type", "minecraft", true);
 
     private final String id;
     private final Function<BlockState, BlockState> values;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/entity/EntityType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/entity/EntityType.java
@@ -23,7 +23,7 @@ import com.sk89q.worldedit.registry.Keyed;
 import com.sk89q.worldedit.registry.NamespacedRegistry;
 
 public record EntityType(String id) implements Keyed {
-    public static final NamespacedRegistry<EntityType> REGISTRY = new NamespacedRegistry<>("entity type", true);
+    public static final NamespacedRegistry<EntityType> REGISTRY = new NamespacedRegistry<>("entity type", "entity_type", "minecraft", true);
 
     public EntityType {
         // If it has no namespace, assume minecraft.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/fluid/FluidCategory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/fluid/FluidCategory.java
@@ -31,7 +31,7 @@ import java.util.Set;
  */
 public class FluidCategory extends Category<FluidType> implements Keyed {
 
-    public static final NamespacedRegistry<FluidCategory> REGISTRY = new NamespacedRegistry<>("fluid tag");
+    public static final NamespacedRegistry<FluidCategory> REGISTRY = new NamespacedRegistry<>("fluid tag", "fluid_tag", "minecraft");
 
     public FluidCategory(final String id) {
         // TODO Make this work.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/fluid/FluidType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/fluid/FluidType.java
@@ -29,7 +29,7 @@ import com.sk89q.worldedit.registry.NamespacedRegistry;
  */
 public record FluidType(String id) implements Keyed {
 
-    public static final NamespacedRegistry<FluidType> REGISTRY = new NamespacedRegistry<>("fluid type");
+    public static final NamespacedRegistry<FluidType> REGISTRY = new NamespacedRegistry<>("fluid type", "fluid_type", "minecraft");
 
     @Override
     public String toString() {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/gamemode/GameMode.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/gamemode/GameMode.java
@@ -24,7 +24,7 @@ import com.sk89q.worldedit.registry.Registry;
 
 public record GameMode(String id) implements Keyed {
 
-    public static final Registry<GameMode> REGISTRY = new Registry<>("game mode");
+    public static final Registry<GameMode> REGISTRY = new Registry<>("game mode", "game_mode");
 
     /**
      * Gets the name of this game mode, or the ID if the name cannot be found.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/generation/ConfiguredFeatureType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/generation/ConfiguredFeatureType.java
@@ -23,7 +23,7 @@ import com.sk89q.worldedit.registry.Keyed;
 import com.sk89q.worldedit.registry.NamespacedRegistry;
 
 public record ConfiguredFeatureType(String id) implements Keyed {
-    public static final NamespacedRegistry<ConfiguredFeatureType> REGISTRY = new NamespacedRegistry<>("configured feature type");
+    public static final NamespacedRegistry<ConfiguredFeatureType> REGISTRY = new NamespacedRegistry<>("configured feature type", "configured_feature_type", "minecraft");
 
     @Override
     public String toString() {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/generation/StructureType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/generation/StructureType.java
@@ -23,7 +23,7 @@ import com.sk89q.worldedit.registry.Keyed;
 import com.sk89q.worldedit.registry.NamespacedRegistry;
 
 public record StructureType(String id) implements Keyed {
-    public static final NamespacedRegistry<StructureType> REGISTRY = new NamespacedRegistry<>("structure type");
+    public static final NamespacedRegistry<StructureType> REGISTRY = new NamespacedRegistry<>("structure type", "structure_type", "minecraft");
 
     @Override
     public String toString() {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/item/ItemCategory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/item/ItemCategory.java
@@ -32,7 +32,7 @@ import com.sk89q.worldedit.registry.NamespacedRegistry;
  */
 public class ItemCategory extends Category<ItemType> implements Keyed {
 
-    public static final NamespacedRegistry<ItemCategory> REGISTRY = new NamespacedRegistry<>("item tag");
+    public static final NamespacedRegistry<ItemCategory> REGISTRY = new NamespacedRegistry<>("item tag", "item_tag", "minecraft");
 
     public ItemCategory(final String id) {
         super(id, () -> WorldEdit.getInstance().getPlatformManager()

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/item/ItemType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/item/ItemType.java
@@ -34,7 +34,7 @@ import javax.annotation.Nullable;
 
 public class ItemType implements Keyed {
 
-    public static final NamespacedRegistry<ItemType> REGISTRY = new NamespacedRegistry<>("item type", true);
+    public static final NamespacedRegistry<ItemType> REGISTRY = new NamespacedRegistry<>("item type", "item_type", "minecraft", true);
 
     private final String id;
     @SuppressWarnings({"deprecation", "this-escape"})


### PR DESCRIPTION
This PR adds a //registry <registry_name> command to search registries.

Currently blocked by piston bug preventing registering generic types as a key, no matter what kind of hacky workaround like annotations i try