### PR TITLE
Changes /curve /line thickness param from int to double

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -131,7 +131,7 @@ public class RegionCommands {
                     @Arg(desc = "The pattern of blocks to place")
                         Pattern pattern,
                     @Arg(desc = "The thickness of the line", def = "0")
-                        int thickness,
+                        double thickness,
                     @Switch(name = 'h', desc = "Generate only a shell")
                         boolean shell) throws WorldEditException {
         if (!((region instanceof CuboidRegion) || (region instanceof ConvexPolyhedralRegion))) {
@@ -168,7 +168,7 @@ public class RegionCommands {
                      @Arg(desc = "The pattern of blocks to place")
                          Pattern pattern,
                      @Arg(desc = "The thickness of the curve", def = "0")
-                         int thickness,
+                         double thickness,
                      @Switch(name = 'h', desc = "Generate only a shell")
                          boolean shell) throws WorldEditException {
         if (!(region instanceof ConvexPolyhedralRegion cpregion)) {


### PR DESCRIPTION
- [Issue](https://github.com/EngineHub/WorldEdit/issues/2622)
- Changes the parameters of curve and line methods to accept double values instead of integers.
- I tested the changes in game and by running the test task.