### PR TITLE
Update NeoForge platform name

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,7 +21,7 @@ body:
   attributes:
     label: Platform Version
     description: |
-      The version of the platform you are on, i.e. Spigot, Paper, Fabric, or Forge.
+      The version of the platform you are on, i.e. Spigot, Paper, Fabric, or NeoForge.
       Please ensure you are running up-to-date software before making a bug report.
       Old versions or hybrids will receive little to no support.
     placeholder: e.g. git-Spigot-21fe707-e1ebe52, git-Paper-463, Fabric 0.7.1, Forge 35.1.37

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 * Use it in creative, survival in single player or on your server.
 * Use it on your Minecraft server to fix griefing and mistakes.
 
-Java Edition required. WorldEdit is compatible with Forge, Fabric, Bukkit, Spigot, Paper, and Sponge.
+Java Edition required. WorldEdit is compatible with NeoForge, Fabric, Bukkit, Spigot, Paper, and Sponge.
 
 ## Download WorldEdit
 

--- a/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgePlatform.java
+++ b/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgePlatform.java
@@ -197,7 +197,7 @@ class NeoForgePlatform extends AbstractPlatform implements MultiUserPlatform {
 
     @Override
     public String getPlatformName() {
-        return "Forge-Official";
+        return "NeoForge-Official";
     }
 
     @Override
@@ -207,7 +207,7 @@ class NeoForgePlatform extends AbstractPlatform implements MultiUserPlatform {
 
     @Override
     public String id() {
-        return "enginehub:forge";
+        return "enginehub:neoforge";
     }
 
     @Override


### PR DESCRIPTION
Seems like this was forgotten with the switch to NeoForge. Also updated mentions in the Readme and the issue template.