### PR TITLE
Fix incorrect paste orientation with `//perf -h update off`

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/transform/BlockTransformExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/transform/BlockTransformExtent.java
@@ -283,7 +283,7 @@ public class BlockTransformExtent extends AbstractDelegateExtent {
                                 Property<Object> propAsObj = (Property<Object>) prop;
                                 result = result.with(propAsObj, "none");
                             }
-                            directionalProperties.put(closestProp, result.getState(prop));
+                            directionalProperties.put(closestProp, state);
                         }
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/EngineHub/WorldEdit/issues/2575

Regression was introduced in https://github.com/EngineHub/WorldEdit/commit/6818272ace6f0ccf23b9ef448f0b04356d9ac784

The commit does not mention why the change was made. To me it looks like a cleanup that didn't intend for any changes that got squashed into the addition of support for crafters.