### PR TITLE
Fix tree generators working on the unbuffered underlying world.

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1.21.3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_3/StaticRefraction.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_3/StaticRefraction.java
@@ -37,6 +37,7 @@ public final class StaticRefraction {
     );
     public static final String NEXT_TICK_TIME = Refraction.pickName("nextTickTime", "e");
     public static final String GET_BLOCK_STATE = Refraction.pickName("getBlockState", "a_");
+    public static final String IS_STATE_AT_POSITION = Refraction.pickName("isStateAtPosition", "a");
     /**
      * {@code addFreshEntityWithPassengers(Entity entity)}.
      */

--- a/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/StaticRefraction.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/StaticRefraction.java
@@ -37,6 +37,7 @@ public final class StaticRefraction {
     );
     public static final String NEXT_TICK_TIME = Refraction.pickName("nextTickTime", "e");
     public static final String GET_BLOCK_STATE = Refraction.pickName("getBlockState", "a_");
+    public static final String IS_STATE_AT_POSITION = Refraction.pickName("isStateAtPosition", "a");
     /**
      * {@code addFreshEntityWithPassengers(Entity entity)}.
      */

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -715,6 +715,30 @@ public class EditSession implements Extent, AutoCloseable {
     }
 
     /**
+     * As with {@link #getBlock(BlockVector3)}, gets the block at the given position.
+     * However, this may return blocks not yet set to the world (i.e., buffered) by
+     * the current EditSession.
+     *
+     * @param position position of the block
+     * @return the block
+     */
+    public BlockState getBlockWithBuffer(BlockVector3 position) {
+        return this.bypassNone.getBlock(position);
+    }
+
+    /**
+     * As with {@link #getFullBlock(BlockVector3)}, gets the block at the given position,
+     * but as with {@link #getBlockWithBuffer(BlockVector3)}, this may return a block in
+     * the current EditSession's buffer rather than from the world.
+     *
+     * @param position position of the block
+     * @return the block
+     */
+    public BaseBlock getFullBlockWithBuffer(BlockVector3 position) {
+        return this.bypassNone.getFullBlock(position);
+    }
+
+    /**
      * Returns the highest solid 'terrain' block.
      *
      * @param x the X coordinate

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/internal/FabricServerLevelDelegateProxy.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/internal/FabricServerLevelDelegateProxy.java
@@ -41,6 +41,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Predicate;
 
 public class FabricServerLevelDelegateProxy implements InvocationHandler, AutoCloseable {
 
@@ -81,7 +82,7 @@ public class FabricServerLevelDelegateProxy implements InvocationHandler, AutoCl
     }
 
     private BlockState getBlockState(BlockPos blockPos) {
-        return FabricAdapter.adapt(this.editSession.getBlock(FabricAdapter.adapt(blockPos)));
+        return FabricAdapter.adapt(this.editSession.getBlockWithBuffer(FabricAdapter.adapt(blockPos)));
     }
 
     private boolean setBlock(BlockPos blockPos, BlockState blockState) {
@@ -145,6 +146,13 @@ public class FabricServerLevelDelegateProxy implements InvocationHandler, AutoCl
             case "getBlockState", "method_8320" -> {
                 if (args.length == 1 && args[0] instanceof BlockPos blockPos) {
                     return getBlockState(blockPos);
+                }
+            }
+            case "isStateAtPosition", "method_16358" -> {
+                if (args.length == 2 && args[0] instanceof BlockPos blockPos && args[1] instanceof Predicate) {
+                    @SuppressWarnings("unchecked")
+                    Predicate<BlockState> predicate = (Predicate<BlockState>) args[1];
+                    return predicate.test(getBlockState(blockPos));
                 }
             }
             case "getBlockEntity", "method_8321" -> {

--- a/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/internal/NeoForgeServerLevelDelegateProxy.java
+++ b/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/internal/NeoForgeServerLevelDelegateProxy.java
@@ -42,6 +42,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Predicate;
 
 public class NeoForgeServerLevelDelegateProxy implements InvocationHandler, AutoCloseable {
 
@@ -82,7 +83,7 @@ public class NeoForgeServerLevelDelegateProxy implements InvocationHandler, Auto
     }
 
     private BlockState getBlockState(BlockPos blockPos) {
-        return NeoForgeAdapter.adapt(this.editSession.getBlock(NeoForgeAdapter.adapt(blockPos)));
+        return NeoForgeAdapter.adapt(this.editSession.getBlockWithBuffer(NeoForgeAdapter.adapt(blockPos)));
     }
 
     private boolean setBlock(BlockPos blockPos, BlockState blockState) {
@@ -148,6 +149,13 @@ public class NeoForgeServerLevelDelegateProxy implements InvocationHandler, Auto
             case "getBlockState", "m_8055_" -> {
                 if (args.length == 1 && args[0] instanceof BlockPos blockPos) {
                     return getBlockState(blockPos);
+                }
+            }
+            case "isStateAtPosition", "m_7433_" -> {
+                if (args.length == 2 && args[0] instanceof BlockPos blockPos && args[1] instanceof Predicate) {
+                    @SuppressWarnings("unchecked")
+                    Predicate<BlockState> predicate = (Predicate<BlockState>) args[1];
+                    return predicate.test(getBlockState(blockPos));
                 }
             }
             case "getBlockEntity", "m_7702_" -> {


### PR DESCRIPTION
Adds two methods to EditSession to allow getting blocks which are buffered by the EditSession, not yet set in the world. This allows the proxies used by tree generators to know the eventual state of the world, rather than the "real" state.