### PR TITLE
Fix sending CUI packets to unwilling clients.

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -957,8 +957,10 @@ public class LocalSession {
     public void dispatchCUISelection(Actor actor) {
         checkNotNull(actor);
 
-        if (!hasCUISupport && useServerCUI) {
-            updateServerCUI(actor);
+        if (!hasCUISupport) {
+            if (useServerCUI) {
+                updateServerCUI(actor);
+            }
             return;
         }
 


### PR DESCRIPTION
Some servers track channel registration: NF throws an error every time this happens; Bukkit silently drops it; Fabric silently sends it (presumably the client ignores it).