### PR TITLE
Make task executor lifecycled to platform readiness.

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.SetMultimap;
 import com.google.common.util.concurrent.ListeningExecutorService;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.sk89q.worldedit.blocks.BaseItem;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.event.platform.BlockInteractEvent;
@@ -55,7 +54,6 @@ import com.sk89q.worldedit.session.SessionManager;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.asset.AssetLoaders;
-import com.sk89q.worldedit.util.concurrency.EvenMoreExecutors;
 import com.sk89q.worldedit.util.eventbus.EventBus;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
@@ -124,8 +122,6 @@ public final class WorldEdit {
     @Deprecated
     private final EditSessionFactory editSessionFactory = new EditSessionFactory.EditSessionFactoryImpl();
     private final SessionManager sessions = new SessionManager(this);
-    private final ListeningExecutorService executorService = MoreExecutors.listeningDecorator(
-            EvenMoreExecutors.newBoundedCachedThreadPool(0, 1, 20, "WorldEdit Task Executor - %s"));
     private final Supervisor supervisor = new SimpleSupervisor();
     private final AssetLoaders assetLoaders = new AssetLoaders(this);
 
@@ -192,7 +188,7 @@ public final class WorldEdit {
      * @return the executor service
      */
     public ListeningExecutorService getExecutorService() {
-        return executorService;
+        return platformManager.getExecutorService();
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/event/platform/PlatformInitializeEvent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/event/platform/PlatformInitializeEvent.java
@@ -23,7 +23,7 @@ import com.sk89q.worldedit.event.Event;
 
 /**
  * Fired when configuration has been loaded and the platform is in the
- * intialization stage.
+ * initialization stage.
  *
  * <p>This event is fired once.</p>
  */


### PR DESCRIPTION
Closes #2459.

Note that the platform list (now map) was/is not threadsafe, which in theory might be problematic if platforms throw ready/unready in multiple threads. Ready/unready should be fixed by #2571 if this is an issue.