### PR TITLE
Update a few Gradle dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ neoforge-minecraft = "1.21.10"
 
 sponge-minecraft = "1.21.10"
 # https://repo.spongepowered.org/service/rest/repository/browse/maven-public/org/spongepowered/spongeapi/
-sponge-api = "17.0.0-20251001.030412-2"
+sponge-api = "17.0.0-20251120.101908-3"
 sponge-api-major = "17"
 
 # https://parchmentmc.org/docs/getting-started; note that we use older MC versions some times which is OK
@@ -25,7 +25,7 @@ parchment-minecraft = "1.21.10"
 parchment-mappings = "2025.10.12"
 
 # https://repo.spongepowered.org/service/rest/repository/browse/maven-public/org/spongepowered/vanillagradle/
-sponge-vanillagradle = "0.2.1-20250105.203323-92"
+sponge-vanillagradle = "0.2.2-20251112.100313-2"
 
 # Minimum versions we apply to make dependencies support newer Java
 minimumAsm = "9.7"
@@ -43,12 +43,12 @@ sponge-vanillagradle = { module = "org.spongepowered:vanillagradle", version.ref
 levelHeadered = "net.octyl.level-headered:plugin:0.1.1"
 japicmp = "me.champeau.gradle:japicmp-gradle-plugin:0.4.6"
 shadow = "com.gradleup.shadow:com.gradleup.shadow.gradle.plugin:8.3.9"
-jfrog-buildinfo = "org.jfrog.buildinfo:build-info-extractor-gradle:6.0.1"
+jfrog-buildinfo = "org.jfrog.buildinfo:build-info-extractor-gradle:6.0.4"
 
 # https://maven.fabricmc.net/net/fabricmc/sponge-mixin/
-fabric-mixin = "net.fabricmc:sponge-mixin:0.16.4+mixin.0.8.7"
+fabric-mixin = "net.fabricmc:sponge-mixin:0.16.5+mixin.0.8.7"
 
-paperweight = "io.papermc.paperweight.userdev:io.papermc.paperweight.userdev.gradle.plugin:2.0.0-beta.18"
+paperweight = "io.papermc.paperweight.userdev:io.papermc.paperweight.userdev.gradle.plugin:2.0.0-beta.19"
 
 linBus-bom = "org.enginehub.lin-bus:lin-bus-bom:0.2.0"
 linBus-common.module = "org.enginehub.lin-bus:lin-bus-common"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,8 +8,8 @@ pluginManagement {
     }
 }
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
-    id("fabric-loom") version "1.11.4"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+    id("fabric-loom") version "1.13.4"
 }
 dependencyResolutionManagement {
     repositories {


### PR DESCRIPTION
This updates various Gradle deps. We'd been held back due to not being on Gradle 9 for a while, while we now are. So we can do this bump now.