### PR TITLE
Fix SideEffectSet inconsistencies, improve perf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ target
 forge-download
 out
 run
+.jqwik-database
 
 /dependency-reduced-pom.xml
 *-private.sh

--- a/build-logic/src/main/kotlin/buildlogic.common-java.gradle.kts
+++ b/build-logic/src/main/kotlin/buildlogic.common-java.gradle.kts
@@ -30,7 +30,9 @@ configure<CheckstyleExtension> {
 }
 
 tasks.withType<Test>().configureEach {
-    useJUnitPlatform()
+    useJUnitPlatform {
+        includeEngines("junit-jupiter", "jqwik")
+    }
 }
 
 dependencies {
@@ -38,6 +40,7 @@ dependencies {
     "testImplementation"(platform(stringyLibs.getLibrary("junit-bom")))
     "testImplementation"(stringyLibs.getLibrary("junit-jupiter-api"))
     "testImplementation"(stringyLibs.getLibrary("junit-jupiter-params"))
+    "testImplementation"(stringyLibs.getLibrary("jqwik"))
     "testImplementation"(platform(stringyLibs.getLibrary("mockito-bom")))
     "testImplementation"(stringyLibs.getLibrary("mockito-core"))
     "testImplementation"(stringyLibs.getLibrary("mockito-junit-jupiter"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,6 +66,8 @@ junit-jupiter-api.module = "org.junit.jupiter:junit-jupiter-api"
 junit-jupiter-params.module = "org.junit.jupiter:junit-jupiter-params"
 junit-jupiter-engine.module = "org.junit.jupiter:junit-jupiter-engine"
 
+jqwik = "net.jqwik:jqwik:1.9.0"
+
 mockito-bom = "org.mockito:mockito-bom:5.11.0"
 mockito-core.module = "org.mockito:mockito-core"
 mockito-junit-jupiter.module = "org.mockito:mockito-junit-jupiter"

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -559,7 +559,7 @@ public class EditSession implements Extent, AutoCloseable {
      */
     @Deprecated
     public boolean hasFastMode() {
-        return sideEffectExtent != null && this.sideEffectExtent.getSideEffectSet().doesApplyAny();
+        return sideEffectExtent != null && !this.sideEffectExtent.getSideEffectSet().doesApplyAny();
     }
 
     public SideEffectSet getSideEffectApplier() {

--- a/worldedit-core/src/test/java/com/sk89q/worldedit/util/SideEffectSetTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/worldedit/util/SideEffectSetTest.java
@@ -1,0 +1,125 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.util;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SideEffectSetTest {
+    private static void assertAppliesWithState(Map<SideEffect, SideEffect.State> expected, SideEffectSet set) {
+        Preconditions.checkArgument(
+            expected.keySet().containsAll(EnumSet.allOf(SideEffect.class)),
+            "Expected map must contain all side effects"
+        );
+
+        Set<SideEffect> appliedSet = expected.entrySet().stream()
+            .filter(e -> e.getValue() != SideEffect.State.OFF)
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toSet());
+        assertEquals(appliedSet, set.getSideEffectsToApply());
+        assertEquals(!appliedSet.isEmpty(), set.doesApplyAny());
+        for (SideEffect effect : SideEffect.values()) {
+            assertEquals(
+                appliedSet.contains(effect), set.shouldApply(effect), "Does not apply expected effect: " + effect
+            );
+            assertEquals(
+                expected.get(effect), set.getState(effect),
+                "Does not have expected state for effect: " + effect
+            );
+        }
+    }
+
+    private static Map<SideEffect, SideEffect.State> initStateMap(Function<SideEffect, SideEffect.State> stateFunction) {
+        return Arrays.stream(SideEffect.values()).collect(Collectors.toMap(Function.identity(), stateFunction));
+    }
+
+    @Test
+    public void defaults() {
+        assertAppliesWithState(
+            initStateMap(SideEffect::getDefaultValue),
+            SideEffectSet.defaults()
+        );
+    }
+
+    @Test
+    public void noneExposed() {
+        assertAppliesWithState(
+            initStateMap(effect -> {
+                if (effect.isExposed()) {
+                    return SideEffect.State.OFF;
+                } else {
+                    return effect.getDefaultValue();
+                }
+            }),
+            SideEffectSet.none()
+        );
+    }
+
+    @Test
+    public void allOn() {
+        Map<SideEffect, SideEffect.State> expected = initStateMap(effect -> SideEffect.State.ON);
+        assertAppliesWithState(
+            expected,
+            new SideEffectSet(expected)
+        );
+    }
+
+    @Test
+    public void allDelayed() {
+        Map<SideEffect, SideEffect.State> expected = initStateMap(effect -> SideEffect.State.DELAYED);
+        assertAppliesWithState(
+            expected,
+            new SideEffectSet(expected)
+        );
+    }
+
+    @Test
+    public void allOff() {
+        Map<SideEffect, SideEffect.State> expected = initStateMap(effect -> SideEffect.State.OFF);
+        assertAppliesWithState(
+            expected,
+            new SideEffectSet(expected)
+        );
+    }
+
+    @Test
+    public void with() {
+        Map<SideEffect, SideEffect.State> expected = initStateMap(SideEffect::getDefaultValue);
+        SideEffectSet set = SideEffectSet.defaults();
+
+        for (SideEffect effect : SideEffect.values()) {
+            for (SideEffect.State state : SideEffect.State.values()) {
+                expected = Maps.transformEntries(expected, (e, s) -> e == effect ? state : s);
+                set = set.with(effect, state);
+                assertAppliesWithState(expected, set);
+            }
+        }
+    }
+}

--- a/worldedit-core/src/test/resources/junit-platform.properties
+++ b/worldedit-core/src/test/resources/junit-platform.properties
@@ -3,3 +3,5 @@ junit.jupiter.execution.parallel.mode.default=concurrent
 junit.jupiter.execution.parallel.mode.classes.default=same_thread
 junit.jupiter.execution.parallel.config.strategy=dynamic
 junit.jupiter.execution.parallel.config.dynamic.factor=4
+
+jqwik.tries.default = 10000


### PR DESCRIPTION
The `apply` term was inconsistent in this API, but should have always been the same. This makes the "set" actually store the state of the given effect, even if it's the default, and therefore consistent.