### PR TITLE
Add a replacebiome command

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/BiomeCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/BiomeCommands.java
@@ -190,12 +190,7 @@ public class BiomeCommands {
         RegionVisitor visitor = new RegionVisitor(region, replace);
         Operations.completeLegacy(visitor);
 
-        actor.printInfo(TranslatableComponent.of(
-            "worldedit.setbiome.changed",
-            TextComponent.of(visitor.getAffected())
-        )
-            .append(TextComponent.newline())
-            .append(TranslatableComponent.of("worldedit.setbiome.warning")));
+        actor.printInfo(TranslatableComponent.of("worldedit.setbiome.changed", TextComponent.of(visitor.getAffected())));
     }
 
 
@@ -232,11 +227,6 @@ public class BiomeCommands {
         RegionVisitor visitor = new RegionVisitor(region, filter);
         Operations.completeLegacy(visitor);
 
-        actor.printInfo(TranslatableComponent.of(
-            "worldedit.replacebiome.changed",
-            TextComponent.of(visitor.getAffected())
-        )
-            .append(TextComponent.newline())
-            .append(TranslatableComponent.of("worldedit.setbiome.warning")));
+        actor.printInfo(TranslatableComponent.of("worldedit.replacebiome.changed", TextComponent.of(visitor.getAffected())));
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/BrushCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/BrushCommands.java
@@ -649,7 +649,6 @@ public class BrushCommands {
 
         setOperationBasedBrush(player, localSession, radius,
             new ApplyRegion(new BiomeFactory(biomeType)), shape, "worldedit.brush.biome");
-        player.printInfo(TranslatableComponent.of("worldedit.setbiome.warning"));
         ToolCommands.sendUnbindInstruction(player, UNBIND_COMMAND_COMPONENT);
     }
 

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -45,7 +45,6 @@
     "worldedit.replacebiome.changed": "Biomes were changed for approximately {0} blocks.",
 
     "worldedit.setbiome.changed": "Biomes were changed for approximately {0} blocks.",
-    "worldedit.setbiome.warning": "You may have to re-join your game (or close and re-open your world) to see changes.",
     "worldedit.setbiome.not-locatable": "Command sender must be present in the world to use the -p flag.",
 
     "worldedit.drawsel.disabled": "Server CUI disabled.",


### PR DESCRIPTION
This PR adds a `//replacebiome [mask] <biome type>` command, which acts as a shorthand similar to `//replace` to set biomes based on a given mask.