### PR TITLE
Tweak Bukkit mojmap detection logic to be more reliable in non-mojmapped envs

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/Refraction.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/Refraction.java
@@ -23,7 +23,10 @@ package com.sk89q.worldedit.bukkit.adapter;
  * Reflection helper to deal with obfuscation.
  */
 public class Refraction {
-    private static final String MOJANG_MAPPED_CLASS_NAME = "net.minecraft.nbt.ListTag";
+    // Spigot remaps to a v1_21_R7 style, whereas Paper mojmap environments lack this.
+    // This is a safer method to determine whether a class is mojmapped, given Spigot now uses
+    // mojmapping purely for class names.
+    private static final String MOJANG_MAPPED_CLASS_NAME = "org.bukkit.craftbukkit.CraftServer";
     private static final boolean IS_MOJANG_MAPPED;
 
     static {


### PR DESCRIPTION
This PR moves to `org.bukkit.craftbukkit.CraftServer` as the mojmap detector class, as ironically it's less stable than actual Minecraft classes between Spigot & Paper. This means it's more reliable as a detector method, as Spigot now mojmaps classnames.

As the next MC release is dropping obfuscation, this will purely exist for the current adapters- and given it works for those, there's no chance of this breaking in the future.

