### PR TITLE
Cleanup non-platform registry init

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightAdapter.java
@@ -70,7 +70,6 @@ import com.sk89q.worldedit.world.entity.EntityTypes;
 import com.sk89q.worldedit.world.generation.ConfiguredFeatureType;
 import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.generation.TreeType;
-import com.sk89q.worldedit.world.generation.WorldEditTreeTypes;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.SharedConstants;
@@ -979,7 +978,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
                 }
             }
         }
-        WorldEditTreeTypes.init();
 
         // BiomeCategories
         Registry<Biome> biomeRegistry = server.registryAccess().lookupOrThrow(Registries.BIOME);

--- a/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
@@ -70,7 +70,6 @@ import com.sk89q.worldedit.world.entity.EntityTypes;
 import com.sk89q.worldedit.world.generation.ConfiguredFeatureType;
 import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.generation.TreeType;
-import com.sk89q.worldedit.world.generation.WorldEditTreeTypes;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.SharedConstants;
@@ -943,7 +942,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
                 }
             }
         }
-        WorldEditTreeTypes.init();
 
         // BiomeCategories
         Registry<Biome> biomeRegistry = server.registryAccess().lookupOrThrow(Registries.BIOME);

--- a/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
@@ -70,7 +70,6 @@ import com.sk89q.worldedit.world.entity.EntityTypes;
 import com.sk89q.worldedit.world.generation.ConfiguredFeatureType;
 import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.generation.TreeType;
-import com.sk89q.worldedit.world.generation.WorldEditTreeTypes;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.SharedConstants;
@@ -941,7 +940,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
                 }
             }
         }
-        WorldEditTreeTypes.init();
 
         // BiomeCategories
         Registry<Biome> biomeRegistry = server.registryAccess().lookupOrThrow(Registries.BIOME);

--- a/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
@@ -70,7 +70,6 @@ import com.sk89q.worldedit.world.entity.EntityTypes;
 import com.sk89q.worldedit.world.generation.ConfiguredFeatureType;
 import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.generation.TreeType;
-import com.sk89q.worldedit.world.generation.WorldEditTreeTypes;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.SharedConstants;
@@ -978,7 +977,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
                 }
             }
         }
-        WorldEditTreeTypes.init();
 
         // BiomeCategories
         Registry<Biome> biomeRegistry = server.registryAccess().lookupOrThrow(Registries.BIOME);

--- a/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightAdapter.java
@@ -70,7 +70,6 @@ import com.sk89q.worldedit.world.entity.EntityTypes;
 import com.sk89q.worldedit.world.generation.ConfiguredFeatureType;
 import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.generation.TreeType;
-import com.sk89q.worldedit.world.generation.WorldEditTreeTypes;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.SharedConstants;
@@ -976,7 +975,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
                 }
             }
         }
-        WorldEditTreeTypes.init();
 
         // BiomeCategories
         Registry<Biome> biomeRegistry = server.registryAccess().lookupOrThrow(Registries.BIOME);

--- a/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
@@ -69,7 +69,6 @@ import com.sk89q.worldedit.world.entity.EntityTypes;
 import com.sk89q.worldedit.world.generation.ConfiguredFeatureType;
 import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.generation.TreeType;
-import com.sk89q.worldedit.world.generation.WorldEditTreeTypes;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 import io.papermc.paper.world.PaperWorldLoader;
@@ -969,7 +968,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
                 }
             }
         }
-        WorldEditTreeTypes.init();
 
         // BiomeCategories
         Registry<Biome> biomeRegistry = server.registryAccess().lookupOrThrow(Registries.BIOME);

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -47,7 +47,7 @@ import com.sk89q.worldedit.extent.inventory.BlockBag;
 import com.sk89q.worldedit.internal.anvil.ChunkDeleter;
 import com.sk89q.worldedit.internal.command.CommandUtil;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
-import com.sk89q.worldedit.registry.Registries;
+import com.sk89q.worldedit.registry.CommonRegistries;
 import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.util.concurrency.LazyReference;
 import com.sk89q.worldedit.util.lifecycle.Lifecycled;
@@ -58,10 +58,8 @@ import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.FuzzyBlockState;
 import com.sk89q.worldedit.world.entity.EntityType;
-import com.sk89q.worldedit.world.gamemode.GameModes;
 import com.sk89q.worldedit.world.item.ItemCategory;
 import com.sk89q.worldedit.world.item.ItemType;
-import com.sk89q.worldedit.world.weather.WeatherTypes;
 import io.papermc.lib.PaperLib;
 import io.papermc.paper.ServerBuildInfo;
 import net.kyori.adventure.key.Key;
@@ -248,10 +246,8 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
             adapter.initializeRegistries();
         }
 
-        // ... :|
-        GameModes.get("");
-        WeatherTypes.get("");
-        Registries.get("");
+        // Common registries
+        CommonRegistries.init();
     }
 
     private void setupTags() {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/registry/CommonRegistries.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/registry/CommonRegistries.java
@@ -1,0 +1,42 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.registry;
+
+import com.sk89q.worldedit.world.gamemode.GameModes;
+import com.sk89q.worldedit.world.generation.WorldEditTreeTypes;
+import com.sk89q.worldedit.world.weather.WeatherTypes;
+
+public final class CommonRegistries {
+
+    private CommonRegistries() {
+    }
+
+    /**
+     * Initializes registries that do not require any platform code.
+     */
+    public static void init() {
+        WorldEditTreeTypes.init();
+
+        // ... :|
+        GameModes.get("");
+        WeatherTypes.get("");
+        com.sk89q.worldedit.registry.Registries.get("");
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/registry/Registries.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/registry/Registries.java
@@ -29,6 +29,7 @@ import com.sk89q.worldedit.world.fluid.FluidType;
 import com.sk89q.worldedit.world.gamemode.GameMode;
 import com.sk89q.worldedit.world.generation.ConfiguredFeatureType;
 import com.sk89q.worldedit.world.generation.StructureType;
+import com.sk89q.worldedit.world.generation.TreeType;
 import com.sk89q.worldedit.world.item.ItemCategory;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.weather.WeatherType;
@@ -36,6 +37,7 @@ import com.sk89q.worldedit.world.weather.WeatherType;
 import javax.annotation.Nullable;
 
 public class Registries {
+    public static final Registry<Registry<?>> REGISTRY = addRegistry(Registry.REGISTRY);
     public static final Registry<BlockType> BLOCK_TYPE = addRegistry(BlockType.REGISTRY);
     public static final Registry<BlockCategory> BLOCK_CATEGORY = addRegistry(BlockCategory.REGISTRY);
     public static final Registry<ItemType> ITEM_TYPE = addRegistry(ItemType.REGISTRY);
@@ -49,6 +51,7 @@ public class Registries {
     public static final Registry<FluidCategory> FLUID_CATEGORY = addRegistry(FluidCategory.REGISTRY);
     public static final Registry<ConfiguredFeatureType> CONFIGURED_FEATURE_TYPE = addRegistry(ConfiguredFeatureType.REGISTRY);
     public static final Registry<StructureType> STRUCTURE_TYPE = addRegistry(StructureType.REGISTRY);
+    public static final Registry<TreeType> TREE_TYPE = addRegistry(TreeType.REGISTRY);
 
     private static <T extends Keyed> Registry<T> addRegistry(Registry<T> registry) {
         Registry.REGISTRY.register(registry.id(), registry);

--- a/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorldEdit.java
+++ b/worldedit-fabric/src/main/java/com/sk89q/worldedit/fabric/FabricWorldEdit.java
@@ -34,6 +34,7 @@ import com.sk89q.worldedit.extension.platform.PlatformManager;
 import com.sk89q.worldedit.internal.anvil.ChunkDeleter;
 import com.sk89q.worldedit.internal.event.InteractionDebouncer;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
+import com.sk89q.worldedit.registry.CommonRegistries;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.lifecycle.Lifecycled;
 import com.sk89q.worldedit.util.lifecycle.SimpleLifecycled;
@@ -42,14 +43,11 @@ import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockCategory;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.entity.EntityType;
-import com.sk89q.worldedit.world.gamemode.GameModes;
 import com.sk89q.worldedit.world.generation.ConfiguredFeatureType;
 import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.generation.TreeType;
-import com.sk89q.worldedit.world.generation.WorldEditTreeTypes;
 import com.sk89q.worldedit.world.item.ItemCategory;
 import com.sk89q.worldedit.world.item.ItemType;
-import com.sk89q.worldedit.world.weather.WeatherTypes;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
@@ -320,12 +318,9 @@ public class FabricWorldEdit implements ModInitializer {
                 }
             }
         }
-        WorldEditTreeTypes.init();
 
-        // ... :|
-        GameModes.get("");
-        WeatherTypes.get("");
-        com.sk89q.worldedit.registry.Registries.get("");
+        // Common registries
+        CommonRegistries.init();
     }
 
     private void onStartingServer(MinecraftServer minecraftServer) {

--- a/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgeWorldEdit.java
+++ b/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgeWorldEdit.java
@@ -35,6 +35,7 @@ import com.sk89q.worldedit.extension.platform.PlatformManager;
 import com.sk89q.worldedit.internal.anvil.ChunkDeleter;
 import com.sk89q.worldedit.internal.event.InteractionDebouncer;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
+import com.sk89q.worldedit.registry.CommonRegistries;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.world.biome.BiomeCategory;
@@ -42,14 +43,11 @@ import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockCategory;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.entity.EntityType;
-import com.sk89q.worldedit.world.gamemode.GameModes;
 import com.sk89q.worldedit.world.generation.ConfiguredFeatureType;
 import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.generation.TreeType;
-import com.sk89q.worldedit.world.generation.WorldEditTreeTypes;
 import com.sk89q.worldedit.world.item.ItemCategory;
 import com.sk89q.worldedit.world.item.ItemType;
-import com.sk89q.worldedit.world.weather.WeatherTypes;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
@@ -247,12 +245,9 @@ public class NeoForgeWorldEdit {
                 }
             }
         }
-        WorldEditTreeTypes.init();
 
-        // ... :|
-        GameModes.get("");
-        WeatherTypes.get("");
-        com.sk89q.worldedit.registry.Registries.get("");
+        // Common registries
+        CommonRegistries.init();
     }
 
     @SubscribeEvent

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorldEdit.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorldEdit.java
@@ -35,13 +35,12 @@ import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.extension.platform.PlatformManager;
 import com.sk89q.worldedit.internal.anvil.ChunkDeleter;
 import com.sk89q.worldedit.internal.command.CommandUtil;
-import com.sk89q.worldedit.registry.Registries;
+import com.sk89q.worldedit.registry.CommonRegistries;
 import com.sk89q.worldedit.sponge.config.SpongeConfiguration;
 import com.sk89q.worldedit.world.biome.BiomeCategory;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockCategory;
 import com.sk89q.worldedit.world.generation.TreeType;
-import com.sk89q.worldedit.world.generation.WorldEditTreeTypes;
 import com.sk89q.worldedit.world.item.ItemCategory;
 import net.kyori.adventure.audience.Audience;
 import org.apache.logging.log4j.Logger;
@@ -224,7 +223,6 @@ public class SpongeWorldEdit {
                 }
             }
         });
-        WorldEditTreeTypes.init();
         event.game().registry(RegistryTypes.BLOCK_TYPE).tags().forEach(blockTypeTag -> {
             String id = blockTypeTag.key().asString();
             if (!BlockCategory.REGISTRY.keySet().contains(id)) {
@@ -244,7 +242,8 @@ public class SpongeWorldEdit {
             }
         });
 
-        Registries.get("");
+        // Common registries
+        CommonRegistries.init();
 
         config.load();
         WorldEdit.getInstance().getEventBus().post(new ConfigurationLoadEvent(config));


### PR DESCRIPTION
This PR cleans up registry init of non-platform-specific registries.

Also fixed that TREE_TYPE and REGISTRY were missing from our registry registry