### PR TITLE
Improve schematic filename exception handling

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/RecursiveDirectoryWatcher.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/RecursiveDirectoryWatcher.java
@@ -122,8 +122,13 @@ public class RecursiveDirectoryWatcher implements Closeable {
                 if (Files.isDirectory(path)) {
                     triggerInitialEvents(path);
                 } else {
-                    path = WorldEdit.getInstance().getSafeOpenFile(null, schematicRoot.toFile(), schematicRoot.relativize(path).toString(), null).toPath();
-                    eventConsumer.accept(new FileCreatedEvent(path));
+                    try {
+                        path = WorldEdit.getInstance().getSafeOpenFile(null, schematicRoot.toFile(), schematicRoot.relativize(path).toString(), null).toPath();
+                        eventConsumer.accept(new FileCreatedEvent(path));
+                    } catch (FilenameException e) {
+                        // Invalid filename, warn but don't fail.
+                        LOGGER.warn("Illegal file detected", e);
+                    }
                 }
             }
         }
@@ -182,17 +187,22 @@ public class RecursiveDirectoryWatcher implements Closeable {
                         path = parentPath.resolve(path);
 
                         if (kind.equals(StandardWatchEventKinds.ENTRY_CREATE)) {
-                            path = WorldEdit.getInstance().getSafeOpenFile(null, schematicRoot.toFile(), schematicRoot.relativize(path).toString(), null).toPath();
+                            try {
+                                path = WorldEdit.getInstance().getSafeOpenFile(null, schematicRoot.toFile(), schematicRoot.relativize(path).toString(), null).toPath();
 
-                            if (Files.isDirectory(path)) { // new subfolder created, create watch for it
-                                try {
-                                    registerFolderWatcher(path);
-                                    triggerInitialEvents(path);
-                                } catch (IOException | FilenameException e) {
-                                    LOGGER.error(e);
+                                if (Files.isDirectory(path)) { // new subfolder created, create watch for it
+                                    try {
+                                        registerFolderWatcher(path);
+                                        triggerInitialEvents(path);
+                                    } catch (IOException | FilenameException e) {
+                                        LOGGER.error(e);
+                                    }
+                                } else { // new file created
+                                    eventConsumer.accept(new FileCreatedEvent(path));
                                 }
-                            } else { // new file created
-                                eventConsumer.accept(new FileCreatedEvent(path));
+                            } catch (FilenameException e) {
+                                // Invalid filename, warn but don't fail.
+                                LOGGER.warn("Illegal file detected", e);
                             }
                         } else if (kind.equals(StandardWatchEventKinds.ENTRY_DELETE)) {
                             // When we are notified about a deleted entry, we can't simply ask the filesystem
@@ -218,7 +228,7 @@ public class RecursiveDirectoryWatcher implements Closeable {
                         }
                     }
                 }
-            } catch (ClosedWatchServiceException | FilenameException ignored) {
+            } catch (ClosedWatchServiceException ignored) {
                 // Watch service closed, exit
             }
             LOGGER.debug("RecursiveDirectoryWatcher::EventConsumer exited");

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/RecursiveDirectoryWatcher.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/RecursiveDirectoryWatcher.java
@@ -189,20 +189,21 @@ public class RecursiveDirectoryWatcher implements Closeable {
                         if (kind.equals(StandardWatchEventKinds.ENTRY_CREATE)) {
                             try {
                                 path = WorldEdit.getInstance().getSafeOpenFile(null, schematicRoot.toFile(), schematicRoot.relativize(path).toString(), null).toPath();
-
-                                if (Files.isDirectory(path)) { // new subfolder created, create watch for it
-                                    try {
-                                        registerFolderWatcher(path);
-                                        triggerInitialEvents(path);
-                                    } catch (IOException | FilenameException e) {
-                                        LOGGER.error(e);
-                                    }
-                                } else { // new file created
-                                    eventConsumer.accept(new FileCreatedEvent(path));
-                                }
                             } catch (FilenameException e) {
                                 // Invalid filename, warn but don't fail.
                                 LOGGER.warn("Illegal file detected", e);
+                                continue;
+                            }
+
+                            if (Files.isDirectory(path)) { // new subfolder created, create watch for it
+                                try {
+                                    registerFolderWatcher(path);
+                                    triggerInitialEvents(path);
+                                } catch (IOException | FilenameException e) {
+                                    LOGGER.error(e);
+                                }
+                            } else { // new file created
+                                eventConsumer.accept(new FileCreatedEvent(path));
                             }
                         } else if (kind.equals(StandardWatchEventKinds.ENTRY_DELETE)) {
                             // When we are notified about a deleted entry, we can't simply ask the filesystem


### PR DESCRIPTION
Currently if the watcher encounters an illegal file it kills the watcher. Instead it should warn for this specific file, but continue along so that one single bad file doesn't prevent others being seen.