### PR TITLE
Remove newlines from translation files

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
@@ -236,9 +236,10 @@ public class BukkitPlayer extends AbstractPlayerActor {
     @Override
     public void sendAnnouncements() {
         if (!WorldEditPlugin.getInstance().getLifecycledBukkitImplAdapter().isValid()) {
-            printError(TranslatableComponent.of("worldedit.version.bukkit.unsupported-adapter",
-                    TextComponent.of("https://enginehub.org/worldedit/#downloads", TextColor.AQUA)
-                        .clickEvent(ClickEvent.openUrl("https://enginehub.org/worldedit/#downloads"))));
+            printError(TranslatableComponent.of("worldedit.version.bukkit.unsupported-version")
+                .append(TextComponent.newline())
+                .append(TextComponent.of("https://enginehub.org/worldedit/#downloads", TextColor.AQUA).clickEvent(ClickEvent.openUrl("https://enginehub.org/worldedit/#downloads")))
+            );
         }
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -59,6 +59,7 @@ import com.sk89q.worldedit.util.concurrency.EvenMoreExecutors;
 import com.sk89q.worldedit.util.eventbus.EventBus;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
 import com.sk89q.worldedit.util.formatting.text.format.TextColor;
 import com.sk89q.worldedit.util.io.file.FileSelectionAbortedException;
 import com.sk89q.worldedit.util.io.file.FilenameException;
@@ -751,7 +752,12 @@ public final class WorldEdit {
         try {
             engine = new RhinoCraftScriptEngine();
         } catch (NoClassDefFoundError ignored) {
-            player.printError(TranslatableComponent.of("worldedit.script.no-script-engine"));
+            player.printError(TranslatableComponent.of("worldedit.script.missing-script-engine")
+                .append(TextComponent.newline())
+                .append(TranslatableComponent.of("worldedit.script.please-see",
+                    TextComponent.of("https://worldedit.enginehub.org/en/latest/usage/other/craftscripts/", TextColor.AQUA).clickEvent(ClickEvent.openUrl("https://worldedit.enginehub.org/en/latest/usage/other/craftscripts/")))
+                )
+            );
             return;
         }
 


### PR DESCRIPTION
This removes the two locations newlines are used in our translation bundles to hardcode the newlines, as CrowdIn seems to break these a lot. It also removes a usage of a URL from the translation bundles, and cleans it up to be displayed like other URLs for consistency.

I've renamed the relevant translation keys so that we don't end up with weird mixes of these two, meaning these need re-translating.