### PR TITLE
Add a Full Cube mask to mask to blocks that fill an entire cube

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/MaskFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/MaskFactory.java
@@ -20,7 +20,22 @@
 package com.sk89q.worldedit.extension.factory;
 
 import com.sk89q.worldedit.WorldEdit;
-import com.sk89q.worldedit.extension.factory.parser.mask.*;
+import com.sk89q.worldedit.extension.factory.parser.mask.AirMaskParser;
+import com.sk89q.worldedit.extension.factory.parser.mask.BiomeMaskParser;
+import com.sk89q.worldedit.extension.factory.parser.mask.BlockCategoryMaskParser;
+import com.sk89q.worldedit.extension.factory.parser.mask.BlockStateMaskParser;
+import com.sk89q.worldedit.extension.factory.parser.mask.BlocksMaskParser;
+import com.sk89q.worldedit.extension.factory.parser.mask.ClipboardMaskParser;
+import com.sk89q.worldedit.extension.factory.parser.mask.ExistingMaskParser;
+import com.sk89q.worldedit.extension.factory.parser.mask.ExposedMaskParser;
+import com.sk89q.worldedit.extension.factory.parser.mask.ExpressionMaskParser;
+import com.sk89q.worldedit.extension.factory.parser.mask.FullCubeMaskParser;
+import com.sk89q.worldedit.extension.factory.parser.mask.LazyRegionMaskParser;
+import com.sk89q.worldedit.extension.factory.parser.mask.NegateMaskParser;
+import com.sk89q.worldedit.extension.factory.parser.mask.NoiseMaskParser;
+import com.sk89q.worldedit.extension.factory.parser.mask.OffsetMaskParser;
+import com.sk89q.worldedit.extension.factory.parser.mask.RegionMaskParser;
+import com.sk89q.worldedit.extension.factory.parser.mask.SolidMaskParser;
 import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.NoMatchException;
 import com.sk89q.worldedit.extension.input.ParserContext;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/MaskFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/MaskFactory.java
@@ -20,21 +20,7 @@
 package com.sk89q.worldedit.extension.factory;
 
 import com.sk89q.worldedit.WorldEdit;
-import com.sk89q.worldedit.extension.factory.parser.mask.AirMaskParser;
-import com.sk89q.worldedit.extension.factory.parser.mask.BiomeMaskParser;
-import com.sk89q.worldedit.extension.factory.parser.mask.BlockCategoryMaskParser;
-import com.sk89q.worldedit.extension.factory.parser.mask.BlockStateMaskParser;
-import com.sk89q.worldedit.extension.factory.parser.mask.BlocksMaskParser;
-import com.sk89q.worldedit.extension.factory.parser.mask.ClipboardMaskParser;
-import com.sk89q.worldedit.extension.factory.parser.mask.ExistingMaskParser;
-import com.sk89q.worldedit.extension.factory.parser.mask.ExposedMaskParser;
-import com.sk89q.worldedit.extension.factory.parser.mask.ExpressionMaskParser;
-import com.sk89q.worldedit.extension.factory.parser.mask.LazyRegionMaskParser;
-import com.sk89q.worldedit.extension.factory.parser.mask.NegateMaskParser;
-import com.sk89q.worldedit.extension.factory.parser.mask.NoiseMaskParser;
-import com.sk89q.worldedit.extension.factory.parser.mask.OffsetMaskParser;
-import com.sk89q.worldedit.extension.factory.parser.mask.RegionMaskParser;
-import com.sk89q.worldedit.extension.factory.parser.mask.SolidMaskParser;
+import com.sk89q.worldedit.extension.factory.parser.mask.*;
 import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.NoMatchException;
 import com.sk89q.worldedit.extension.input.ParserContext;
@@ -71,6 +57,7 @@ public final class MaskFactory extends AbstractFactory<Mask> {
         register(new AirMaskParser(worldEdit));
         register(new ExposedMaskParser(worldEdit));
         register(new SolidMaskParser(worldEdit));
+        register(new FullCubeMaskParser(worldEdit));
         register(new LazyRegionMaskParser(worldEdit));
         register(new RegionMaskParser(worldEdit));
         register(new OffsetMaskParser(worldEdit));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/FullCubeMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/FullCubeMaskParser.java
@@ -19,7 +19,6 @@
 
 package com.sk89q.worldedit.extension.factory.parser.mask;
 
-import com.google.common.collect.ImmutableList;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.ParserContext;
@@ -31,7 +30,7 @@ import java.util.List;
 
 public class FullCubeMaskParser extends SimpleInputParser<Mask> {
 
-    private final List<String> aliases = ImmutableList.of("#fullcube");
+    private static final List<String> aliases = List.of("#fullcube");
 
     public FullCubeMaskParser(WorldEdit worldEdit) {
         super(worldEdit);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/FullCubeMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/FullCubeMaskParser.java
@@ -1,0 +1,49 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.extension.factory.parser.mask;
+
+import com.google.common.collect.ImmutableList;
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.extension.input.InputParseException;
+import com.sk89q.worldedit.extension.input.ParserContext;
+import com.sk89q.worldedit.function.mask.FullCubeMask;
+import com.sk89q.worldedit.function.mask.Mask;
+import com.sk89q.worldedit.internal.registry.SimpleInputParser;
+
+import java.util.List;
+
+public class FullCubeMaskParser extends SimpleInputParser<Mask> {
+
+    private final List<String> aliases = ImmutableList.of("#fullcube");
+
+    public FullCubeMaskParser(WorldEdit worldEdit) {
+        super(worldEdit);
+    }
+
+    @Override
+    public List<String> getMatchedAliases() {
+        return aliases;
+    }
+
+    @Override
+    public Mask parseFromSimpleInput(String input, ParserContext context) throws InputParseException {
+        return new FullCubeMask(context.requireExtent());
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/FullCubeMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/FullCubeMask.java
@@ -1,0 +1,39 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.function.mask;
+
+import com.sk89q.worldedit.extent.Extent;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.world.block.BlockState;
+
+public class FullCubeMask extends AbstractExtentMask {
+
+    public FullCubeMask(Extent extent) {
+        super(extent);
+    }
+
+    @Override
+    public boolean test(BlockVector3 vector) {
+        Extent extent = getExtent();
+        BlockState block = extent.getBlock(vector);
+        return block.getBlockType().getMaterial().isFullCube();
+    }
+
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/FullCubeMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/FullCubeMask.java
@@ -23,7 +23,7 @@ import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockState;
 
-public class FullCubeMask extends AbstractExtentMask {
+public final class FullCubeMask extends AbstractExtentMask {
 
     public FullCubeMask(Extent extent) {
         super(extent);


### PR DESCRIPTION
This adds a mask (`#fullcube`) that masks to anything that fits the "isFullCube" material property. This is distinct from the solid check, which includes blocks that don't quite fill the cube. Oddly, the solid check includes blocks that fill more than `0.7291666666666666` of the bounds of a block, which means stairs, etc are all included. fullblock would only include blocks that are exactly the bounds of the block.

This PR somewhat ideally needs https://github.com/EngineHub/WorldEdit/pull/2447, which implements this check everywhere.