### PR TITLE
Enable experimental snapshot mode by default

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/PropertiesConfiguration.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/PropertiesConfiguration.java
@@ -138,7 +138,7 @@ public class PropertiesConfiguration extends LocalConfiguration {
         LocalSession.MAX_HISTORY_SIZE = Math.max(15, getInt("history-size", 15));
 
         String snapshotsDir = getString("snapshots-dir", "");
-        boolean experimentalSnapshots = getBool("snapshots-experimental", false);
+        boolean experimentalSnapshots = getBool("snapshots-experimental", true);
         initializeSnapshotConfiguration(snapshotsDir, experimentalSnapshots);
 
         path.getParentFile().mkdirs();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/YAMLConfiguration.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/YAMLConfiguration.java
@@ -120,7 +120,7 @@ public class YAMLConfiguration extends LocalConfiguration {
         serverSideCUI = config.getBoolean("server-side-cui", true);
 
         String snapshotsDir = config.getString("snapshots.directory", "");
-        boolean experimentalSnapshots = config.getBoolean("snapshots.experimental", false);
+        boolean experimentalSnapshots = config.getBoolean("snapshots.experimental", true);
         initializeSnapshotConfiguration(snapshotsDir, experimentalSnapshots);
 
         String type = config.getString("shell-save-type", "").trim();

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/config/ConfigurateConfiguration.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/config/ConfigurateConfiguration.java
@@ -135,7 +135,7 @@ public class ConfigurateConfiguration extends LocalConfiguration {
         serverSideCUI = node.node("server-side-cui").getBoolean(true);
 
         String snapshotsDir = node.node("snapshots", "directory").getString("");
-        boolean experimentalSnapshots = node.node("snapshots", "experimental").getBoolean(false);
+        boolean experimentalSnapshots = node.node("snapshots", "experimental").getBoolean(true);
         initializeSnapshotConfiguration(snapshotsDir, experimentalSnapshots);
 
         String type = node.node("shell-save-type").getString("").trim();


### PR DESCRIPTION
This enables the experimental snapshot mode by default, to start working towards removal of the old mode.