### PR TITLE
Retrieve BlockEntities tag in v3 Sponge Schematics optionally

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/sponge/SpongeSchematicV3Reader.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/sponge/SpongeSchematicV3Reader.java
@@ -143,7 +143,7 @@ public class SpongeSchematicV3Reader implements ClipboardReader {
         );
 
         byte[] blocks = blockContainer.getTag("Data", LinTagType.byteArrayTag()).value();
-        LinListTag<LinCompoundTag> blockEntities = blockContainer.getListTag("BlockEntities", LinTagType.compoundTag());
+        LinListTag<LinCompoundTag> blockEntities = blockContainer.findListTag("BlockEntities", LinTagType.compoundTag());
 
         ReaderUtil.initializeClipboardFromBlocks(
             clipboard, palette, blocks, blockEntities, fixer, true


### PR DESCRIPTION
`LinCompoundTag#findListTag` does not throw an exception if the tag does not exists, but rather returns `null`. `ReaderUtil.initializeClipboardFromBlocks` already handles `null` for `blockEntities` - so passing `null` is safe.

Fixes #2615