### PR TITLE
Fixed certain commands that teleport the player or an entity to Folia.

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitEntity.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitEntity.java
@@ -29,6 +29,7 @@ import com.sk89q.worldedit.regions.RegionOperationException;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.NullWorld;
+import io.papermc.lib.PaperLib;
 
 import java.lang.ref.WeakReference;
 import javax.annotation.Nullable;
@@ -76,7 +77,12 @@ class BukkitEntity implements Entity {
     public boolean setLocation(Location location) {
         org.bukkit.entity.Entity entity = entityRef.get();
         if (entity != null) {
-            return entity.teleport(BukkitAdapter.adapt(location));
+            if (PaperLib.isPaper()) {
+                var unused = PaperLib.teleportAsync(entity, BukkitAdapter.adapt(location));
+                return true;
+            } else {
+                return entity.teleport(BukkitAdapter.adapt(location));
+            }
         } else {
             return false;
         }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitEntity.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitEntity.java
@@ -77,7 +77,7 @@ class BukkitEntity implements Entity {
     public boolean setLocation(Location location) {
         org.bukkit.entity.Entity entity = entityRef.get();
         if (entity != null) {
-            if (PaperLib.isPaper()) {
+            if (WorldEditPlugin.getInstance().isFolia()) {
                 var unused = PaperLib.teleportAsync(entity, BukkitAdapter.adapt(location));
                 return true;
             } else {

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
@@ -45,6 +45,7 @@ import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockTypes;
 import com.sk89q.worldedit.world.gamemode.GameMode;
 import com.sk89q.worldedit.world.gamemode.GameModes;
+import io.papermc.lib.PaperLib;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -146,8 +147,15 @@ public class BukkitPlayer extends AbstractPlayerActor {
 
     @Override
     public boolean trySetPosition(Vector3 pos, float pitch, float yaw) {
-        return player.teleport(new Location(player.getWorld(), pos.x(), pos.y(),
-            pos.z(), yaw, pitch));
+        Location location = new Location(player.getWorld(), pos.x(), pos.y(),
+                pos.z(), yaw, pitch);
+        if (PaperLib.isPaper()) {
+            var unused = PaperLib.teleportAsync(player, location);
+            return true;
+        } else {
+            return player.teleport(location);
+        }
+
     }
 
     @Override
@@ -224,7 +232,12 @@ public class BukkitPlayer extends AbstractPlayerActor {
 
     @Override
     public boolean setLocation(com.sk89q.worldedit.util.Location location) {
-        return player.teleport(BukkitAdapter.adapt(location));
+        if (PaperLib.isPaper()) {
+            var unused = PaperLib.teleportAsync(player, BukkitAdapter.adapt(location));
+            return true;
+        } else {
+            return player.teleport(BukkitAdapter.adapt(location));
+        }
     }
 
     @SuppressWarnings("deprecation") // Paper's deprecation, we need to support Spigot still

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
@@ -149,13 +149,12 @@ public class BukkitPlayer extends AbstractPlayerActor {
     public boolean trySetPosition(Vector3 pos, float pitch, float yaw) {
         Location location = new Location(player.getWorld(), pos.x(), pos.y(),
                 pos.z(), yaw, pitch);
-        if (PaperLib.isPaper()) {
+        if (WorldEditPlugin.getInstance().isFolia()) {
             var unused = PaperLib.teleportAsync(player, location);
             return true;
         } else {
             return player.teleport(location);
         }
-
     }
 
     @Override
@@ -232,7 +231,7 @@ public class BukkitPlayer extends AbstractPlayerActor {
 
     @Override
     public boolean setLocation(com.sk89q.worldedit.util.Location location) {
-        if (PaperLib.isPaper()) {
+        if (WorldEditPlugin.getInstance().isFolia()) {
             var unused = PaperLib.teleportAsync(player, BukkitAdapter.adapt(location));
             return true;
         } else {


### PR DESCRIPTION
The Entity#teleport method is not supported on Folia, unlike Entity#teleportAsync. Furthermore, since PaperLib is integrated with WorldEdit, it can be used if a Folia server is detected.