### PR TITLE
[Bukkit] Workaround string NBT data being wrapped with quotes in MC 1.21.5

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
@@ -1047,7 +1047,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         } else if (foreign instanceof net.minecraft.nbt.ShortTag shortTag) {
             return LinShortTag.of(shortTag.shortValue());
         } else if (foreign instanceof net.minecraft.nbt.StringTag stringTag) {
-            return LinStringTag.of(stringTag.toString());
+            return LinStringTag.of(stringTag.value());
         } else if (foreign instanceof net.minecraft.nbt.EndTag) {
             return LinEndTag.instance();
         } else {


### PR DESCRIPTION
For some reason the method we use to convert String NBT tags as of MC 1.21.5 now wraps the strings with unnecessary `"` characters. This swaps to using a different function to get the value (which was already used in other platforms), so that we can get it without the extra wrapping.

Fixes https://github.com/EngineHub/WorldEdit/issues/2752