### PR TITLE
Allow any pattern to be used in the type applying pattern

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/TypeOrStateApplyingPatternParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/TypeOrStateApplyingPatternParser.java
@@ -60,8 +60,8 @@ public class TypeOrStateApplyingPatternParser extends InputParser<Pattern> {
         String[] parts = input.split("\\[", 2);
         String type = parts[0];
 
-        if (parts.length == 1) {
-            return worldEdit.getBlockFactory().getSuggestions(input, context).stream().map(s -> "^" + s);
+        if (parts.length == 1 || input.startsWith("#")) {
+            return worldEdit.getPatternFactory().getSuggestions(input, context).stream().map(s -> "^" + s);
         } else {
             if (type.isEmpty()) {
                 return Stream.empty(); // without knowing a type, we can't really suggest states
@@ -83,9 +83,9 @@ public class TypeOrStateApplyingPatternParser extends InputParser<Pattern> {
         String[] parts = input.split("\\[", 2);
         String type = parts[0];
 
-        if (parts.length == 1) {
-            return new TypeApplyingPattern(extent,
-                    worldEdit.getBlockFactory().parseFromInput(type, context).getBlockType().getDefaultState());
+        if (parts.length == 1 || input.startsWith("#")) {
+            // This is something we can likely parse as a pattern directly
+            return new TypeApplyingPattern(extent, worldEdit.getPatternFactory().parseFromInput(input, context));
         } else {
             // states given
             if (!parts[1].endsWith("]")) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/TypeApplyingPattern.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/TypeApplyingPattern.java
@@ -31,17 +31,39 @@ import java.util.Map.Entry;
  * Applies a block type while retaining all possible states.
  */
 public class TypeApplyingPattern extends AbstractExtentPattern {
-    private final BlockState blockState;
+    private final Pattern pattern;
 
+    // TODO Remove in WorldEdit 8
+    /**
+     * Create a new TypeApplyingPattern that applies the given block type.
+     *
+     * <p>
+     * As the {@link TypeApplyingPattern#TypeApplyingPattern(Extent, Pattern)} constructor is more flexible,
+     * this constructor will be removed in WorldEdit 8.0.
+     * </p>
+     *
+     * @param extent The extent to work in
+     * @param blockState The block state to get block types from
+     */
     public TypeApplyingPattern(Extent extent, BlockState blockState) {
+        this(extent, (Pattern) blockState);
+    }
+
+    /**
+     * Create a new TypeApplyingPattern that applies the given pattern.
+     *
+     * @param extent The extent to work in
+     * @param pattern The pattern to get block types from
+     */
+    public TypeApplyingPattern(Extent extent, Pattern pattern) {
         super(extent);
-        this.blockState = blockState;
+        this.pattern = pattern;
     }
 
     @Override
     public BaseBlock applyBlock(BlockVector3 position) {
         BlockState oldBlock = getExtent().getBlock(position);
-        BlockState newBlock = blockState;
+        BlockState newBlock = pattern.applyBlock(position).toImmutableState();
         for (Entry<Property<?>, Object> entry : oldBlock.getStates().entrySet()) {
             @SuppressWarnings("unchecked")
             Property<Object> prop = (Property<Object>) entry.getKey();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/TypeApplyingPattern.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/TypeApplyingPattern.java
@@ -35,7 +35,7 @@ public class TypeApplyingPattern extends AbstractExtentPattern {
 
     // TODO Remove in WorldEdit 8
     /**
-     * Create a new TypeApplyingPattern that applies the given block type.
+     * Create a new TypeApplyingPattern that applies the block type from the given block state.
      *
      * <p>
      * As the {@link TypeApplyingPattern#TypeApplyingPattern(Extent, Pattern)} constructor is more flexible,
@@ -50,7 +50,7 @@ public class TypeApplyingPattern extends AbstractExtentPattern {
     }
 
     /**
-     * Create a new TypeApplyingPattern that applies the given pattern.
+     * Create a new TypeApplyingPattern that applies the block type from the given pattern.
      *
      * @param extent The extent to work in
      * @param pattern The pattern to get block types from


### PR DESCRIPTION
This PR allows any pattern to be used in the type applying pattern. Notably, if the state applying is simultaneously in use, it's limited back to single block types (inherent limitation of the state applying pattern).

This allows interesting behaviours, such as using it with the clipboard pattern, or block tags (as seen in example screenshot)

<img width="1920" height="1080" alt="2025-08-27_19 35 39" src="https://github.com/user-attachments/assets/dfe64a69-f19e-4636-aadd-213c2cff1d44" />

I've done a fair bit of testing and am fairly sure this has no unintended side effects. I've opted to not deprecate the constructor in TypeApplyingPattern, as it'd lead to warnings for correct usages. I'll remove it in WE8 for an ABI break, which is noted on the JavaDocs- however it'd still be source-compatible as the new constructor is compatible.