### PR TITLE
[Bukkit] Fix regen on 26.1+

### DIFF
--- a/worldedit-bukkit/adapters/adapter-26.1/build.gradle.kts
+++ b/worldedit-bukkit/adapters/adapter-26.1/build.gradle.kts
@@ -6,5 +6,5 @@ plugins {
 
 dependencies {
     // https://artifactory.papermc.io/ui/native/universe/io/papermc/paper/dev-bundle/
-    the<PaperweightUserDependenciesExtension>().paperDevBundle("26.1.1.build.14-alpha")
+    the<PaperweightUserDependenciesExtension>().paperDevBundle("26.1.1.build.29-alpha")
 }

--- a/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
@@ -139,6 +139,7 @@ import net.minecraft.world.level.levelgen.structure.BoundingBox;
 import net.minecraft.world.level.levelgen.structure.Structure;
 import net.minecraft.world.level.levelgen.structure.StructureStart;
 import net.minecraft.world.level.storage.LevelStorageSource;
+import net.minecraft.world.level.storage.SavedDataStorage;
 import net.minecraft.world.level.storage.TagValueInput;
 import net.minecraft.world.level.storage.TagValueOutput;
 import net.minecraft.world.phys.BlockHitResult;
@@ -234,7 +235,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         var unused = CraftServer.class.cast(Bukkit.getServer());
 
         int dataVersion = SharedConstants.getCurrentVersion().dataVersion().version();
-        if (dataVersion != Constants.DATA_VERSION_MC_26_1 && dataVersion != Constants.DATA_VERSION_MC_26_1_1) {
+        if (dataVersion < Constants.DATA_VERSION_MC_26_1 || dataVersion > Constants.DATA_VERSION_MC_26_1_2) {
             logger.warning(WRONG_VERSION);
         }
 
@@ -793,7 +794,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
                     env,
                     gen,
                     bukkitWorld.getBiomeProvider(),
-                    originalWorld.getDataStorage(),
+                    new SavedDataStorage(session.getDimensionPath(originalWorld.dimension()), originalWorld.getServer().getFixerUpper(), originalWorld.registryAccess()),
                     loadedWorldData
             );
             try {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/Constants.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/Constants.java
@@ -144,4 +144,9 @@ public final class Constants {
      * The DataVersion for Minecraft 26.1.1.
      */
     public static final int DATA_VERSION_MC_26_1_1 = 4788;
+
+    /**
+     * The DataVersion for Minecraft 26.1.2.
+     */
+    public static  final int DATA_VERSION_MC_26_1_2 = 4790;
 }


### PR DESCRIPTION
This PR fixes regen on Paper 26.1+

Spigot is extremely broken still, and may not be feasible to support for regen depending on how their world system ends up.