### PR TITLE
Fix revolve transform offset in some situations

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ClipboardCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ClipboardCommands.java
@@ -302,10 +302,12 @@ public class ClipboardCommands {
         Operations.complete(copy);
 
         ClipboardHolder holder = new ClipboardHolder(clipboard);
+        // Offset this by half a block to ensure rotations are aligned properly
+        AffineTransform offsetTransform = new AffineTransform().translate(0.5, 0.5, 0.5);
 
         // Now paste it multiple times, rotating each time
         for (int i = 1; i < pasteCount; i++) {
-            holder.setTransform(new AffineTransform().rotateY((reverse ? 1 : -1) * (360 * i) / (double) pasteCount));
+            holder.setTransform(offsetTransform.rotateY((reverse ? 1 : -1) * (360 * i) / (double) pasteCount));
 
             Operation operation = holder
                     .createPaste(editSession)


### PR DESCRIPTION
This PR fixes instances where the revolve command can go off centre, by translating the AffineTransform by half a block. I've also moved it out of the loop as it's immutable, and there's no point doing this matrix translation every paste