### PR TITLE
Deprecate playEffect without replacement

### DIFF
--- a/verification/src/changes/accepted-fabric-public-api-changes.json
+++ b/verification/src/changes/accepted-fabric-public-api-changes.json
@@ -7,5 +7,14 @@
         "CONSTRUCTOR_REMOVED"
       ]
     }
+  ],
+  "Removal of override": [
+    {
+      "type": "com.sk89q.worldedit.fabric.FabricWorld",
+      "member": "Method com.sk89q.worldedit.fabric.FabricWorld.playEffect(com.sk89q.worldedit.math.Vector3,int,int)",
+      "changes": [
+        "METHOD_REMOVED"
+      ]
+    }
   ]
 }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
@@ -355,6 +355,7 @@ public class BukkitWorld extends AbstractWorld {
         }
     }
 
+    @Deprecated
     @Override
     public boolean playEffect(Vector3 position, int type, int data) {
         World world = getWorld();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/AreaPickaxe.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/AreaPickaxe.java
@@ -52,6 +52,7 @@ public class AreaPickaxe implements BlockTool {
         return player.hasPermission("worldedit.superpickaxe.area");
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, Location clicked, @Nullable Direction face) {
         World world = BlockTool.requireWorld(clicked);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/RecursivePickaxe.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/RecursivePickaxe.java
@@ -86,6 +86,7 @@ public class RecursivePickaxe implements BlockTool {
         return true;
     }
 
+    @SuppressWarnings("deprecation")
     private static void recurse(Platform server, EditSession editSession, World world, BlockVector3 pos,
             BlockVector3 origin, double size, BlockType initialType, Set<BlockVector3> visited) throws MaxChangedBlocksException {
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/AbstractWorld.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/AbstractWorld.java
@@ -46,6 +46,7 @@ import javax.annotation.Nullable;
  */
 public abstract class AbstractWorld implements World {
 
+    @Deprecated
     private final PriorityQueue<QueuedEffect> effectQueue = new PriorityQueue<>();
     private int taskId = -1;
 
@@ -102,11 +103,13 @@ public abstract class AbstractWorld implements World {
     public void fixLighting(Iterable<BlockVector2> chunks) {
     }
 
+    @Deprecated
     @Override
     public boolean playEffect(Vector3 position, int type, int data) {
         return false;
     }
 
+    @Deprecated
     @Override
     public boolean queueBlockBreakEffect(Platform server, BlockVector3 position, BlockType blockType, double priority) {
         if (taskId == -1) {
@@ -164,6 +167,7 @@ public abstract class AbstractWorld implements World {
     public void setWeather(WeatherType weatherType, long duration) {
     }
 
+    @Deprecated
     private class QueuedEffect implements Comparable<QueuedEffect> {
         private final Vector3 position;
         private final BlockType blockType;
@@ -175,7 +179,6 @@ public abstract class AbstractWorld implements World {
             this.priority = priority;
         }
 
-        @SuppressWarnings("deprecation")
         public void play() {
             playEffect(position, 2001, blockType.getLegacyId());
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
@@ -336,7 +336,9 @@ public interface World extends Extent, Keyed {
      * @param type the effect type
      * @param data the effect data
      * @return true if the effect was played
+     * @deprecated This is deprecated without replacement.
      */
+    @Deprecated
     boolean playEffect(Vector3 position, int type, int data);
 
     /**
@@ -347,7 +349,9 @@ public interface World extends Extent, Keyed {
      * @param blockType the block type
      * @param priority the priority
      * @return true if the effect was played
+     * @deprecated This is deprecated without replacement.
      */
+    @Deprecated
     boolean queueBlockBreakEffect(Platform server, BlockVector3 position, BlockType blockType, double priority);
 
     /**

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorld.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorld.java
@@ -577,13 +577,6 @@ public class FabricWorld extends AbstractWorld {
     }
 
     @Override
-    public boolean playEffect(Vector3 position, int type, int data) {
-        // TODO update sound API
-        // getWorld().playSound(type, FabricAdapter.toBlockPos(position.toBlockPoint()), data);
-        return true;
-    }
-
-    @Override
     public WeatherType getWeather() {
         LevelData info = getWorld().getLevelData();
         if (info.isThundering()) {

--- a/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgeWorld.java
+++ b/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgeWorld.java
@@ -562,13 +562,6 @@ public class NeoForgeWorld extends AbstractWorld {
     }
 
     @Override
-    public boolean playEffect(Vector3 position, int type, int data) {
-        // TODO update sound API
-        // getWorld().play(type, NeoForgeAdapter.toBlockPos(position.toBlockPoint()), data);
-        return true;
-    }
-
-    @Override
     public WeatherType getWeather() {
         LevelData info = getWorld().getLevelData();
         if (info.isThundering()) {


### PR DESCRIPTION
This PR deprecates playEffect without replacement. It's purely used for superpickaxe, so likely isn't worth keeping around anymore.