### PR TITLE
Correct all BlockTools to use the Location's World

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/AreaPickaxe.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/AreaPickaxe.java
@@ -54,10 +54,11 @@ public class AreaPickaxe implements BlockTool {
 
     @Override
     public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked, @Nullable Direction face) {
+        World world = BlockTool.requireWorld(clicked);
         int ox = clicked.getBlockX();
         int oy = clicked.getBlockY();
         int oz = clicked.getBlockZ();
-        BlockType initialType = clicked.getExtent().getBlock(clicked.toVector().toBlockPoint()).getBlockType();
+        BlockType initialType = world.getBlock(clicked.toVector().toBlockPoint()).getBlockType();
 
         if (initialType.getMaterial().isAir()) {
             return false;
@@ -67,7 +68,7 @@ public class AreaPickaxe implements BlockTool {
             return false;
         }
 
-        try (EditSession editSession = session.createEditSession(player)) {
+        try (EditSession editSession = BlockTool.createEditSession(player, session, clicked)) {
             editSession.getSurvivalExtent().setToolUse(config.superPickaxeManyDrop);
 
             try {
@@ -81,8 +82,9 @@ public class AreaPickaxe implements BlockTool {
 
                             editSession.setBlock(pos, BlockTypes.AIR.getDefaultState());
 
-                            ((World) clicked.getExtent()).queueBlockBreakEffect(server, pos, initialType,
-                                    clicked.toVector().toBlockPoint().distanceSq(pos));
+                            world.queueBlockBreakEffect(
+                                server, pos, initialType, clicked.toVector().toBlockPoint().distanceSq(pos)
+                            );
                         }
                     }
                 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockDataCyler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockDataCyler.java
@@ -57,7 +57,7 @@ public class BlockDataCyler implements DoubleActionBlockTool {
     private boolean handleCycle(LocalConfiguration config, Player player, LocalSession session,
                                 Location clicked, boolean forward) {
 
-        World world = (World) clicked.getExtent();
+        World world = BlockTool.requireWorld(clicked);
 
         BlockVector3 blockPoint = clicked.toVector().toBlockPoint();
         BaseBlock block = world.getFullBlock(blockPoint);
@@ -87,7 +87,7 @@ public class BlockDataCyler implements DoubleActionBlockTool {
                 Property<Object> objProp = (Property<Object>) currentProperty;
                 BaseBlock newBlock = block.with(objProp, currentProperty.getValues().get(index));
 
-                try (EditSession editSession = session.createEditSession(player)) {
+                try (EditSession editSession = BlockTool.createEditSession(player, session, clicked)) {
                     editSession.disableBuffering();
 
                     try {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockReplacer.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockReplacer.java
@@ -56,7 +56,7 @@ public class BlockReplacer implements DoubleActionBlockTool {
     public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked, @Nullable Direction face) {
         BlockBag bag = session.getBlockBag(player);
 
-        try (EditSession editSession = session.createEditSession(player)) {
+        try (EditSession editSession = BlockTool.createEditSession(player, session, clicked)) {
             try {
                 editSession.disableBuffering();
                 BlockVector3 position = clicked.toVector().toBlockPoint();
@@ -77,7 +77,7 @@ public class BlockReplacer implements DoubleActionBlockTool {
 
     @Override
     public boolean actSecondary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked, @Nullable Direction face) {
-        BaseBlock targetBlock = player.getWorld().getFullBlock(clicked.toVector().toBlockPoint());
+        BaseBlock targetBlock = clicked.getExtent().getFullBlock(clicked.toVector().toBlockPoint());
 
         if (targetBlock != null) {
             pattern = targetBlock;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockTool.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit.command.tool;
 
+import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.LocalConfiguration;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.entity.Player;
@@ -27,10 +28,40 @@ import com.sk89q.worldedit.internal.util.DeprecationUtil;
 import com.sk89q.worldedit.internal.util.NonAbstractForCompatibility;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldedit.world.World;
 
 import javax.annotation.Nullable;
 
 public interface BlockTool extends Tool {
+
+    /**
+     * Helper method to require the world that should be used for a tool action.
+     *
+     * @param clicked the location that was clicked
+     * @return the world to use
+     */
+    static World requireWorld(Location clicked) {
+        if (!(clicked.getExtent() instanceof World world)) {
+            throw new IllegalArgumentException("Location is not in a world: " + clicked);
+        }
+        return world;
+    }
+
+    /**
+     * Helper method to create an {@link EditSession} for a tool action.
+     *
+     * @param player the player
+     * @param clicked the location that was clicked
+     */
+    static EditSession createEditSession(Player player, LocalSession session, Location clicked) {
+        World overrideToRestore = session.getWorldOverride();
+        session.setWorldOverride(BlockTool.requireWorld(clicked));
+        try {
+            return session.createEditSession(player);
+        } finally {
+            session.setWorldOverride(overrideToRestore);
+        }
+    }
 
     /**
      * Perform the primary action of this tool.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/FloatingTreeRemover.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/FloatingTreeRemover.java
@@ -71,7 +71,7 @@ public class FloatingTreeRemover implements BlockTool {
                               Player player, LocalSession session, Location clicked,
                               @Nullable Direction face) {
 
-        final World world = (World) clicked.getExtent();
+        final World world = BlockTool.requireWorld(clicked);
         final BlockState state = world.getBlock(clicked.toVector().toBlockPoint());
 
         if (!isTreeBlock(state.getBlockType())) {
@@ -79,7 +79,7 @@ public class FloatingTreeRemover implements BlockTool {
             return true;
         }
 
-        try (EditSession editSession = session.createEditSession(player)) {
+        try (EditSession editSession = BlockTool.createEditSession(player, session, clicked)) {
             try {
                 final Set<BlockVector3> blockSet = bfs(world, clicked.toVector().toBlockPoint());
                 if (blockSet == null) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/FloodFillTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/FloodFillTool.java
@@ -59,7 +59,7 @@ public class FloodFillTool implements BlockTool {
 
     @Override
     public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked, @Nullable Direction face) {
-        World world = (World) clicked.getExtent();
+        World world = BlockTool.requireWorld(clicked);
 
         BlockVector3 origin = clicked.toVector().toBlockPoint();
         BlockType initialType = world.getBlock(origin).getBlockType();
@@ -72,7 +72,7 @@ public class FloodFillTool implements BlockTool {
             return true;
         }
 
-        try (EditSession editSession = session.createEditSession(player)) {
+        try (EditSession editSession = BlockTool.createEditSession(player, session, clicked)) {
             try {
                 recurse(editSession, origin, origin, range, initialType, new HashSet<>());
             } catch (MaxChangedBlocksException e) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/QueryTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/QueryTool.java
@@ -51,7 +51,7 @@ public class QueryTool implements BlockTool {
     @Override
     public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked, @Nullable Direction face) {
 
-        World world = (World) clicked.getExtent();
+        World world = BlockTool.requireWorld(clicked);
         BlockVector3 blockPoint = clicked.toVector().toBlockPoint();
         BaseBlock block = world.getFullBlock(blockPoint);
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/RecursivePickaxe.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/RecursivePickaxe.java
@@ -57,7 +57,7 @@ public class RecursivePickaxe implements BlockTool {
 
     @Override
     public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked, @Nullable Direction face) {
-        World world = (World) clicked.getExtent();
+        World world = BlockTool.requireWorld(clicked);
 
         BlockVector3 origin = clicked.toVector().toBlockPoint();
         BlockType initialType = world.getBlock(origin).getBlockType();
@@ -70,7 +70,7 @@ public class RecursivePickaxe implements BlockTool {
             return false;
         }
 
-        try (EditSession editSession = session.createEditSession(player)) {
+        try (EditSession editSession = BlockTool.createEditSession(player, session, clicked)) {
             editSession.getSurvivalExtent().setToolUse(config.superPickaxeManyDrop);
 
             try {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/SelectionWand.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/SelectionWand.java
@@ -36,7 +36,7 @@ public class SelectionWand implements DoubleActionBlockTool {
 
     @Override
     public boolean actSecondary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked, @Nullable Direction face) {
-        RegionSelector selector = session.getRegionSelector(player.getWorld());
+        RegionSelector selector = session.getRegionSelector(BlockTool.requireWorld(clicked));
         BlockVector3 blockPoint = clicked.toVector().toBlockPoint();
 
         if (selector.selectPrimary(blockPoint, ActorSelectorLimits.forActor(player))) {
@@ -47,7 +47,7 @@ public class SelectionWand implements DoubleActionBlockTool {
 
     @Override
     public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked, @Nullable Direction face) {
-        RegionSelector selector = session.getRegionSelector(player.getWorld());
+        RegionSelector selector = session.getRegionSelector(BlockTool.requireWorld(clicked));
         BlockVector3 blockPoint = clicked.toVector().toBlockPoint();
 
         if (selector.selectSecondary(blockPoint, ActorSelectorLimits.forActor(player))) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/SinglePickaxe.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/SinglePickaxe.java
@@ -48,14 +48,14 @@ public class SinglePickaxe implements BlockTool {
 
     @Override
     public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked, @Nullable Direction face) {
-        World world = (World) clicked.getExtent();
+        World world = BlockTool.requireWorld(clicked);
         BlockVector3 blockPoint = clicked.toVector().toBlockPoint();
         final BlockType blockType = world.getBlock(blockPoint).getBlockType();
         if (blockType == BlockTypes.BEDROCK && !player.canDestroyBedrock()) {
             return false;
         }
 
-        try (EditSession editSession = session.createEditSession(player)) {
+        try (EditSession editSession = BlockTool.createEditSession(player, session, clicked)) {
             editSession.getSurvivalExtent().setToolUse(config.superPickaxeDrop);
             editSession.setBlock(blockPoint, BlockTypes.AIR.getDefaultState());
         } catch (MaxChangedBlocksException e) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/StackTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/StackTool.java
@@ -52,7 +52,7 @@ public class StackTool implements BlockTool {
         }
         BlockBag bag = session.getBlockBag(player);
 
-        try (EditSession editSession = session.createEditSession(player)) {
+        try (EditSession editSession = BlockTool.createEditSession(player, session, clicked)) {
             BlockStateHolder<?> block = editSession.getFullBlock(clicked.toVector().toBlockPoint());
 
             try {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/TreePlanter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/TreePlanter.java
@@ -53,7 +53,7 @@ public class TreePlanter implements BlockTool {
     @Override
     public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked, @Nullable Direction face) {
 
-        try (EditSession editSession = session.createEditSession(player)) {
+        try (EditSession editSession = BlockTool.createEditSession(player, session, clicked)) {
             try {
                 boolean successful = false;
 


### PR DESCRIPTION
All tools would inadvertently use the player's World at some point, which is incorrect in the presense of some mods as seen in #2560

Fixes #2560