### PR TITLE
Add NIO ClipboardFormat methods, and deprecate File ones

### DIFF
--- a/verification/src/changes/accepted-core-public-api-changes.json
+++ b/verification/src/changes/accepted-core-public-api-changes.json
@@ -65,5 +65,14 @@
                 "FIELD_REMOVED_IN_SUPERCLASS"
             ]
         }
-    ]
+    ],
+    "Acceptable addition of default method in interface": [
+        {
+            "type": "com.sk89q.worldedit.extent.clipboard.io.ClipboardFormat",
+            "member": "Method com.sk89q.worldedit.extent.clipboard.io.ClipboardFormat.isFormat(java.nio.file.Path)",
+            "changes": [
+              "METHOD_NEW_DEFAULT"
+            ]
+        }
+  ]
 }

--- a/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIWorldEdit.java
+++ b/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIWorldEdit.java
@@ -322,7 +322,7 @@ public class CLIWorldEdit {
             if (file.getName().endsWith("level.dat")) {
                 throw new IllegalArgumentException("level.dat file support is unfinished.");
             } else {
-                ClipboardFormat format = ClipboardFormats.findByFile(file);
+                ClipboardFormat format = ClipboardFormats.findByPath(file.toPath());
                 if (format != null) {
                     int dataVersion;
                     if (format != BuiltInClipboardFormat.MCEDIT_SCHEMATIC) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -127,7 +127,7 @@ public class SchematicCommands {
             return;
         }
 
-        ClipboardFormat inferredFormat = ClipboardFormats.findByFile(f);
+        ClipboardFormat inferredFormat = ClipboardFormats.findByPath(f.toPath());
         if (inferredFormat != null) {
             format = inferredFormat;
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormat.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormat.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Set;
 
 /**
@@ -68,9 +69,21 @@ public interface ClipboardFormat {
      *
      * @param file the file
      * @return true if the given file is of this format
+     * @deprecated Use {@link #isFormat(Path)} instead
      */
+    @Deprecated
     default boolean isFormat(File file) {
-        try (InputStream stream = Files.newInputStream(file.toPath())) {
+        return isFormat(file.toPath());
+    }
+
+    /**
+     * Return whether the given path is of this format.
+     *
+     * @param path the path
+     * @return true if the given path is of this format
+     */
+    default boolean isFormat(Path path) {
+        try (InputStream stream = Files.newInputStream(path)) {
             return isFormat(stream);
         } catch (IOException e) {
             return false;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormats.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormats.java
@@ -27,6 +27,7 @@ import com.sk89q.worldedit.WorldEdit;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -72,8 +73,7 @@ public class ClipboardFormats {
     /**
      * Find the clipboard format named by the given alias.
      *
-     * @param alias
-     *            the alias
+     * @param alias the alias
      * @return the format, otherwise null if none is matched
      */
     @Nullable
@@ -85,16 +85,30 @@ public class ClipboardFormats {
     /**
      * Detect the format of a given file.
      *
-     * @param file
-     *            the file
+     * @param file the file
      * @return the format, otherwise null if one cannot be detected
+     * @deprecated Use {@link #findByPath(Path)} instead.
      */
+    @Deprecated
     @Nullable
     public static ClipboardFormat findByFile(File file) {
         checkNotNull(file);
 
+        return findByPath(file.toPath());
+    }
+
+    /**
+     * Detect the format of a given path.
+     *
+     * @param path the path
+     * @return the format, otherwise null if one cannot be detected
+     */
+    @Nullable
+    public static ClipboardFormat findByPath(Path path) {
+        checkNotNull(path);
+
         for (ClipboardFormat format : registeredFormats) {
-            if (format.isFormat(file)) {
+            if (format.isFormat(path)) {
                 return format;
             }
         }


### PR DESCRIPTION
This PR deprecates the old IO methods in the clipboard-related classes, and adds new NIO versions to replace them.