### PR TITLE
Fix rails rotation

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/transform/BlockTransformExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/transform/BlockTransformExtent.java
@@ -211,6 +211,45 @@ public class BlockTransformExtent extends AbstractDelegateExtent {
                             result = result.with(enumProp, newValue);
                         }
                     }
+
+                    // rails
+                    if (affineTransform.isVerticalFlip()) {
+                        String value = (String) result.getState(property);
+                        String newValue = switch (value) {
+                            case "ascending_east" -> "ascending_west";
+                            case "ascending_west" -> "ascending_east";
+                            case "ascending_north" -> "ascending_south";
+                            case "ascending_south" -> "ascending_north";
+                            default -> null;
+                        };
+                        if (newValue != null && enumProp.getValues().contains(newValue)) {
+                            result = result.with(enumProp, newValue);
+                        }
+                    }
+
+                    String value = (String) result.getState(property);
+
+                    String[] parts = value.split("_");
+                    String newStartString = parts[0];
+                    if (!newStartString.equals("ascending")) {
+                        Direction start = Direction.valueOf(parts[0].toUpperCase(Locale.ROOT));
+                        Vector3 newStartVec = transform.apply(start.toVector());
+                        Direction newStart = Direction.findClosest(newStartVec, Direction.Flag.CARDINAL);
+                        newStartString = newStart.toString().toLowerCase(Locale.ROOT);
+                    }
+
+                    Direction end = Direction.valueOf(parts[1].toUpperCase(Locale.ROOT));
+                    Vector3 newEndVec = transform.apply(end.toVector());
+                    Direction newEnd = Direction.findClosest(newEndVec, Direction.Flag.CARDINAL);
+                    String newEndString = newEnd.toString().toLowerCase(Locale.ROOT);
+
+                    String newShape = newStartString + "_" + newEndString;
+                    String newShapeSwapped = newEndString + "_" + newStartString;
+                    if (enumProp.getValues().contains(newShape)) {
+                        result = result.with(enumProp, newShape);
+                    } else if (enumProp.getValues().contains(newShapeSwapped)) {
+                        result = result.with(enumProp, newShapeSwapped);
+                    }
                 } else if (property.getName().equals("orientation") && transform instanceof AffineTransform affineTransform) {
                     // crafters
                     if (affineTransform.isHorizontalFlip()) {


### PR DESCRIPTION
## Summary
Fixes an issue where rails did not rotate correctly because their shape property was not being taken into consideration when doing transformations.

## Problem
Previously, WorldEdit’s block transformation logic did not account for the fact that rails use a shape property instead of a rotation or facing property. As a result, many rail shapes remained unchanged after rotation or flip transformations.

## Solution
- Added vertical flip handling for ascending rail shapes.
- Split the shape property into two direction components and applied the transformation to each separately.

## Related Issue
Closes #2657 