### PR TITLE
Fix pos commands not clamping to world bounds

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -120,6 +120,7 @@ public class LocalSession {
     private transient boolean tickingWatchdog = true;
     private transient boolean hasBeenToldVersion;
     private transient boolean tracingActions;
+    private transient boolean ignoreYBounds;
 
     // Saved properties
     private String lastScript;
@@ -328,6 +329,25 @@ public class LocalSession {
 
     public void setTracingActions(boolean tracingActions) {
         this.tracingActions = tracingActions;
+    }
+
+    /**
+     * Returns whether this session allows selections that extend outside the world's vertical (Y-axis) boundaries.
+     *
+     * @return {@code true} if Y boundaries are ignored when making selections, {@code false} otherwise.
+     */
+    public boolean isIgnoringYBounds() {
+        return ignoreYBounds;
+    }
+
+    /**
+     * Sets whether this session should allow selections to extend outside the world's vertical (Y-axis) boundaries.
+     *
+     * @param ignoreYBounds {@code true} to ignore Y boundaries and allow selections beyond the world height,
+     *                      {@code false} to restrict selections to within the world's vertical limits.
+     */
+    public void setIgnoreYBounds(boolean ignoreYBounds) {
+        this.ignoreYBounds = ignoreYBounds;
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
@@ -449,6 +449,31 @@ public class GeneralCommands {
     }
 
     @Command(
+        name = "/ignoreybounds",
+        aliases = {"/iyb"},
+        desc = "Toggles or sets whether selections can extend outside the world's Y boundaries"
+    )
+    @CommandPermissions("worldedit.ignoreybounds")
+    public void ignoreYBounds(Actor actor, LocalSession session,
+                                     @Arg(desc = "If specified, sets the new state. If omitted, the state will be toggled.", def = "")
+                                     Boolean state) {
+        boolean isUnchanged = false;
+
+        if (state != null) {
+            isUnchanged = session.isIgnoringYBounds() == state;
+        } else {
+            state = !session.isIgnoringYBounds();
+        }
+
+        session.setIgnoreYBounds(state);
+
+        String baseKey = "worldedit.ignoreybounds";
+        String stateKey = state ? ".enabled" : ".disabled";
+        String alreadyKey = isUnchanged ? ".already" : "";
+        actor.printInfo(TranslatableComponent.of(baseKey + stateKey + alreadyKey));
+    }
+
+    @Command(
         name = "searchitem",
         aliases = {"/searchitem", "/l", "/search"},
         desc = "Search for an item"

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SelectionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SelectionCommands.java
@@ -84,6 +84,7 @@ import org.enginehub.piston.annotation.param.ArgFlag;
 import org.enginehub.piston.annotation.param.Switch;
 import org.enginehub.piston.exception.StopExecutionException;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -142,6 +143,15 @@ public class SelectionCommands {
             pos2 = List.of(newPos2);
         }
 
+        if (!session.isIgnoringYBounds()) {
+            pos1 = pos1.clampY(world.getMinY(), world.getMaxY());
+            List<BlockVector3> clampedPos2 = new ArrayList<>();
+            for (BlockVector3 coordinates : pos2) {
+                clampedPos2.add(coordinates.clampY(world.getMinY(), world.getMaxY()));
+            }
+            pos2 = clampedPos2;
+        }
+
         RegionSelector regionSelector = session.getRegionSelector(world);
 
         if (selectorChoice != null) {
@@ -181,6 +191,10 @@ public class SelectionCommands {
             }
         }
 
+        if (!session.isIgnoringYBounds()) {
+            coordinates = coordinates.clampY(world.getMinY(), world.getMaxY());
+        }
+
         if (!session.getRegionSelector(world).selectPrimary(coordinates, ActorSelectorLimits.forActor(actor))) {
             actor.printError(TranslatableComponent.of("worldedit.pos.already-set"));
             return;
@@ -203,6 +217,10 @@ public class SelectionCommands {
             if (coordinates == null) {
                 return;
             }
+        }
+
+        if (!session.isIgnoringYBounds()) {
+            coordinates = coordinates.clampY(world.getMinY(), world.getMaxY());
         }
 
         if (!session.getRegionSelector(world).selectSecondary(coordinates, ActorSelectorLimits.forActor(actor))) {

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -90,6 +90,10 @@
     "worldedit.watchdog.inactive": "Watchdog hook now inactive.",
     "worldedit.world.remove": "Removed world override.",
     "worldedit.world.set": "Set the world override to {0}. (Use //world to go back to default)",
+    "worldedit.ignoreybounds.enabled": "Selections can now extend outside the world's Y boundaries.",
+    "worldedit.ignoreybounds.disabled": "Selections are now restricted to the world's Y boundaries.",
+    "worldedit.ignoreybounds.enabled.already": "Selections are already allowed outside the world's Y boundaries.",
+    "worldedit.ignoreybounds.disabled.already": "Selections are already restricted to the world's Y boundaries.",
 
     "worldedit.undo.undone": "Undid {0} available edits.",
     "worldedit.undo.none": "Nothing left to undo.",


### PR DESCRIPTION
# Summary

Fixes an issue where `//pos`, `//pos1` and `//pos2` allowed Y-coordinates outside world bounds. Adds a session toggle and command to enable or disable y clamping.

# Problem

`//pos`, `//pos1` and `//pos2` accepted Y values below min and above max world boundaries. When this happened, the selection stored those coordinates instead of clamping or erroring. This led to inconsistent behavior with other selection commands and could produce negative expand operations.

# Solution

Positions set through commands are now clamped to the valid world height range. A session toggle and corresponding command were added to control whether this clamping behavior is active.

# Related Issue

Closes #1270