### PR TITLE
Deprecate HttpRequest in favor of native JDK HttpClient

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/net/HttpRequest.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/net/HttpRequest.java
@@ -45,6 +45,12 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
+/**
+ * A class for making HTTP requests.
+ *
+ * @deprecated Use the native JDK HttpClient API instead.
+ */
+@Deprecated(forRemoval = true)
 public class HttpRequest implements Closeable {
 
     private static final int CONNECT_TIMEOUT = 1000 * 5;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/paste/EngineHubPaste.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/paste/EngineHubPaste.java
@@ -21,11 +21,13 @@ package com.sk89q.worldedit.util.paste;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import com.sk89q.worldedit.util.net.HttpRequest;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
@@ -49,47 +51,55 @@ public class EngineHubPaste implements Paster {
 
         @Override
         public URL call() throws IOException, InterruptedException {
-            URL initialUrl = HttpRequest.url("https://paste.enginehub.org/signed_paste");
+            try (HttpClient client = HttpClient.newHttpClient()) {
+                HttpRequest.Builder signRequestBuilder = HttpRequest.newBuilder()
+                        .uri(URI.create("https://paste.enginehub.org/signed_paste_v2"))
+                        .header("x-paste-meta-from", "EngineHub");
 
-            HttpRequest requestBuilder = HttpRequest.get(initialUrl);
+                if (metadata.name != null) {
+                    signRequestBuilder.header("x-paste-meta-name", metadata.name);
+                }
+                if (metadata.author != null) {
+                    signRequestBuilder.header("x-paste-meta-author", metadata.author);
+                }
+                if (metadata.extension != null) {
+                    signRequestBuilder.header("x-paste-meta-extension", metadata.extension);
+                }
 
-            requestBuilder.header("x-paste-meta-from", "EngineHub");
-            if (metadata.name != null) {
-                requestBuilder.header("x-paste-meta-name", metadata.name);
+                HttpResponse<String> signResponse = client.send(signRequestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+
+                if (signResponse.statusCode() != 200) {
+                    throw new IOException("Failed to initiate paste upload: " + signResponse.statusCode() + " " + signResponse.body());
+                }
+
+                SignedPasteResponse response = GSON.fromJson(
+                        signResponse.body(),
+                        TypeToken.get(SignedPasteResponse.class).getType()
+                );
+
+                HttpRequest.Builder uploadRequestBuilder = HttpRequest.newBuilder()
+                        .uri(URI.create(response.uploadUrl))
+                        .method("PUT", HttpRequest.BodyPublishers.ofString(content));
+
+                for (Map.Entry<String, String> entry : response.headers.entrySet()) {
+                    uploadRequestBuilder.header(entry.getKey(), entry.getValue());
+                }
+
+                // If this succeeds, it will not return any data aside from a 204 status.
+                HttpResponse<String> uploadResponse = client.send(uploadRequestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+
+                if (uploadResponse.statusCode() != 200 && uploadResponse.statusCode() != 204) {
+                    throw new IOException("Failed to upload paste: " + uploadResponse.statusCode() + " " + uploadResponse.body());
+                }
+
+                return URI.create(response.viewUrl).toURL();
             }
-            if (metadata.author != null) {
-                requestBuilder.header("x-paste-meta-author", metadata.author);
-            }
-            if (metadata.extension != null) {
-                requestBuilder.header("x-paste-meta-extension", metadata.extension);
-            }
-
-            SignedPasteResponse response = GSON.fromJson(requestBuilder
-                .execute()
-                .expectResponseCode(200)
-                .returnContent()
-                .asString("UTF-8"), TypeToken.get(SignedPasteResponse.class).getType());
-
-            HttpRequest.Form form = HttpRequest.Form.create();
-            for (Map.Entry<String, String> entry : response.uploadFields.entrySet()) {
-                form.add(entry.getKey(), entry.getValue());
-            }
-            form.add("file", content);
-
-            URL url = HttpRequest.url(response.uploadUrl);
-            // If this succeeds, it will not return any data aside from a 204 status.
-            HttpRequest.post(url)
-                    .bodyMultipartForm(form)
-                    .execute()
-                    .expectResponseCode(200, 204);
-
-            return URI.create(response.viewUrl).toURL();
         }
     }
 
     private static final class SignedPasteResponse {
         String viewUrl;
         String uploadUrl;
-        Map<String, String> uploadFields;
+        Map<String, String> headers;
     }
 }


### PR DESCRIPTION
This PR deprecates the HttpRequest class, and swaps its one usage over to the JDK HttpClient class.

I've also taken the opportunity to move the paste callback to use the V2 signed paste API, which has a larger file size cap and doesn't require multipart form encoding.

Closes https://github.com/EngineHub/WorldEdit/issues/2480