### PR TITLE
Fixed error in Schematic Watcher when directory is present

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/RecursiveDirectoryWatcher.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/RecursiveDirectoryWatcher.java
@@ -119,10 +119,10 @@ public class RecursiveDirectoryWatcher implements Closeable {
         eventConsumer.accept(new DirectoryCreatedEvent(root));
         try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(root)) {
             for (Path path : directoryStream) {
-                path = WorldEdit.getInstance().getSafeOpenFile(null, schematicRoot.toFile(), schematicRoot.relativize(path).toString(), null).toPath();
                 if (Files.isDirectory(path)) {
                     triggerInitialEvents(path);
                 } else {
+                    path = WorldEdit.getInstance().getSafeOpenFile(null, schematicRoot.toFile(), schematicRoot.relativize(path).toString(), null).toPath();
                     eventConsumer.accept(new FileCreatedEvent(path));
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/EngineHub/WorldEdit/issues/2731. As far as I can tell, this resolves the issue entirely.