### PR TITLE
Remove legacy <1.13 warning from Bukkit plugin

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -99,20 +99,6 @@ import static com.sk89q.worldedit.internal.anvil.ChunkDeleter.DELCHUNKS_FILE_NAM
  */
 public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
 
-    // This must be before the Logger is initialized, which fails in 1.8
-    static {
-        if (PaperLib.getMinecraftVersion() < 13) {
-            throw new IllegalStateException(
-                """
-                **********************************************
-                ** This Minecraft version (%s) is not supported by this version of WorldEdit.
-                ** Please download an OLDER version of WorldEdit which does.
-                **********************************************
-                """.formatted(Bukkit.getVersion())
-            );
-        }
-    }
-
     private static final Logger LOGGER = LogManagerCompat.getLogger();
     public static final String CUI_PLUGIN_CHANNEL = "worldedit:cui";
     private static WorldEditPlugin INSTANCE;


### PR DESCRIPTION
It's been basically a decade at this point, this warning likely does not function anymore and should be cleaned up.

https://howoldisminecraft1122.today/ says 8 years, 3 months, and 29 days old 😌