### PR TITLE
Filter `push` GH Actions run to version and master branches

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,5 +1,11 @@
 name: Gradle Build
-on: [push, pull_request, merge_group]
+on:
+  push:
+    branches:
+      - 'master'
+      - 'version/*'
+  pull_request:
+  merge_group:
 
 jobs:
   build:


### PR DESCRIPTION
Just to reduce the number of redundant runs when someone with push access makes a PR