### PR TITLE
Deprecate World#fixAfterFastMode

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/SideEffectExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/SideEffectExtent.java
@@ -50,7 +50,6 @@ public class SideEffectExtent extends AbstractDelegateExtent {
 
     private final World world;
     private final Map<BlockVector3, BlockState> positions = BlockMap.create();
-    private final Set<BlockVector2> dirtyChunks = new HashSet<>();
     private final Set<BlockVector2> dirtyBiomes = new HashSet<>();
     private SideEffectSet sideEffectSet = SideEffectSet.defaults();
     private boolean postEditSimulation;
@@ -89,9 +88,6 @@ public class SideEffectExtent extends AbstractDelegateExtent {
 
     @Override
     public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 location, B block) throws WorldEditException {
-        if (sideEffectSet.getState(SideEffect.LIGHTING) == SideEffect.State.DELAYED) {
-            dirtyChunks.add(BlockVector2.at(location.x() >> 4, location.z() >> 4));
-        }
         if (postEditSimulation) {
             positions.put(location, world.getBlock(location));
         }
@@ -106,7 +102,7 @@ public class SideEffectExtent extends AbstractDelegateExtent {
     }
 
     public boolean commitRequired() {
-        return postEditSimulation || !dirtyChunks.isEmpty() || !dirtyBiomes.isEmpty();
+        return postEditSimulation || !dirtyBiomes.isEmpty();
     }
 
     @Override
@@ -117,10 +113,6 @@ public class SideEffectExtent extends AbstractDelegateExtent {
         return new Operation() {
             @Override
             public Operation resume(RunContext run) throws WorldEditException {
-                if (!dirtyChunks.isEmpty()) {
-                    world.fixAfterFastMode(dirtyChunks);
-                }
-
                 if (!dirtyBiomes.isEmpty()) {
                     world.sendBiomeUpdates(dirtyBiomes);
                 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/AbstractWorld.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/AbstractWorld.java
@@ -91,6 +91,7 @@ public abstract class AbstractWorld implements World {
     public void checkLoadedChunk(BlockVector3 pt) {
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void fixAfterFastMode(Iterable<BlockVector2> chunks) {
     }
@@ -99,6 +100,7 @@ public abstract class AbstractWorld implements World {
     public void sendBiomeUpdates(Iterable<BlockVector2> chunks) {
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void fixLighting(Iterable<BlockVector2> chunks) {
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
@@ -324,7 +324,11 @@ public interface World extends Extent, Keyed {
      * errors and may trigger block change notifications.</p>
      *
      * @param chunks a list of chunk coordinates to fix
+     * @deprecated This method refers to the old fast mode system, which was replaced by fine-grained side effects.
+     *     Any post-edit tasks should be handled within the side effect system. To manually apply side effects,
+     *     use {@link #applySideEffects(BlockVector3, BlockState, SideEffectSet)}.
      */
+    @Deprecated
     void fixAfterFastMode(Iterable<BlockVector2> chunks);
 
     /**
@@ -342,7 +346,11 @@ public interface World extends Extent, Keyed {
      * Relight the given chunks if possible.
      *
      * @param chunks a list of chunk coordinates to fix
+     * @deprecated This was part of the old fast mode system, which was replaced by fine-grained side effects. Use
+     *     {@link #applySideEffects(BlockVector3, BlockState, SideEffectSet)} with the {@link SideEffect#LIGHTING} side
+     *     effect to manually relight blocks.
      */
+    @Deprecated
     void fixLighting(Iterable<BlockVector2> chunks);
 
     /**


### PR DESCRIPTION
This PR deprecates the fixAfterFastMode and fixLighting methods, as they are mostly unused and were written for the old fast mode system which has been supplanted by side effects.