### PR TITLE
Ensure schematics manager is initialised on reloads

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/Capability.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/Capability.java
@@ -53,7 +53,6 @@ public enum Capability {
         @Override
         void initialize(PlatformManager platformManager, Platform platform) {
             WorldEdit.getInstance().getAssetLoaders().init();
-            WorldEdit.getInstance().getSchematicsManager().init();
         }
 
         @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/SchematicsEventListener.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/SchematicsEventListener.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit.internal;
 
+import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.event.platform.ConfigurationLoadEvent;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.util.eventbus.Subscribe;
@@ -43,5 +44,9 @@ public class SchematicsEventListener {
         } catch (IOException e) {
             LOGGER.warn("Failed to create schematics directory", e);
         }
+
+        // Initialize the schematics manager, running uninit first in case this is a reload.
+        WorldEdit.getInstance().getSchematicsManager().uninit();
+        WorldEdit.getInstance().getSchematicsManager().init();
     }
 }


### PR DESCRIPTION
Move the init point of the schematics manager to the reload configuration event, running `uninit` before the actual init to make sure that it's adequately cleaned up. `uninit` is safe to run when not yet initialised, as it checks before cleaning anything up.

This also ensures that fallback schematic systems are initialised late enough to obtain necessary data.

This should fix issues such as https://github.com/EngineHub/WorldEdit/issues/2895 with filesystems that need to fallback, as well the fact that reloading does not apply schematic folder changes (albeit without an issue number as it's not been reported)