### PR TITLE
Made the RecursiveDirectoryWatcher thread a daemon

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/RecursiveDirectoryWatcher.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/RecursiveDirectoryWatcher.java
@@ -235,6 +235,7 @@ public class RecursiveDirectoryWatcher implements Closeable {
             LOGGER.debug("RecursiveDirectoryWatcher::EventConsumer exited");
         });
         watchThread.setName("WorldEdit-RecursiveDirectoryWatcher");
+        watchThread.setDaemon(true);
         watchThread.start();
     }
 


### PR DESCRIPTION
Makes this thread a daemon to prevent any possible issues, although I wasn't able to reproduce anything but it should theoretically work. Fixes #2955