### PR TITLE
Use a more robust relative path setup in the schematic list

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -494,12 +494,7 @@ public class SchematicCommands {
 
             String path = inRoot
                     ? file.getFileName().toString()
-                    : file.toString().substring(rootDir.toString().length());
-
-            if (path.startsWith(File.separator)) {
-                // Remove leading separator from the path if present, the load command fails otherwise
-                path = path.substring(1);
-            }
+                    : rootDir.relativize(file).toString();
 
             return TextComponent.builder()
                     .content("")


### PR DESCRIPTION
On Windows environments, the schematic list outputs entries prepended with `\`. This breaks the `[L]` buttons as the command cannot accept the path with a prepended `\`. This PR drops the separator at the start of the list strings