### PR TITLE
Configure PublishingExtension for WorldEdit Sponge

### DIFF
--- a/worldedit-sponge/build.gradle.kts
+++ b/worldedit-sponge/build.gradle.kts
@@ -90,3 +90,9 @@ tasks.named<ShadowJar>("shadowJar") {
 tasks.named("assemble").configure {
     dependsOn("shadowJar")
 }
+
+configure<PublishingExtension> {
+    publications.named<MavenPublication>("maven") {
+        from(components["java"])
+    }
+}


### PR DESCRIPTION
Currently, sponge api aren't be published to the maven repository (only the `pom`s are): https://maven.enginehub.org/repo/com/sk89q/worldedit/worldedit-sponge/7.4.0-SNAPSHOT/

Looks like the `worldedit-sponge` is just not configuring publishing:
- Sponge (No `configure<PublishingExtension> `) - https://github.com/EngineHub/WorldEdit/blob/version/7.3.x/worldedit-sponge/build.gradle.kts
- Bukkit (configures it) - https://github.com/EngineHub/WorldEdit/blob/version/7.3.x/worldedit-bukkit/build.gradle.kts#L110
- Fabric (configures it) - https://github.com/EngineHub/WorldEdit/blob/version/7.3.x/worldedit-fabric/build.gradle.kts#L71

Presumably since `worldedit-sponge` is missing:
```kt
configure<PublishingExtension> {
    publications.named<MavenPublication>("maven") {
        from(components["java"])
    }
}
```
It doesn't get the information from the `java-library` plugin to actually include the jar, so it just includes the pom.

Unfortunately I obviously don't have permission to publish the enginehub repository, but perhaps someone could take a look to see if this fix would work?