### PR TITLE
Fix entities with persist=false copied in an invalid state

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1.21.3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_3/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_3/PaperweightAdapter.java
@@ -290,8 +290,8 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
      * @param entity the entity
      * @param tag the tag
      */
-    private static void readEntityIntoTag(Entity entity, net.minecraft.nbt.CompoundTag tag) {
-        entity.save(tag);
+    private static boolean readEntityIntoTag(Entity entity, net.minecraft.nbt.CompoundTag tag) {
+        return entity.save(tag);
     }
 
     private static Block getBlockFromType(BlockType blockType) {
@@ -471,15 +471,12 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         CraftEntity craftEntity = ((CraftEntity) entity);
         Entity mcEntity = craftEntity.getHandle();
 
-        // Do not allow creating of passenger entity snapshots, passengers are included in the vehicle entity
-        if (mcEntity.isPassenger()) {
-            return null;
-        }
-
         String id = getEntityId(mcEntity);
 
         net.minecraft.nbt.CompoundTag tag = new net.minecraft.nbt.CompoundTag();
-        readEntityIntoTag(mcEntity, tag);
+        if (!readEntityIntoTag(mcEntity, tag)) {
+            return null;
+        }
         return new BaseEntity(
             EntityTypes.get(id),
             LazyReference.from(() -> (LinCompoundTag) toNative(tag))

--- a/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
@@ -290,8 +290,8 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
      * @param entity the entity
      * @param tag the tag
      */
-    private static void readEntityIntoTag(Entity entity, net.minecraft.nbt.CompoundTag tag) {
-        entity.save(tag);
+    private static boolean readEntityIntoTag(Entity entity, net.minecraft.nbt.CompoundTag tag) {
+        return entity.save(tag);
     }
 
     private static Block getBlockFromType(BlockType blockType) {
@@ -471,15 +471,12 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         CraftEntity craftEntity = ((CraftEntity) entity);
         Entity mcEntity = craftEntity.getHandle();
 
-        // Do not allow creating of passenger entity snapshots, passengers are included in the vehicle entity
-        if (mcEntity.isPassenger()) {
-            return null;
-        }
-
         String id = getEntityId(mcEntity);
 
         net.minecraft.nbt.CompoundTag tag = new net.minecraft.nbt.CompoundTag();
-        readEntityIntoTag(mcEntity, tag);
+        if (!readEntityIntoTag(mcEntity, tag)) {
+            return null;
+        }
         return new BaseEntity(
             EntityTypes.get(id),
             LazyReference.from(() -> (LinCompoundTag) toNative(tag))

--- a/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
@@ -290,8 +290,8 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
      * @param entity the entity
      * @param tag the tag
      */
-    private static void readEntityIntoTag(Entity entity, net.minecraft.nbt.CompoundTag tag) {
-        entity.save(tag);
+    private static boolean readEntityIntoTag(Entity entity, net.minecraft.nbt.CompoundTag tag) {
+        return entity.save(tag);
     }
 
     private static Block getBlockFromType(BlockType blockType) {
@@ -471,15 +471,12 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         CraftEntity craftEntity = ((CraftEntity) entity);
         Entity mcEntity = craftEntity.getHandle();
 
-        // Do not allow creating of passenger entity snapshots, passengers are included in the vehicle entity
-        if (mcEntity.isPassenger()) {
-            return null;
-        }
-
         String id = getEntityId(mcEntity);
 
         net.minecraft.nbt.CompoundTag tag = new net.minecraft.nbt.CompoundTag();
-        readEntityIntoTag(mcEntity, tag);
+        if (!readEntityIntoTag(mcEntity, tag)) {
+            return null;
+        }
         return new BaseEntity(
             EntityTypes.get(id),
             LazyReference.from(() -> (LinCompoundTag) toNative(tag))

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/internal/FabricEntity.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/internal/FabricEntity.java
@@ -52,12 +52,14 @@ public class FabricEntity implements Entity {
     @Override
     public BaseEntity getState() {
         net.minecraft.world.entity.Entity entity = entityRef.get();
-        if (entity == null || entity.isPassenger()) {
+        if (entity == null) {
+            return null;
+        }
+        CompoundTag tag = new CompoundTag();
+        if (!entity.save(tag)) {
             return null;
         }
         ResourceLocation id = FabricWorldEdit.getRegistry(Registries.ENTITY_TYPE).getKey(entity.getType());
-        CompoundTag tag = new CompoundTag();
-        entity.saveWithoutId(tag);
         return new BaseEntity(
             EntityTypes.get(id.toString()),
             LazyReference.from(() -> NBTConverter.fromNative(tag))

--- a/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/internal/NeoForgeEntity.java
+++ b/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/internal/NeoForgeEntity.java
@@ -52,13 +52,18 @@ public class NeoForgeEntity implements Entity {
     @Override
     public BaseEntity getState() {
         net.minecraft.world.entity.Entity entity = entityRef.get();
-        if (entity == null || entity.isPassenger()) {
+        if (entity == null) {
+            return null;
+        }
+        CompoundTag tag = new CompoundTag();
+        if (!entity.save(tag)) {
             return null;
         }
         ResourceLocation id = BuiltInRegistries.ENTITY_TYPE.getKey(entity.getType());
-        CompoundTag tag = new CompoundTag();
-        entity.saveWithoutId(tag);
-        return new BaseEntity(EntityTypes.get(id.toString()), LazyReference.from(() -> NBTConverter.fromNative(tag)));
+        return new BaseEntity(
+            EntityTypes.get(id.toString()),
+            LazyReference.from(() -> NBTConverter.fromNative(tag))
+        );
     }
 
     @Override

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeEntity.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeEntity.java
@@ -53,7 +53,11 @@ class SpongeEntity implements Entity {
         if (entity == null || entity.vehicle().isPresent()) {
             return null;
         }
-        EntityType entityType = EntityType.REGISTRY.get(entity.type().key(RegistryTypes.ENTITY_TYPE).asString());
+        org.spongepowered.api.entity.EntityType<?> spongeEntityType = entity.type();
+        if (spongeEntityType.isTransient()) {
+            return null;
+        }
+        EntityType entityType = EntityType.REGISTRY.get(spongeEntityType.key(RegistryTypes.ENTITY_TYPE).asString());
         if (entityType == null) {
             return null;
         }


### PR DESCRIPTION
Remove a redundant passenger check, as entity.save() returns false in that case.

This also causes leash knots to not be copied. I don't think this is a problem because:
- They would not be saved to disk, it's misleading for users that they appear.
- Pasted leashed mobs still think they're leashed to the original position and get unleashed* - no change in behaviour.
    \* Unless they're pasted close enough to the original position, in which case this has better behaviour because they create their own leash_knot entity.

Fixes https://github.com/EngineHub/WorldEdit/issues/2719