### PR TITLE
Add setBiome override in MaskingExtent.

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/BiomeCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/BiomeCommands.java
@@ -32,9 +32,7 @@ import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extension.platform.Capability;
 import com.sk89q.worldedit.extension.platform.Locatable;
 import com.sk89q.worldedit.function.RegionFunction;
-import com.sk89q.worldedit.function.RegionMaskingFilter;
 import com.sk89q.worldedit.function.biome.BiomeReplace;
-import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.operation.Operations;
 import com.sk89q.worldedit.function.visitor.RegionVisitor;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -173,7 +171,6 @@ public class BiomeCommands {
                          @Switch(name = 'p', desc = "Use your current position")
                              boolean atPosition) throws WorldEditException {
         Region region;
-        Mask mask = editSession.getMask();
 
         if (atPosition) {
             if (actor instanceof Locatable) {
@@ -188,9 +185,6 @@ public class BiomeCommands {
         }
 
         RegionFunction replace = new BiomeReplace(editSession, target);
-        if (mask != null) {
-            replace = new RegionMaskingFilter(mask, replace);
-        }
         RegionVisitor visitor = new RegionVisitor(region, replace);
         Operations.completeLegacy(visitor);
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/MaskingExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/MaskingExtent.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit.extent;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -69,4 +70,8 @@ public class MaskingExtent extends AbstractDelegateExtent {
         return mask.test(location) && super.setBlock(location, block);
     }
 
+    @Override
+    public boolean setBiome(BlockVector3 location, BiomeType biome) {
+        return mask.test(location) && super.setBiome(location, biome);
+    }
 }


### PR DESCRIPTION
This makes biome operations respect masks set on an EditSession.

Previously, `//setbiome` directly masked its own operation, but `/brush biome` (or anything else directly using `BiomeFactory` or `BiomeReplace`) would manually have to do this masking as well (which `/br biome` didn't). While we could manually add contextual masking to `/br biome` (i.e. by modifying `BiomeFactory#createFromContext`), I think a unified solution like this PR is better in the long-term than the patchwork approach. Technically, however, this is a behavioral change, but judging by all the times people have asked why this doesn't work, I think the new behavior is the expected one.