### PR TITLE
Make non-legacy blocks' type/data values -1, to allow overriding non-legacy blocks with air in //generate

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -2481,8 +2481,8 @@ public class EditSession implements Extent, AutoCloseable {
 
                 try {
                     int[] legacy = LegacyMapper.getInstance().getLegacyFromBlock(defaultMaterial.toImmutableState());
-                    int typeVar = 0;
-                    int dataVar = 0;
+                    int typeVar = -1;
+                    int dataVar = -1;
                     if (legacy != null) {
                         typeVar = legacy[0];
                         if (legacy.length > 1) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/WorldEditExpressionEnvironment.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/WorldEditExpressionEnvironment.java
@@ -60,7 +60,7 @@ public class WorldEditExpressionEnvironment implements ExpressionEnvironment {
 
     private int getLegacy(BlockVector3 position, int index) {
         final int[] legacy = LegacyMapper.getInstance().getLegacyFromBlock(extent.getBlock(position).toImmutableState());
-        return legacy == null ? 0 : legacy[index];
+        return legacy == null ? -1 : legacy[index];
     }
 
     @Override


### PR DESCRIPTION
Previously, it was impossible to override a non-legacy block (i.e. one that was introduced after the switch to string IDs) with air. This was due to the fact that non-legacy blocks and air had the same type id (0). This change gives them separate type ids, making it possible to override non-legacy blocks with air.

The query functions have been adjusted to match.