### PR TITLE
Check world validity when handling override worlds

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
@@ -555,4 +555,9 @@ public class BukkitWorld extends AbstractWorld {
         }
         return true;
     }
+
+    @Override
+    public boolean isValid() {
+        return worldRef.get() != null;
+    }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -298,11 +298,15 @@ public class LocalSession {
     }
 
     public boolean hasWorldOverride() {
-        return this.worldOverride != null;
+        return this.worldOverride != null && this.worldOverride.isValid();
     }
 
     @Nullable
     public World getWorldOverride() {
+        if (this.worldOverride != null && !this.worldOverride.isValid()) {
+            // Don't mutate the data in the getter, but do not return an invalid world.
+            return null;
+        }
         return this.worldOverride;
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/AbstractWorld.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/AbstractWorld.java
@@ -164,6 +164,11 @@ public abstract class AbstractWorld implements World {
     public void setWeather(WeatherType weatherType, long duration) {
     }
 
+    @Override
+    public boolean isValid() {
+        return true;
+    }
+
     private class QueuedEffect implements Comparable<QueuedEffect> {
         private final Vector3 position;
         private final BlockType blockType;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
@@ -386,6 +386,18 @@ public interface World extends Extent, Keyed {
      */
     BlockVector3 getSpawnPosition();
 
+    /**
+     * Gets whether this world  is valid (i.e. not unloaded, and accessible by the platform).
+     *
+     * <p>
+     * If the platform has no concept of "validity" in worlds, this should return true. It should assume a valid world
+     * unless it knows for sure that the world is invalid.
+     * </p>
+     *
+     * @return Whether the world is valid
+     */
+    boolean isValid();
+
     @Override
     boolean equals(Object other);
 

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorld.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorld.java
@@ -769,4 +769,8 @@ public class FabricWorld extends AbstractWorld {
         };
     }
 
+    @Override
+    public boolean isValid() {
+        return worldRef.get() != null;
+    }
 }

--- a/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgeWorld.java
+++ b/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgeWorld.java
@@ -751,4 +751,9 @@ public class NeoForgeWorld extends AbstractWorld {
             }
         };
     }
+
+    @Override
+    public boolean isValid() {
+        return worldRef.get() != null;
+    }
 }

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorld.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorld.java
@@ -552,4 +552,8 @@ public final class SpongeWorld extends AbstractWorld {
         return SpongeAdapter.adaptVector3i(getWorld().properties().spawnPosition());
     }
 
+    @Override
+    public boolean isValid() {
+        return worldRef.get() != null;
+    }
 }


### PR DESCRIPTION
This PR adds a concept of "validity" to worlds, to check whether the reference actually corresponds to a real world. This is hooked into the world override system, so that `hasWorldOverride` and `getWorldOverride` behave as if there isn't one if the world is currently invalid.

Fixes https://github.com/EngineHub/WorldEdit/issues/2832