### PR TITLE
[Bukkit] Cleanup adapter version warnings

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightAdapter.java
@@ -217,14 +217,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
     private static final RandomSource random = RandomSource.create();
 
-    private static final String WRONG_VERSION =
-            """
-            This version of WorldEdit has not been tested with the current Minecraft version.
-            While it may work, there might be unexpected issues.
-            It is recommended to use a version of WorldEdit that supports your Minecraft version.
-            For more information, see https://worldedit.enginehub.org/en/latest/faq/#bukkit-adapters
-            """.stripIndent();
-
     // ------------------------------------------------------------------------
     // Code that may break between versions of Minecraft
     // ------------------------------------------------------------------------
@@ -236,10 +228,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
         int dataVersion = SharedConstants.getCurrentVersion().dataVersion().version();
         if (dataVersion != Constants.DATA_VERSION_MC_1_21_11) {
-            logger.warning(WRONG_VERSION);
-        }
-        if (dataVersion >= Constants.DATA_VERSION_MC_26_1) {
-            throw new RuntimeException("Force prevent this loading on 26.1+");
+            throw new RuntimeException("Force prevent this loading on >=26.1 or <=1.21.10");
         }
 
         serverWorldsField = CraftServer.class.getDeclaredField("worlds");

--- a/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
@@ -226,7 +226,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
         int dataVersion = SharedConstants.getCurrentVersion().getDataVersion().getVersion();
         if (dataVersion != Constants.DATA_VERSION_MC_1_21_4) {
-            throw new UnsupportedClassVersionError("Not 1.21.4!");
+            throw new RuntimeException("Not 1.21.4!");
         }
 
         serverWorldsField = CraftServer.class.getDeclaredField("worlds");

--- a/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
@@ -226,7 +226,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
         int dataVersion = SharedConstants.getCurrentVersion().getDataVersion().getVersion();
         if (dataVersion != Constants.DATA_VERSION_MC_1_21_5) {
-            throw new UnsupportedClassVersionError("Not 1.21.5!");
+            throw new RuntimeException("Not 1.21.5!");
         }
 
         serverWorldsField = CraftServer.class.getDeclaredField("worlds");

--- a/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
@@ -218,14 +218,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
     private static final RandomSource random = RandomSource.create();
 
-    private static final String WRONG_VERSION =
-        """
-        This version of WorldEdit has not been tested with the current Minecraft version.
-        While it may work, there might be unexpected issues.
-        It is recommended to use a version of WorldEdit that supports your Minecraft version.
-        For more information, see https://worldedit.enginehub.org/en/latest/faq/#bukkit-adapters
-        """.stripIndent();
-
     // ------------------------------------------------------------------------
     // Code that may break between versions of Minecraft
     // ------------------------------------------------------------------------
@@ -237,7 +229,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
         int dataVersion = SharedConstants.getCurrentVersion().dataVersion().version();
         if (dataVersion < Constants.DATA_VERSION_MC_1_21_6 || dataVersion > Constants.DATA_VERSION_MC_1_21_8) {
-            logger.warning(WRONG_VERSION);
+            throw new RuntimeException("Force prevent this loading on >=1.21.9 or <=1.21.5");
         }
 
         serverWorldsField = CraftServer.class.getDeclaredField("worlds");

--- a/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightAdapter.java
@@ -217,14 +217,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
     private static final RandomSource random = RandomSource.create();
 
-    private static final String WRONG_VERSION =
-        """
-        This version of WorldEdit has not been tested with the current Minecraft version.
-        While it may work, there might be unexpected issues.
-        It is recommended to use a version of WorldEdit that supports your Minecraft version.
-        For more information, see https://worldedit.enginehub.org/en/latest/faq/#bukkit-adapters
-        """.stripIndent();
-
     // ------------------------------------------------------------------------
     // Code that may break between versions of Minecraft
     // ------------------------------------------------------------------------
@@ -236,7 +228,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
         int dataVersion = SharedConstants.getCurrentVersion().dataVersion().version();
         if (dataVersion != Constants.DATA_VERSION_MC_1_21_9 && dataVersion != Constants.DATA_VERSION_MC_1_21_10) {
-            logger.warning(WRONG_VERSION);
+            throw new RuntimeException("Force prevent this loading on >=1.21.11 or <=1.21.8");
         }
 
         serverWorldsField = CraftServer.class.getDeclaredField("worlds");

--- a/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
@@ -224,7 +224,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             While it may work, there might be unexpected issues.
             It is recommended to use a version of WorldEdit that supports your Minecraft version.
             For more information, see https://worldedit.enginehub.org/en/latest/faq/#bukkit-adapters
-            """.stripIndent();
+            """;
 
     // ------------------------------------------------------------------------
     // Code that may break between versions of Minecraft
@@ -237,6 +237,9 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
 
         int dataVersion = SharedConstants.getCurrentVersion().dataVersion().version();
         if (dataVersion < Constants.DATA_VERSION_MC_26_1 || dataVersion > Constants.DATA_VERSION_MC_26_1_2) {
+            if (dataVersion <= Constants.DATA_VERSION_MC_1_21_11) {
+                throw new RuntimeException("Force prevent this loading on <=1.21.11");
+            }
             logger.warning(WRONG_VERSION);
         }
 


### PR DESCRIPTION
This PR changes the "wrong version" warnings to only show up for the latest adapter. The old ones we know for certain, it's only the new ones that are ambiguous (eg, 26.1.3 could release next week but still be compatible).

This should prevent cases where other adapters are partially compatible and cause erroneous warnings.