### PR TITLE
fix ExtendingCuboidRegionSelector constructor

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/ExtendingCuboidRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/ExtendingCuboidRegionSelector.java
@@ -79,8 +79,8 @@ public class ExtendingCuboidRegionSelector extends CuboidRegionSelector {
      */
     public ExtendingCuboidRegionSelector(@Nullable World world, BlockVector3 position1, BlockVector3 position2) {
         this(world);
-        position1 = position1.getMinimum(position2);
-        position2 = position1.getMaximum(position2);
+        this.position1 = position1.getMinimum(position2);
+        this.position2 = position1.getMaximum(position2);
         region.setPos1(position1);
         region.setPos2(position2);
     }


### PR DESCRIPTION
Not sure if this caused any issues anywhere, but I found this after making changes in a forked WorldEdit.