### PR TITLE
Only load the LegacyMapper when needed

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -198,7 +198,6 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
         loadAdapter();
         initializeRegistries(); // this creates the objects matching Bukkit's enums - but doesn't fill them with data yet
         config.load();
-        WorldEdit.getInstance().loadMappings();
     }
 
     private void setupWorldData() {

--- a/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIWorldEdit.java
+++ b/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIWorldEdit.java
@@ -202,7 +202,6 @@ public class CLIWorldEdit {
         setupPlatform();
 
         setupRegistries();
-        WorldEdit.getInstance().loadMappings();
 
         config.load();
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -71,7 +71,6 @@ import com.sk89q.worldedit.util.translation.TranslationManager;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockType;
-import com.sk89q.worldedit.world.registry.LegacyMapper;
 import org.apache.logging.log4j.Logger;
 
 import java.io.DataInputStream;
@@ -411,9 +410,11 @@ public final class WorldEdit {
 
     /**
      * Load the bundled mappings.
+     *
+     * @deprecated This is no longer necessary as all mappings are loaded lazily.
      */
+    @Deprecated(forRemoval = true)
     public void loadMappings() {
-        LegacyMapper.getInstance(); // Load legacy mappings
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultBlockParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultBlockParser.java
@@ -283,9 +283,12 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
                 if (split.length == 0) {
                     throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.invalid-colon"));
                 } else if (split.length == 1) {
-                    state = LegacyMapper.getInstance().getBlockFromLegacy(Integer.parseInt(split[0]));
+                    var legacyTypeId = Integer.parseInt(split[0]);
+                    state = LegacyMapper.getInstance().getBlockFromLegacy(legacyTypeId);
                 } else {
-                    state = LegacyMapper.getInstance().getBlockFromLegacy(Integer.parseInt(split[0]), Integer.parseInt(split[1]));
+                    var legacyTypeId = Integer.parseInt(split[0]);
+                    var legacyDataValue = Integer.parseInt(split[1]);
+                    state = LegacyMapper.getInstance().getBlockFromLegacy(legacyTypeId, legacyDataValue);
                 }
                 if (state != null) {
                     blockType = state.getBlockType();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultItemParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultItemParser.java
@@ -68,9 +68,12 @@ public class DefaultItemParser extends InputParser<BaseItem> {
                 if (split.length == 0) {
                     throw new InputParseException(TranslatableComponent.of("worldedit.error.parser.invalid-colon"));
                 } else if (split.length == 1) {
-                    itemType = LegacyMapper.getInstance().getItemFromLegacy(Integer.parseInt(split[0]));
+                    var legacyItemId = Integer.parseInt(split[0]);
+                    itemType = LegacyMapper.getInstance().getItemFromLegacy(legacyItemId);
                 } else {
-                    itemType = LegacyMapper.getInstance().getItemFromLegacy(Integer.parseInt(split[0]), Integer.parseInt(split[1]));
+                    var legacyItemId = Integer.parseInt(split[0]);
+                    var legacyDataValue = Integer.parseInt(split[1]);
+                    itemType = LegacyMapper.getInstance().getItemFromLegacy(legacyItemId, legacyDataValue);
                 }
                 if (itemType != null) {
                     item = new BaseItem(itemType);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/PropertiesConfiguration.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/PropertiesConfiguration.java
@@ -27,7 +27,6 @@ import com.sk89q.worldedit.LocalConfiguration;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.util.report.Unreported;
-import com.sk89q.worldedit.world.registry.LegacyMapper;
 import org.apache.logging.log4j.Logger;
 
 import java.io.File;
@@ -108,23 +107,13 @@ public class PropertiesConfiguration extends LocalConfiguration {
         logFile = getString("log-file", logFile);
         logFormat = getString("log-format", logFormat);
         registerHelp = getBool("register-help", registerHelp);
-        wandItem = getString("wand-item", wandItem).toLowerCase(Locale.ROOT);
-        try {
-            wandItem = LegacyMapper.getInstance().getItemFromLegacy(Integer.parseInt(wandItem)).id();
-        } catch (Throwable ignored) {
-            // This is just for compatibility with old configs, ignore errors
-        }
+        wandItem = convertLegacyItem(getString("wand-item", wandItem)).toLowerCase(Locale.ROOT);
         superPickaxeDrop = getBool("super-pickaxe-drop-items", superPickaxeDrop);
         superPickaxeManyDrop = getBool("super-pickaxe-many-drop-items", superPickaxeManyDrop);
         useInventory = getBool("use-inventory", useInventory);
         useInventoryOverride = getBool("use-inventory-override", useInventoryOverride);
         useInventoryCreativeOverride = getBool("use-inventory-creative-override", useInventoryCreativeOverride);
-        navigationWand = getString("nav-wand-item", navigationWand).toLowerCase(Locale.ROOT);
-        try {
-            navigationWand = LegacyMapper.getInstance().getItemFromLegacy(Integer.parseInt(navigationWand)).id();
-        } catch (Throwable ignored) {
-            // This is just for compatibility with old configs, ignore errors
-        }
+        navigationWand = convertLegacyItem(getString("nav-wand-item", navigationWand)).toLowerCase(Locale.ROOT);
         navigationWandMaxDistance = getInt("nav-wand-distance", navigationWandMaxDistance);
         navigationUseGlass = getBool("nav-use-glass", navigationUseGlass);
         scriptTimeout = getInt("scripting-timeout", scriptTimeout);

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/config/ConfigurateConfiguration.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/config/ConfigurateConfiguration.java
@@ -24,7 +24,6 @@ import com.sk89q.worldedit.LocalConfiguration;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.session.SessionManager;
 import com.sk89q.worldedit.util.report.Unreported;
-import com.sk89q.worldedit.world.registry.LegacyMapper;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.configurate.CommentedConfigurationNode;
 import org.spongepowered.configurate.ConfigurationOptions;
@@ -63,12 +62,7 @@ public class ConfigurateConfiguration extends LocalConfiguration {
 
         profile = node.node("debug").getBoolean(profile);
         traceUnflushedSessions = node.node("debugging", "trace-unflushed-sessions").getBoolean(traceUnflushedSessions);
-        wandItem = node.node("wand-item").getString(wandItem).toLowerCase(Locale.ROOT);
-        try {
-            wandItem = LegacyMapper.getInstance().getItemFromLegacy(Integer.parseInt(wandItem)).id();
-        } catch (Throwable ignored) {
-            // This is just for old configs, so ignore errors
-        }
+        wandItem = convertLegacyItem(node.node("wand-item").getString(wandItem)).toLowerCase(Locale.ROOT);
 
         defaultChangeLimit = Math.max(-1, node.node("limits", "max-blocks-changed", "default").getInt(defaultChangeLimit));
         maxChangeLimit = Math.max(-1, node.node("limits", "max-blocks-changed", "maximum").getInt(maxChangeLimit));
@@ -115,12 +109,8 @@ public class ConfigurateConfiguration extends LocalConfiguration {
         useInventoryOverride = node.node("use-inventory", "allow-override").getBoolean(useInventoryOverride);
         useInventoryCreativeOverride = node.node("use-inventory", "creative-mode-overrides").getBoolean(useInventoryCreativeOverride);
 
-        navigationWand = node.node("navigation-wand", "item").getString(navigationWand).toLowerCase(Locale.ROOT);
-        try {
-            navigationWand = LegacyMapper.getInstance().getItemFromLegacy(Integer.parseInt(navigationWand)).id();
-        } catch (Throwable ignored) {
-            // This is just for old configs, so ignore errors
-        }
+        navigationWand = convertLegacyItem(node.node("navigation-wand", "item").getString(navigationWand)).toLowerCase(Locale.ROOT);
+
         navigationWandMaxDistance = node.node("navigation-wand", "max-distance").getInt(navigationWandMaxDistance);
         navigationUseGlass = node.node("navigation", "use-glass").getBoolean(navigationUseGlass);
 


### PR DESCRIPTION
This PR makes a few changes to lower the chance of the legacy mapping system being called, as well as stops it getting loaded by default on startup on Bukkit.

This means it's now only actually loaded when necessary, although it isn't too impactful in terms of performance/memory. Just good to have less legacy stuff kept loaded if never used.