### PR TITLE
Fix mixed list type sign components on copy

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
@@ -1132,7 +1132,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         } else if (foreign instanceof LinListTag<?> listTag) {
             net.minecraft.nbt.ListTag tag = new ListTag();
             for (var t : listTag.value()) {
-                tag.add(fromNative(t));
+                tag.addAndUnwrap(fromNative(t));
             }
             return tag;
         } else if (foreign instanceof LinLongTag longTag) {

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/internal/NBTConverter.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/internal/NBTConverter.java
@@ -86,7 +86,7 @@ public final class NBTConverter {
     public static net.minecraft.nbt.ListTag toNative(LinListTag<?> tag) {
         net.minecraft.nbt.ListTag list = new net.minecraft.nbt.ListTag();
         for (LinTag<?> child : tag.value()) {
-            list.add(toNative(child));
+            list.addAndUnwrap(toNative(child));
         }
         return list;
     }

--- a/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/internal/NBTConverter.java
+++ b/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/internal/NBTConverter.java
@@ -86,7 +86,7 @@ public final class NBTConverter {
     public static net.minecraft.nbt.ListTag toNative(LinListTag<?> tag) {
         net.minecraft.nbt.ListTag list = new net.minecraft.nbt.ListTag();
         for (LinTag<?> child : tag.value()) {
-            list.add(toNative(child));
+            list.addAndUnwrap(toNative(child));
         }
         return list;
     }


### PR DESCRIPTION
This fixes #2776, but unsure if it's the best way to do it. It basically just converts it to MC's in-memory representation when converting to MC types, but keeps it as the serialised representation in the LinBus types. It might make sense for LinBus to do a similar thing where serialised & in memory differ, thereby allowing this to be a raw conversion.

I also skipped sponge because that system goes via the Sponge API and who knows what's happening there