### PR TITLE
Add an adjacent option for the offset mark parser

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/OffsetMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/OffsetMaskParser.java
@@ -39,10 +39,10 @@ public class OffsetMaskParser extends InputParser<Mask> {
     @Override
     public Stream<String> getSuggestions(String input, ParserContext context) {
         if (input.isEmpty()) {
-            return Stream.of(">", "<");
+            return Stream.of(">", "<", "~");
         }
         final char firstChar = input.charAt(0);
-        if (firstChar != '>' && firstChar != '<') {
+        if (firstChar != '>' && firstChar != '<' && firstChar != '~') {
             return Stream.empty();
         }
         return worldEdit.getMaskFactory().getSuggestions(input.substring(1), context).stream().map(s -> firstChar + s);
@@ -51,7 +51,7 @@ public class OffsetMaskParser extends InputParser<Mask> {
     @Override
     public Mask parseFromInput(String input, ParserContext context) throws InputParseException {
         final char firstChar = input.charAt(0);
-        if (firstChar != '>' && firstChar != '<') {
+        if (firstChar != '>' && firstChar != '<' && firstChar != '~') {
             return null;
         }
 
@@ -61,6 +61,10 @@ public class OffsetMaskParser extends InputParser<Mask> {
         } else {
             submask = new ExistingBlockMask(context.requireExtent());
         }
-        return OffsetsMask.single(submask, BlockVector3.at(0, firstChar == '>' ? -1 : 1, 0));
+        if (firstChar == '~') {
+            return OffsetsMask.adjacent(submask);
+        } else {
+            return OffsetsMask.single(submask, BlockVector3.at(0, firstChar == '>' ? -1 : 1, 0));
+        }
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/OffsetsMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/OffsetsMask.java
@@ -54,6 +54,16 @@ public class OffsetsMask extends AbstractMask {
     }
 
     /**
+     * Create an offsets mask for any adjacent offset.
+     *
+     * @param mask the mask to use
+     * @return the new offsets mask
+     */
+    public static OffsetsMask adjacent(Mask mask) {
+        return builder(mask).minMatches(1).offsets(OFFSET_LIST).build();
+    }
+
+    /**
      * Create a new builder, using the given mask.
      * @param mask the mask to use
      * @return the builder
@@ -157,7 +167,7 @@ public class OffsetsMask extends AbstractMask {
         checkArgument(minMatches <= maxMatches, "minMatches must be less than or equal to maxMatches");
         checkArgument(minMatches >= 0, "minMatches must be greater than or equal to 0");
         checkArgument(minMatches <= offsets.size(), "minMatches must be less than or equal to the number of offsets");
-        checkArgument(offsets.size() > 0, "offsets must have at least one element");
+        checkArgument(!offsets.isEmpty(), "offsets must have at least one element");
 
         this.mask = mask;
         this.excludeSelf = excludeSelf;


### PR DESCRIPTION
This adds an `~` option to the offset mask parser, which matches any adjacent (cardinal & upright) block.