### PR TITLE
Add parent dir to manifest classpath to account for paper-remapped load point.

### DIFF
--- a/build-logic/src/main/kotlin/buildlogic.platform.gradle.kts
+++ b/build-logic/src/main/kotlin/buildlogic.platform.gradle.kts
@@ -53,7 +53,7 @@ afterEvaluate {
         if (includeClasspath) {
             attributes["Class-Path"] = listOf("truezip", "truevfs", "js")
                 .map { "$it.jar" }
-                .flatMap { listOf(it, "WorldEdit/$it") }
+                .flatMap { listOf(it, "WorldEdit/$it", "../$it", "../WorldEdit/$it") }
                 .joinToString(separator = " ")
         }
         attributes.putAll(extraAttributes)


### PR DESCRIPTION
Currently, the remapped WorldEdit jar on paper is loaded from a sub-directory of the plugins folder, meaning dependencies like truezip and rhino won't be found in the documented search locations. Adding the parent dir temporarily solves this.

See #2692.
Closes #2691.