### PR TITLE
[Bukkit] Warn on version mismatch

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
@@ -213,11 +213,12 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     private static final RandomSource random = RandomSource.create();
 
     private static final String WRONG_VERSION =
-    """
-    This version of WorldEdit has not been tested with the current Minecraft version.
-    While it may work, there might be unexpected issues.
-    It is recommended to use a version of WorldEdit that supports your Minecraft version.
-    """.stripIndent();
+        """
+        This version of WorldEdit has not been tested with the current Minecraft version.
+        While it may work, there might be unexpected issues.
+        It is recommended to use a version of WorldEdit that supports your Minecraft version.
+        For more information, see https://worldedit.enginehub.org/en/latest/faq/#bukkit-adapters
+        """.stripIndent();
 
     // ------------------------------------------------------------------------
     // Code that may break between versions of Minecraft

--- a/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
@@ -212,6 +212,13 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
     private static final RandomSource random = RandomSource.create();
 
+    private static final String WRONG_VERSION =
+    """
+    This version of WorldEdit has not been tested with the current Minecraft version.
+    While it may work, there might be unexpected issues.
+    It is recommended to use a version of WorldEdit that supports your Minecraft version.
+    """.stripIndent();
+
     // ------------------------------------------------------------------------
     // Code that may break between versions of Minecraft
     // ------------------------------------------------------------------------
@@ -222,7 +229,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
         int dataVersion = SharedConstants.getCurrentVersion().dataVersion().version();
         if (dataVersion != Constants.DATA_VERSION_MC_1_21_6 && dataVersion != Constants.DATA_VERSION_MC_1_21_7) {
-            throw new UnsupportedClassVersionError("Not 1.21.6 or 1.21.7!");
+            logger.warning(WRONG_VERSION);
         }
 
         serverWorldsField = CraftServer.class.getDeclaredField("worlds");


### PR DESCRIPTION
This PR warns when a version mismatch occurs, rather than completely failing. In cases where the adapter is unable to load, it'll still outright fail- so this is more for cases like recently where 1.21.6, 1.21.7, and 1.21.8 have released in a monthly cadence without binary incompatibilities between them. Theoretically the 1.21.6 version can load on 1.21.8, and this change would allow it, albeit with a warning.

The warning specifies that it hasn't been tested, and issues might occur.