### PR TITLE
Improve //hollow command

### DIFF
--- a/verification/src/changes/accepted-bukkit-public-api-changes.json
+++ b/verification/src/changes/accepted-bukkit-public-api-changes.json
@@ -8,5 +8,15 @@
                 "ANNOTATION_REMOVED"
             ]
         }
+    ],
+    "Replaced by default method": [
+        {
+            "type": "com.sk89q.worldedit.bukkit.BukkitBlockRegistry",
+            "member": "Method com.sk89q.worldedit.bukkit.BukkitBlockRegistry.getMaterial(com.sk89q.worldedit.world.block.BlockType)",
+            "changes": [
+                "METHOD_REMOVED",
+                "ANNOTATION_REMOVED"
+            ]
+        }
     ]
 }

--- a/verification/src/changes/accepted-bukkit-public-api-changes.json
+++ b/verification/src/changes/accepted-bukkit-public-api-changes.json
@@ -1,2 +1,12 @@
 {
+    "Replaced by default method": [
+        {
+            "type": "com.sk89q.worldedit.bukkit.BukkitBlockRegistry",
+            "member": "Method com.sk89q.worldedit.bukkit.BukkitBlockRegistry.getMaterial(com.sk89q.worldedit.world.block.BlockType)",
+            "changes": [
+                "METHOD_REMOVED",
+                "ANNOTATION_REMOVED"
+            ]
+        }
+    ]
 }

--- a/verification/src/changes/accepted-core-public-api-changes.json
+++ b/verification/src/changes/accepted-core-public-api-changes.json
@@ -22,6 +22,13 @@
             "changes": [
                 "METHOD_REMOVED"
             ]
+        },
+        {
+            "type": "com.sk89q.worldedit.EditSession",
+            "member": "Method com.sk89q.worldedit.EditSession.makeCuboidFaces(com.sk89q.worldedit.regions.Region,int,com.sk89q.worldedit.function.pattern.Pattern)",
+            "changes": [
+                "METHOD_NOW_FINAL"
+            ]
         }
     ],
     "RegionIntersection renamed to RegionUnion": [

--- a/verification/src/changes/accepted-core-public-api-changes.json
+++ b/verification/src/changes/accepted-core-public-api-changes.json
@@ -141,5 +141,14 @@
                 "ANNOTATION_REMOVED"
             ]
         }
+    ],
+    "Why on earth is this even an issue?": [
+        {
+            "type": "com.sk89q.worldedit.world.registry.BlockMaterial",
+            "member": "Method com.sk89q.worldedit.world.registry.BlockMaterial.isFullCube()",
+            "changes": [
+                "METHOD_ABSTRACT_NOW_DEFAULT"
+            ]
+        }
     ]
 }

--- a/verification/src/changes/accepted-core-public-api-changes.json
+++ b/verification/src/changes/accepted-core-public-api-changes.json
@@ -102,6 +102,14 @@
         },
         {
             "type": "com.sk89q.worldedit.world.registry.BlockRegistry",
+            "member": "Method com.sk89q.worldedit.world.registry.BlockRegistry.getMaterial(com.sk89q.worldedit.world.block.BlockType)",
+            "changes": [
+                "METHOD_ABSTRACT_NOW_DEFAULT",
+                "ANNOTATION_DEPRECATED_ADDED"
+            ]
+        },
+        {
+            "type": "com.sk89q.worldedit.world.registry.BlockRegistry",
             "member": "Method com.sk89q.worldedit.world.registry.BlockRegistry.getName(com.sk89q.worldedit.world.block.BlockType)",
             "changes": [
                 "METHOD_REMOVED",

--- a/verification/src/changes/accepted-core-public-api-changes.json
+++ b/verification/src/changes/accepted-core-public-api-changes.json
@@ -148,5 +148,15 @@
                 "METHOD_REMOVED"
             ]
         }
+    ],
+    "//hollow overhaul": [
+        {
+            "type": "com.sk89q.worldedit.EditSession",
+            "member": "Method com.sk89q.worldedit.EditSession.hollowOutRegion(com.sk89q.worldedit.regions.Region,int,com.sk89q.worldedit.function.pattern.Pattern)",
+            "changes": [
+                "METHOD_NOW_FINAL",
+                "ANNOTATION_DEPRECATED_ADDED"
+            ]
+        }
     ]
 }

--- a/verification/src/changes/accepted-core-public-api-changes.json
+++ b/verification/src/changes/accepted-core-public-api-changes.json
@@ -101,6 +101,14 @@
             ]
         },
         {
+            "type": "com.sk89q.worldedit.world.registry.BlockMaterial",
+            "member": "Method com.sk89q.worldedit.world.registry.BlockMaterial.isFullCube()",
+            "changes": [
+                "METHOD_ABSTRACT_NOW_DEFAULT",
+                "ANNOTATION_DEPRECATED_ADDED"
+            ]
+        },
+        {
             "type": "com.sk89q.worldedit.world.registry.BlockRegistry",
             "member": "Method com.sk89q.worldedit.world.registry.BlockRegistry.getMaterial(com.sk89q.worldedit.world.block.BlockType)",
             "changes": [

--- a/verification/src/changes/accepted-sponge-public-api-changes.json
+++ b/verification/src/changes/accepted-sponge-public-api-changes.json
@@ -1,2 +1,11 @@
 {
+    "Replaced by default method": [
+        {
+            "type": "com.sk89q.worldedit.sponge.SpongeBlockRegistry",
+            "member": "Method com.sk89q.worldedit.sponge.SpongeBlockRegistry.getMaterial(com.sk89q.worldedit.world.block.BlockType)",
+            "changes": [
+                "METHOD_REMOVED"
+            ]
+        }
+    ]
 }

--- a/verification/src/changes/accepted-sponge-public-api-changes.json
+++ b/verification/src/changes/accepted-sponge-public-api-changes.json
@@ -6,6 +6,13 @@
             "changes": [
                 "METHOD_REMOVED"
             ]
+        },
+        {
+            "type": "com.sk89q.worldedit.sponge.SpongeBlockMaterial",
+            "member": "Method com.sk89q.worldedit.sponge.SpongeBlockMaterial.isFullCube()",
+            "changes": [
+                "METHOD_REMOVED"
+            ]
         }
     ]
 }

--- a/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightAdapter.java
@@ -586,6 +586,11 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightBlockMaterial(mcBlockState);
     }
 
+    @Override
+    public BlockMaterial getBlockMaterial(BlockState blockState) {
+        return new PaperweightBlockMaterial(adapt(blockState));
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property, Property<?>> PROPERTY_CACHE = CacheBuilder.newBuilder().build(new CacheLoader<>() {
         @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightAdapter.java
@@ -439,7 +439,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightWorldNativeAccess(this, new WeakReference<>(((CraftWorld) world).getHandle()));
     }
 
-    private static net.minecraft.core.Direction adapt(Direction face) {
+    public static net.minecraft.core.Direction adapt(Direction face) {
         return switch (face) {
             case NORTH -> net.minecraft.core.Direction.NORTH;
             case SOUTH -> net.minecraft.core.Direction.SOUTH;

--- a/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightAdapter.java
@@ -606,6 +606,11 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightBlockMaterial(mcBlockState);
     }
 
+    @Override
+    public BlockMaterial getBlockMaterial(BlockState blockState) {
+        return new PaperweightBlockMaterial(adapt(blockState));
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property, Property<?>> PROPERTY_CACHE = CacheBuilder.newBuilder().build(new CacheLoader<>() {
         @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightAdapter.java
@@ -459,7 +459,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightWorldNativeAccess(this, new WeakReference<>(((CraftWorld) world).getHandle()));
     }
 
-    private static net.minecraft.core.Direction adapt(Direction face) {
+    public static net.minecraft.core.Direction adapt(Direction face) {
         return switch (face) {
             case NORTH -> net.minecraft.core.Direction.NORTH;
             case SOUTH -> net.minecraft.core.Direction.SOUTH;

--- a/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightBlockMaterial.java
@@ -19,7 +19,8 @@
 
 package com.sk89q.worldedit.bukkit.adapter.impl.v1_21_11;
 
-import com.sk89q.worldedit.world.registry.BlockMaterial;
+import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -27,8 +28,10 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
-public class PaperweightBlockMaterial implements BlockMaterial {
+public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> {
 
     private final BlockState block;
 
@@ -42,8 +45,16 @@ public class PaperweightBlockMaterial implements BlockMaterial {
     }
 
     @Override
-    public boolean isFullCube() {
-        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
+    protected VoxelShape getShape(ShapeType shapeType) {
+        return switch (shapeType) {
+            case SHAPE -> block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+            case VISUAL_SHAPE -> block.getVisualShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+        };
+    }
+
+    @Override
+    protected boolean isShapeFullBlock(VoxelShape shape) {
+        return Block.isShapeFullBlock(shape);
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightBlockMaterial.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.bukkit.adapter.impl.v1_21_11;
 
 import com.sk89q.worldedit.blocks.ShapeType;
 import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
+import com.sk89q.worldedit.util.Direction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -55,6 +56,11 @@ public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> 
     @Override
     protected boolean isShapeFullBlock(VoxelShape shape) {
         return Block.isShapeFullBlock(shape);
+    }
+
+    @Override
+    protected boolean isFaceFull(VoxelShape shape, Direction face) {
+        return Block.isFaceFull(shape, PaperweightAdapter.adapt(face));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightBlockMaterial.java
@@ -19,7 +19,8 @@
 
 package com.sk89q.worldedit.bukkit.adapter.impl.v1_21_11;
 
-import com.sk89q.worldedit.world.registry.BlockMaterial;
+import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -27,8 +28,10 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
-public class PaperweightBlockMaterial implements BlockMaterial {
+public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> {
 
     private final BlockState block;
 
@@ -41,9 +44,16 @@ public class PaperweightBlockMaterial implements BlockMaterial {
         return block.isAir();
     }
 
+    private VoxelShape getShape(ShapeType shapeType) {
+        return switch (shapeType) {
+            case SHAPE -> block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+            case VISUAL_SHAPE -> block.getVisualShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+        };
+    }
+
     @Override
-    public boolean isFullCube() {
-        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
+    protected boolean isFullCubeUncached(ShapeType shapeType) {
+        return Block.isShapeFullBlock(getShape(shapeType));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightBlockMaterial.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.bukkit.adapter.impl.v1_21_11;
 
 import com.sk89q.worldedit.blocks.ShapeType;
 import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
+import com.sk89q.worldedit.util.Direction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -54,6 +55,11 @@ public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> 
     @Override
     protected boolean isFullCubeUncached(ShapeType shapeType) {
         return Block.isShapeFullBlock(getShape(shapeType));
+    }
+
+    @Override
+    protected boolean isFullFaceUncached(ShapeType shapeType, Direction face) {
+        return Block.isFaceFull(getShape(shapeType), PaperweightAdapter.adapt(face));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
@@ -427,7 +427,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightWorldNativeAccess(this, new WeakReference<>(((CraftWorld) world).getHandle()));
     }
 
-    private static net.minecraft.core.Direction adapt(Direction face) {
+    public static net.minecraft.core.Direction adapt(Direction face) {
         return switch (face) {
             case NORTH -> net.minecraft.core.Direction.NORTH;
             case SOUTH -> net.minecraft.core.Direction.SOUTH;

--- a/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
@@ -567,6 +567,11 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightBlockMaterial(mcBlockState);
     }
 
+    @Override
+    public BlockMaterial getBlockMaterial(BlockState blockState) {
+        return new PaperweightBlockMaterial(adapt(blockState));
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property, Property<?>> PROPERTY_CACHE = CacheBuilder.newBuilder().build(new CacheLoader<>() {
         @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
@@ -587,6 +587,11 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightBlockMaterial(mcBlockState);
     }
 
+    @Override
+    public BlockMaterial getBlockMaterial(BlockState blockState) {
+        return new PaperweightBlockMaterial(adapt(blockState));
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property, Property<?>> PROPERTY_CACHE = CacheBuilder.newBuilder().build(new CacheLoader<>() {
         @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
@@ -447,7 +447,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightWorldNativeAccess(this, new WeakReference<>(((CraftWorld) world).getHandle()));
     }
 
-    private static net.minecraft.core.Direction adapt(Direction face) {
+    public static net.minecraft.core.Direction adapt(Direction face) {
         return switch (face) {
             case NORTH -> net.minecraft.core.Direction.NORTH;
             case SOUTH -> net.minecraft.core.Direction.SOUTH;

--- a/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightBlockMaterial.java
@@ -19,7 +19,8 @@
 
 package com.sk89q.worldedit.bukkit.adapter.impl.v1_21_4;
 
-import com.sk89q.worldedit.world.registry.BlockMaterial;
+import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -27,8 +28,10 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
-public class PaperweightBlockMaterial implements BlockMaterial {
+public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> {
 
     private final BlockState block;
 
@@ -42,8 +45,16 @@ public class PaperweightBlockMaterial implements BlockMaterial {
     }
 
     @Override
-    public boolean isFullCube() {
-        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
+    protected VoxelShape getShape(ShapeType shapeType) {
+        return switch (shapeType) {
+            case SHAPE -> block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+            case VISUAL_SHAPE -> block.getVisualShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+        };
+    }
+
+    @Override
+    protected boolean isShapeFullBlock(VoxelShape shape) {
+        return Block.isShapeFullBlock(shape);
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightBlockMaterial.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.bukkit.adapter.impl.v1_21_4;
 
 import com.sk89q.worldedit.blocks.ShapeType;
 import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
+import com.sk89q.worldedit.util.Direction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -55,6 +56,11 @@ public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> 
     @Override
     protected boolean isShapeFullBlock(VoxelShape shape) {
         return Block.isShapeFullBlock(shape);
+    }
+
+    @Override
+    protected boolean isFaceFull(VoxelShape shape, Direction face) {
+        return Block.isFaceFull(shape, PaperweightAdapter.adapt(face));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightBlockMaterial.java
@@ -19,7 +19,8 @@
 
 package com.sk89q.worldedit.bukkit.adapter.impl.v1_21_4;
 
-import com.sk89q.worldedit.world.registry.BlockMaterial;
+import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -27,8 +28,10 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
-public class PaperweightBlockMaterial implements BlockMaterial {
+public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> {
 
     private final BlockState block;
 
@@ -41,9 +44,16 @@ public class PaperweightBlockMaterial implements BlockMaterial {
         return block.isAir();
     }
 
+    private VoxelShape getShape(ShapeType shapeType) {
+        return switch (shapeType) {
+            case SHAPE -> block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+            case VISUAL_SHAPE -> block.getVisualShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+        };
+    }
+
     @Override
-    public boolean isFullCube() {
-        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
+    protected boolean isFullCubeUncached(ShapeType shapeType) {
+        return Block.isShapeFullBlock(getShape(shapeType));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightBlockMaterial.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.bukkit.adapter.impl.v1_21_4;
 
 import com.sk89q.worldedit.blocks.ShapeType;
 import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
+import com.sk89q.worldedit.util.Direction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -54,6 +55,11 @@ public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> 
     @Override
     protected boolean isFullCubeUncached(ShapeType shapeType) {
         return Block.isShapeFullBlock(getShape(shapeType));
+    }
+
+    @Override
+    protected boolean isFullFaceUncached(ShapeType shapeType, Direction face) {
+        return Block.isFaceFull(getShape(shapeType), PaperweightAdapter.adapt(face));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
@@ -427,7 +427,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightWorldNativeAccess(this, new WeakReference<>(((CraftWorld) world).getHandle()));
     }
 
-    private static net.minecraft.core.Direction adapt(Direction face) {
+    public static net.minecraft.core.Direction adapt(Direction face) {
         return switch (face) {
             case NORTH -> net.minecraft.core.Direction.NORTH;
             case SOUTH -> net.minecraft.core.Direction.SOUTH;

--- a/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
@@ -565,6 +565,11 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightBlockMaterial(mcBlockState);
     }
 
+    @Override
+    public BlockMaterial getBlockMaterial(BlockState blockState) {
+        return new PaperweightBlockMaterial(adapt(blockState));
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property, Property<?>> PROPERTY_CACHE = CacheBuilder.newBuilder().build(new CacheLoader<>() {
         @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
@@ -585,6 +585,11 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightBlockMaterial(mcBlockState);
     }
 
+    @Override
+    public BlockMaterial getBlockMaterial(BlockState blockState) {
+        return new PaperweightBlockMaterial(adapt(blockState));
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property, Property<?>> PROPERTY_CACHE = CacheBuilder.newBuilder().build(new CacheLoader<>() {
         @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
@@ -447,7 +447,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightWorldNativeAccess(this, new WeakReference<>(((CraftWorld) world).getHandle()));
     }
 
-    private static net.minecraft.core.Direction adapt(Direction face) {
+    public static net.minecraft.core.Direction adapt(Direction face) {
         return switch (face) {
             case NORTH -> net.minecraft.core.Direction.NORTH;
             case SOUTH -> net.minecraft.core.Direction.SOUTH;

--- a/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightBlockMaterial.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.bukkit.adapter.impl.v1_21_5;
 
 import com.sk89q.worldedit.blocks.ShapeType;
 import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
+import com.sk89q.worldedit.util.Direction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -55,6 +56,11 @@ public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> 
     @Override
     protected boolean isShapeFullBlock(VoxelShape shape) {
         return Block.isShapeFullBlock(shape);
+    }
+
+    @Override
+    protected boolean isFaceFull(VoxelShape shape, Direction face) {
+        return Block.isFaceFull(shape, PaperweightAdapter.adapt(face));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightBlockMaterial.java
@@ -19,7 +19,8 @@
 
 package com.sk89q.worldedit.bukkit.adapter.impl.v1_21_5;
 
-import com.sk89q.worldedit.world.registry.BlockMaterial;
+import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -27,8 +28,10 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
-public class PaperweightBlockMaterial implements BlockMaterial {
+public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> {
 
     private final BlockState block;
 
@@ -42,8 +45,16 @@ public class PaperweightBlockMaterial implements BlockMaterial {
     }
 
     @Override
-    public boolean isFullCube() {
-        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
+    protected VoxelShape getShape(ShapeType shapeType) {
+        return switch (shapeType) {
+            case SHAPE -> block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+            case VISUAL_SHAPE -> block.getVisualShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+        };
+    }
+
+    @Override
+    protected boolean isShapeFullBlock(VoxelShape shape) {
+        return Block.isShapeFullBlock(shape);
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightBlockMaterial.java
@@ -19,7 +19,8 @@
 
 package com.sk89q.worldedit.bukkit.adapter.impl.v1_21_5;
 
-import com.sk89q.worldedit.world.registry.BlockMaterial;
+import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -27,8 +28,10 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
-public class PaperweightBlockMaterial implements BlockMaterial {
+public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> {
 
     private final BlockState block;
 
@@ -41,9 +44,16 @@ public class PaperweightBlockMaterial implements BlockMaterial {
         return block.isAir();
     }
 
+    private VoxelShape getShape(ShapeType shapeType) {
+        return switch (shapeType) {
+            case SHAPE -> block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+            case VISUAL_SHAPE -> block.getVisualShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+        };
+    }
+
     @Override
-    public boolean isFullCube() {
-        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
+    protected boolean isFullCubeUncached(ShapeType shapeType) {
+        return Block.isShapeFullBlock(getShape(shapeType));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightBlockMaterial.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.bukkit.adapter.impl.v1_21_5;
 
 import com.sk89q.worldedit.blocks.ShapeType;
 import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
+import com.sk89q.worldedit.util.Direction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -54,6 +55,11 @@ public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> 
     @Override
     protected boolean isFullCubeUncached(ShapeType shapeType) {
         return Block.isShapeFullBlock(getShape(shapeType));
+    }
+
+    @Override
+    protected boolean isFullFaceUncached(ShapeType shapeType, Direction face) {
+        return Block.isFaceFull(getShape(shapeType), PaperweightAdapter.adapt(face));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
@@ -440,7 +440,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightWorldNativeAccess(this, new WeakReference<>(((CraftWorld) world).getHandle()));
     }
 
-    private static net.minecraft.core.Direction adapt(Direction face) {
+    public static net.minecraft.core.Direction adapt(Direction face) {
         return switch (face) {
             case NORTH -> net.minecraft.core.Direction.NORTH;
             case SOUTH -> net.minecraft.core.Direction.SOUTH;

--- a/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
@@ -587,6 +587,11 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightBlockMaterial(mcBlockState);
     }
 
+    @Override
+    public BlockMaterial getBlockMaterial(BlockState blockState) {
+        return new PaperweightBlockMaterial(adapt(blockState));
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property, Property<?>> PROPERTY_CACHE = CacheBuilder.newBuilder().build(new CacheLoader<>() {
         @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
@@ -460,7 +460,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightWorldNativeAccess(this, new WeakReference<>(((CraftWorld) world).getHandle()));
     }
 
-    private static net.minecraft.core.Direction adapt(Direction face) {
+    public static net.minecraft.core.Direction adapt(Direction face) {
         return switch (face) {
             case NORTH -> net.minecraft.core.Direction.NORTH;
             case SOUTH -> net.minecraft.core.Direction.SOUTH;

--- a/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
@@ -607,6 +607,11 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightBlockMaterial(mcBlockState);
     }
 
+    @Override
+    public BlockMaterial getBlockMaterial(BlockState blockState) {
+        return new PaperweightBlockMaterial(adapt(blockState));
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property, Property<?>> PROPERTY_CACHE = CacheBuilder.newBuilder().build(new CacheLoader<>() {
         @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightBlockMaterial.java
@@ -19,7 +19,8 @@
 
 package com.sk89q.worldedit.bukkit.adapter.impl.v1_21_6;
 
-import com.sk89q.worldedit.world.registry.BlockMaterial;
+import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -27,8 +28,10 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
-public class PaperweightBlockMaterial implements BlockMaterial {
+public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> {
 
     private final BlockState block;
 
@@ -42,8 +45,16 @@ public class PaperweightBlockMaterial implements BlockMaterial {
     }
 
     @Override
-    public boolean isFullCube() {
-        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
+    protected VoxelShape getShape(ShapeType shapeType) {
+        return switch (shapeType) {
+            case SHAPE -> block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+            case VISUAL_SHAPE -> block.getVisualShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+        };
+    }
+
+    @Override
+    protected boolean isShapeFullBlock(VoxelShape shape) {
+        return Block.isShapeFullBlock(shape);
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightBlockMaterial.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.bukkit.adapter.impl.v1_21_6;
 
 import com.sk89q.worldedit.blocks.ShapeType;
 import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
+import com.sk89q.worldedit.util.Direction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -55,6 +56,11 @@ public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> 
     @Override
     protected boolean isShapeFullBlock(VoxelShape shape) {
         return Block.isShapeFullBlock(shape);
+    }
+
+    @Override
+    protected boolean isFaceFull(VoxelShape shape, Direction face) {
+        return Block.isFaceFull(shape, PaperweightAdapter.adapt(face));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightBlockMaterial.java
@@ -19,7 +19,8 @@
 
 package com.sk89q.worldedit.bukkit.adapter.impl.v1_21_6;
 
-import com.sk89q.worldedit.world.registry.BlockMaterial;
+import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -27,8 +28,10 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
-public class PaperweightBlockMaterial implements BlockMaterial {
+public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> {
 
     private final BlockState block;
 
@@ -41,9 +44,16 @@ public class PaperweightBlockMaterial implements BlockMaterial {
         return block.isAir();
     }
 
+    private VoxelShape getShape(ShapeType shapeType) {
+        return switch (shapeType) {
+            case SHAPE -> block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+            case VISUAL_SHAPE -> block.getVisualShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+        };
+    }
+
     @Override
-    public boolean isFullCube() {
-        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
+    protected boolean isFullCubeUncached(ShapeType shapeType) {
+        return Block.isShapeFullBlock(getShape(shapeType));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightBlockMaterial.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.bukkit.adapter.impl.v1_21_6;
 
 import com.sk89q.worldedit.blocks.ShapeType;
 import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
+import com.sk89q.worldedit.util.Direction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -54,6 +55,11 @@ public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> 
     @Override
     protected boolean isFullCubeUncached(ShapeType shapeType) {
         return Block.isShapeFullBlock(getShape(shapeType));
+    }
+
+    @Override
+    protected boolean isFullFaceUncached(ShapeType shapeType, Direction face) {
+        return Block.isFaceFull(getShape(shapeType), PaperweightAdapter.adapt(face));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightAdapter.java
@@ -586,6 +586,11 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightBlockMaterial(mcBlockState);
     }
 
+    @Override
+    public BlockMaterial getBlockMaterial(BlockState blockState) {
+        return new PaperweightBlockMaterial(adapt(blockState));
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property, Property<?>> PROPERTY_CACHE = CacheBuilder.newBuilder().build(new CacheLoader<>() {
         @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightAdapter.java
@@ -439,7 +439,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightWorldNativeAccess(this, new WeakReference<>(((CraftWorld) world).getHandle()));
     }
 
-    private static net.minecraft.core.Direction adapt(Direction face) {
+    public static net.minecraft.core.Direction adapt(Direction face) {
         return switch (face) {
             case NORTH -> net.minecraft.core.Direction.NORTH;
             case SOUTH -> net.minecraft.core.Direction.SOUTH;

--- a/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightAdapter.java
@@ -606,6 +606,11 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightBlockMaterial(mcBlockState);
     }
 
+    @Override
+    public BlockMaterial getBlockMaterial(BlockState blockState) {
+        return new PaperweightBlockMaterial(adapt(blockState));
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property, Property<?>> PROPERTY_CACHE = CacheBuilder.newBuilder().build(new CacheLoader<>() {
         @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightAdapter.java
@@ -459,7 +459,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightWorldNativeAccess(this, new WeakReference<>(((CraftWorld) world).getHandle()));
     }
 
-    private static net.minecraft.core.Direction adapt(Direction face) {
+    public static net.minecraft.core.Direction adapt(Direction face) {
         return switch (face) {
             case NORTH -> net.minecraft.core.Direction.NORTH;
             case SOUTH -> net.minecraft.core.Direction.SOUTH;

--- a/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightBlockMaterial.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.bukkit.adapter.impl.v1_21_9;
 
 import com.sk89q.worldedit.blocks.ShapeType;
 import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
+import com.sk89q.worldedit.util.Direction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -55,6 +56,11 @@ public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> 
     @Override
     protected boolean isShapeFullBlock(VoxelShape shape) {
         return Block.isShapeFullBlock(shape);
+    }
+
+    @Override
+    protected boolean isFaceFull(VoxelShape shape, Direction face) {
+        return Block.isFaceFull(shape, PaperweightAdapter.adapt(face));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightBlockMaterial.java
@@ -19,7 +19,8 @@
 
 package com.sk89q.worldedit.bukkit.adapter.impl.v1_21_9;
 
-import com.sk89q.worldedit.world.registry.BlockMaterial;
+import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -27,8 +28,10 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
-public class PaperweightBlockMaterial implements BlockMaterial {
+public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> {
 
     private final BlockState block;
 
@@ -42,8 +45,16 @@ public class PaperweightBlockMaterial implements BlockMaterial {
     }
 
     @Override
-    public boolean isFullCube() {
-        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
+    protected VoxelShape getShape(ShapeType shapeType) {
+        return switch (shapeType) {
+            case SHAPE -> block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+            case VISUAL_SHAPE -> block.getVisualShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+        };
+    }
+
+    @Override
+    protected boolean isShapeFullBlock(VoxelShape shape) {
+        return Block.isShapeFullBlock(shape);
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightBlockMaterial.java
@@ -19,7 +19,8 @@
 
 package com.sk89q.worldedit.bukkit.adapter.impl.v1_21_9;
 
-import com.sk89q.worldedit.world.registry.BlockMaterial;
+import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -27,8 +28,10 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
-public class PaperweightBlockMaterial implements BlockMaterial {
+public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> {
 
     private final BlockState block;
 
@@ -41,9 +44,16 @@ public class PaperweightBlockMaterial implements BlockMaterial {
         return block.isAir();
     }
 
+    private VoxelShape getShape(ShapeType shapeType) {
+        return switch (shapeType) {
+            case SHAPE -> block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+            case VISUAL_SHAPE -> block.getVisualShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+        };
+    }
+
     @Override
-    public boolean isFullCube() {
-        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
+    protected boolean isFullCubeUncached(ShapeType shapeType) {
+        return Block.isShapeFullBlock(getShape(shapeType));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightBlockMaterial.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.bukkit.adapter.impl.v1_21_9;
 
 import com.sk89q.worldedit.blocks.ShapeType;
 import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
+import com.sk89q.worldedit.util.Direction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -54,6 +55,11 @@ public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> 
     @Override
     protected boolean isFullCubeUncached(ShapeType shapeType) {
         return Block.isShapeFullBlock(getShape(shapeType));
+    }
+
+    @Override
+    protected boolean isFullFaceUncached(ShapeType shapeType, Direction face) {
+        return Block.isFaceFull(getShape(shapeType), PaperweightAdapter.adapt(face));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
@@ -456,7 +456,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightWorldNativeAccess(this, new WeakReference<>(((CraftWorld) world).getHandle()));
     }
 
-    private static net.minecraft.core.Direction adapt(Direction face) {
+    public static net.minecraft.core.Direction adapt(Direction face) {
         return switch (face) {
             case NORTH -> net.minecraft.core.Direction.NORTH;
             case SOUTH -> net.minecraft.core.Direction.SOUTH;

--- a/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
@@ -603,6 +603,11 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightBlockMaterial(mcBlockState);
     }
 
+    @Override
+    public BlockMaterial getBlockMaterial(BlockState blockState) {
+        return new PaperweightBlockMaterial(adapt(blockState));
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property, Property<?>> PROPERTY_CACHE = CacheBuilder.newBuilder().build(new CacheLoader<>() {
         @Override

--- a/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
@@ -476,7 +476,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightWorldNativeAccess(this, new WeakReference<>(((CraftWorld) world).getHandle()));
     }
 
-    private static net.minecraft.core.Direction adapt(Direction face) {
+    public static net.minecraft.core.Direction adapt(Direction face) {
         return switch (face) {
             case NORTH -> net.minecraft.core.Direction.NORTH;
             case SOUTH -> net.minecraft.core.Direction.SOUTH;

--- a/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
@@ -623,6 +623,11 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightBlockMaterial(mcBlockState);
     }
 
+    @Override
+    public BlockMaterial getBlockMaterial(BlockState blockState) {
+        return new PaperweightBlockMaterial(adapt(blockState));
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property, Property<?>> PROPERTY_CACHE = CacheBuilder.newBuilder().build(new CacheLoader<>() {
         @Override

--- a/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightBlockMaterial.java
@@ -19,7 +19,8 @@
 
 package com.sk89q.worldedit.bukkit.adapter.impl.v26_1;
 
-import com.sk89q.worldedit.world.registry.BlockMaterial;
+import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -27,8 +28,10 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
-public class PaperweightBlockMaterial implements BlockMaterial {
+public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> {
 
     private final BlockState block;
 
@@ -42,8 +45,16 @@ public class PaperweightBlockMaterial implements BlockMaterial {
     }
 
     @Override
-    public boolean isFullCube() {
-        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
+    protected VoxelShape getShape(ShapeType shapeType) {
+        return switch (shapeType) {
+            case SHAPE -> block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+            case VISUAL_SHAPE -> block.getVisualShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+        };
+    }
+
+    @Override
+    protected boolean isShapeFullBlock(VoxelShape shape) {
+        return Block.isShapeFullBlock(shape);
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightBlockMaterial.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.bukkit.adapter.impl.v26_1;
 
 import com.sk89q.worldedit.blocks.ShapeType;
 import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
+import com.sk89q.worldedit.util.Direction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -55,6 +56,11 @@ public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> 
     @Override
     protected boolean isShapeFullBlock(VoxelShape shape) {
         return Block.isShapeFullBlock(shape);
+    }
+
+    @Override
+    protected boolean isFaceFull(VoxelShape shape, Direction face) {
+        return Block.isFaceFull(shape, PaperweightAdapter.adapt(face));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightBlockMaterial.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.bukkit.adapter.impl.v26_1;
 
 import com.sk89q.worldedit.blocks.ShapeType;
 import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
+import com.sk89q.worldedit.util.Direction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -54,6 +55,11 @@ public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> 
     @Override
     protected boolean isFullCubeUncached(ShapeType shapeType) {
         return Block.isShapeFullBlock(getShape(shapeType));
+    }
+
+    @Override
+    protected boolean isFullFaceUncached(ShapeType shapeType, Direction face) {
+        return Block.isFaceFull(getShape(shapeType), PaperweightAdapter.adapt(face));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightBlockMaterial.java
@@ -19,7 +19,8 @@
 
 package com.sk89q.worldedit.bukkit.adapter.impl.v26_1;
 
-import com.sk89q.worldedit.world.registry.BlockMaterial;
+import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -27,8 +28,10 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
-public class PaperweightBlockMaterial implements BlockMaterial {
+public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> {
 
     private final BlockState block;
 
@@ -41,9 +44,16 @@ public class PaperweightBlockMaterial implements BlockMaterial {
         return block.isAir();
     }
 
+    private VoxelShape getShape(ShapeType shapeType) {
+        return switch (shapeType) {
+            case SHAPE -> block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+            case VISUAL_SHAPE -> block.getVisualShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+        };
+    }
+
     @Override
-    public boolean isFullCube() {
-        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
+    protected boolean isFullCubeUncached(ShapeType shapeType) {
+        return Block.isShapeFullBlock(getShape(shapeType));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-26.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_2/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-26.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_2/PaperweightAdapter.java
@@ -477,7 +477,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightWorldNativeAccess(this, new WeakReference<>(((CraftWorld) world).getHandle()));
     }
 
-    private static net.minecraft.core.Direction adapt(Direction face) {
+    public static net.minecraft.core.Direction adapt(Direction face) {
         return switch (face) {
             case NORTH -> net.minecraft.core.Direction.NORTH;
             case SOUTH -> net.minecraft.core.Direction.SOUTH;

--- a/worldedit-bukkit/adapters/adapter-26.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_2/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-26.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_2/PaperweightAdapter.java
@@ -628,6 +628,11 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return new PaperweightBlockMaterial(mcBlockState);
     }
 
+    @Override
+    public BlockMaterial getBlockMaterial(BlockState blockState) {
+        return new PaperweightBlockMaterial(adapt(blockState));
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private static final LoadingCache<net.minecraft.world.level.block.state.properties.Property, Property<?>> PROPERTY_CACHE = CacheBuilder.newBuilder().build(new CacheLoader<>() {
         @Override

--- a/worldedit-bukkit/adapters/adapter-26.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_2/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-26.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_2/PaperweightBlockMaterial.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.bukkit.adapter.impl.v26_2;
 
 import com.sk89q.worldedit.blocks.ShapeType;
 import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
+import com.sk89q.worldedit.util.Direction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -54,6 +55,11 @@ public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> 
     @Override
     protected boolean isFullCubeUncached(ShapeType shapeType) {
         return Block.isShapeFullBlock(getShape(shapeType));
+    }
+
+    @Override
+    protected boolean isFullFaceUncached(ShapeType shapeType, Direction face) {
+        return Block.isFaceFull(getShape(shapeType), PaperweightAdapter.adapt(face));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-26.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_2/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-26.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_2/PaperweightBlockMaterial.java
@@ -19,7 +19,8 @@
 
 package com.sk89q.worldedit.bukkit.adapter.impl.v26_2;
 
-import com.sk89q.worldedit.world.registry.BlockMaterial;
+import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -27,8 +28,10 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
-public class PaperweightBlockMaterial implements BlockMaterial {
+public class PaperweightBlockMaterial extends AbstractBlockMaterial<VoxelShape> {
 
     private final BlockState block;
 
@@ -41,9 +44,16 @@ public class PaperweightBlockMaterial implements BlockMaterial {
         return block.isAir();
     }
 
+    private VoxelShape getShape(ShapeType shapeType) {
+        return switch (shapeType) {
+            case SHAPE -> block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+            case VISUAL_SHAPE -> block.getVisualShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+        };
+    }
+
     @Override
-    public boolean isFullCube() {
-        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
+    protected boolean isFullCubeUncached(ShapeType shapeType) {
+        return Block.isShapeFullBlock(getShape(shapeType));
     }
 
     @Override

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockRegistry.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockRegistry.java
@@ -35,7 +35,7 @@ import java.util.OptionalInt;
 import javax.annotation.Nullable;
 
 public class BukkitBlockRegistry implements BlockRegistry {
-    private final Map<Material, BukkitBlockMaterial> materialMap = new HashMap<>();
+    private final Map<BlockState, BukkitBlockMaterial> materialMap = new HashMap<>();
 
     @Override
     public Component getRichName(BlockType blockType) {
@@ -47,15 +47,16 @@ public class BukkitBlockRegistry implements BlockRegistry {
 
     @Nullable
     @Override
-    public BlockMaterial getMaterial(BlockType blockType) {
-        Material mat = BukkitAdapter.adapt(blockType);
-        if (mat == null) {
-            return null;
-        }
-        return materialMap.computeIfAbsent(mat, material -> {
+    public BlockMaterial getMaterial(BlockState blockState) {
+        return materialMap.computeIfAbsent(blockState, _ -> {
+            Material material = BukkitAdapter.adapt(blockState.getBlockType());
+            if (material == null) {
+                // return null means create no mapping
+                return null;
+            }
             BlockMaterial platformMaterial = null;
             if (WorldEditPlugin.getInstance().getBukkitImplAdapter() != null) {
-                platformMaterial = WorldEditPlugin.getInstance().getBukkitImplAdapter().getBlockMaterial(blockType);
+                platformMaterial = WorldEditPlugin.getInstance().getBukkitImplAdapter().getBlockMaterial(blockState);
             }
             return new BukkitBlockMaterial(platformMaterial, material);
         });

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockRegistry.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockRegistry.java
@@ -37,7 +37,7 @@ import java.util.OptionalInt;
 import javax.annotation.Nullable;
 
 public class BukkitBlockRegistry implements BlockRegistry {
-    private final Map<Material, BukkitBlockMaterial> materialMap = new HashMap<>();
+    private final Map<BlockState, BukkitBlockMaterial> materialMap = new HashMap<>();
 
     @Override
     public Component getRichName(BlockType blockType) {
@@ -49,15 +49,16 @@ public class BukkitBlockRegistry implements BlockRegistry {
 
     @Nullable
     @Override
-    public BlockMaterial getMaterial(BlockType blockType) {
-        Material mat = BukkitAdapter.adapt(blockType);
-        if (mat == null) {
-            return null;
-        }
-        return materialMap.computeIfAbsent(mat, material -> {
+    public BlockMaterial getMaterial(BlockState blockState) {
+        return materialMap.computeIfAbsent(blockState, _ -> {
+            Material material = BukkitAdapter.adapt(blockState.getBlockType());
+            if (material == null) {
+                // return null means create no mapping
+                return null;
+            }
             BlockMaterial platformMaterial = null;
             if (WorldEditPlugin.getInstance().getBukkitImplAdapter() != null) {
-                platformMaterial = WorldEditPlugin.getInstance().getBukkitImplAdapter().getBlockMaterial(blockType);
+                platformMaterial = WorldEditPlugin.getInstance().getBukkitImplAdapter().getBlockMaterial(blockState);
             }
             return new BukkitBlockMaterial(platformMaterial, material);
         });

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
@@ -162,6 +162,17 @@ public interface BukkitImplAdapter {
     BlockMaterial getBlockMaterial(BlockType blockType);
 
     /**
+     * Gets the block material for the given block state.
+     *
+     * @param blockState the block state
+     * @return the material
+     */
+    @Nullable
+    default BlockMaterial getBlockMaterial(BlockState blockState) {
+        return getBlockMaterial(blockState.getBlockType());
+    }
+
+    /**
      * Get a map of {@code string -> property}.
      *
      * @param blockType The block type

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
@@ -165,6 +165,17 @@ public interface BukkitImplAdapter {
     BlockMaterial getBlockMaterial(BlockType blockType);
 
     /**
+     * Gets the block material for the given block state.
+     *
+     * @param blockState the block state
+     * @return the material
+     */
+    @Nullable
+    default BlockMaterial getBlockMaterial(BlockState blockState) {
+        return getBlockMaterial(blockState.getBlockType());
+    }
+
+    /**
      * Get a map of {@code string -> property}.
      *
      * @param blockType The block type

--- a/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/CoreMcAdapter.java
+++ b/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/CoreMcAdapter.java
@@ -25,6 +25,7 @@ import com.sk89q.worldedit.coremc.internal.CoreMcBlockCommandSender;
 import com.sk89q.worldedit.coremc.internal.CoreMcCommandSender;
 import com.sk89q.worldedit.coremc.internal.CoreMcPlatform;
 import com.sk89q.worldedit.coremc.internal.CoreMcPlayer;
+import com.sk89q.worldedit.coremc.internal.CoreMcTransmogrifier;
 import com.sk89q.worldedit.coremc.internal.CoreMcWorld;
 import com.sk89q.worldedit.coremc.internal.NBTConverter;
 import com.sk89q.worldedit.coremc.mixin.AccessorCommandSourceStack;
@@ -121,14 +122,7 @@ public abstract class CoreMcAdapter {
     }
 
     public net.minecraft.core.Direction adapt(Direction face) {
-        return switch (face) {
-            case NORTH -> net.minecraft.core.Direction.NORTH;
-            case SOUTH -> net.minecraft.core.Direction.SOUTH;
-            case WEST -> net.minecraft.core.Direction.WEST;
-            case EAST -> net.minecraft.core.Direction.EAST;
-            case DOWN -> net.minecraft.core.Direction.DOWN;
-            default -> net.minecraft.core.Direction.UP;
-        };
+        return CoreMcTransmogrifier.transmogToMinecraft(face);
     }
 
     public Direction adaptEnumFacing(@Nullable net.minecraft.core.Direction face) {

--- a/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcBlockMaterial.java
+++ b/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcBlockMaterial.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.coremc.internal;
 
 import com.sk89q.worldedit.blocks.ShapeType;
 import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
+import com.sk89q.worldedit.util.Direction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -59,6 +60,11 @@ public final class CoreMcBlockMaterial extends AbstractBlockMaterial<VoxelShape>
     @Override
     protected boolean isShapeFullBlock(VoxelShape shape) {
         return Block.isShapeFullBlock(shape);
+    }
+
+    @Override
+    protected boolean isFaceFull(VoxelShape shape, Direction face) {
+        return Block.isFaceFull(shape, CoreMcTransmogrifier.transmogToMinecraft(face));
     }
 
     @Override

--- a/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcBlockMaterial.java
+++ b/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcBlockMaterial.java
@@ -19,7 +19,8 @@
 
 package com.sk89q.worldedit.coremc.internal;
 
-import com.sk89q.worldedit.world.registry.BlockMaterial;
+import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -27,12 +28,14 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
 /**
  * Minecraft block material implementation for platforms sharing native code.
  * Pulls as much info as possible from the Minecraft BlockState.
  */
-public final class CoreMcBlockMaterial implements BlockMaterial {
+public final class CoreMcBlockMaterial extends AbstractBlockMaterial<VoxelShape> {
 
     private final BlockState block;
 
@@ -46,8 +49,16 @@ public final class CoreMcBlockMaterial implements BlockMaterial {
     }
 
     @Override
-    public boolean isFullCube() {
-        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
+    protected VoxelShape getShape(ShapeType shapeType) {
+        return switch (shapeType) {
+            case SHAPE -> block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+            case VISUAL_SHAPE -> block.getVisualShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+        };
+    }
+
+    @Override
+    protected boolean isShapeFullBlock(VoxelShape shape) {
+        return Block.isShapeFullBlock(shape);
     }
 
     @Override

--- a/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcBlockMaterial.java
+++ b/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcBlockMaterial.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.coremc.internal;
 
 import com.sk89q.worldedit.blocks.ShapeType;
 import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
+import com.sk89q.worldedit.util.Direction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -58,6 +59,11 @@ public final class CoreMcBlockMaterial extends AbstractBlockMaterial<VoxelShape>
     @Override
     protected boolean isFullCubeUncached(ShapeType shapeType) {
         return Block.isShapeFullBlock(getShape(shapeType));
+    }
+
+    @Override
+    protected boolean isFullFaceUncached(ShapeType shapeType, Direction face) {
+        return Block.isFaceFull(getShape(shapeType), CoreMcTransmogrifier.transmogToMinecraft(face));
     }
 
     @Override

--- a/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcBlockMaterial.java
+++ b/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcBlockMaterial.java
@@ -19,7 +19,8 @@
 
 package com.sk89q.worldedit.coremc.internal;
 
-import com.sk89q.worldedit.world.registry.BlockMaterial;
+import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -27,12 +28,14 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
 /**
  * Minecraft block material implementation for platforms sharing native code.
  * Pulls as much info as possible from the Minecraft BlockState.
  */
-public final class CoreMcBlockMaterial implements BlockMaterial {
+public final class CoreMcBlockMaterial extends AbstractBlockMaterial<VoxelShape> {
 
     private final BlockState block;
 
@@ -45,9 +48,16 @@ public final class CoreMcBlockMaterial implements BlockMaterial {
         return block.isAir();
     }
 
+    private VoxelShape getShape(ShapeType shapeType) {
+        return switch (shapeType) {
+            case SHAPE -> block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+            case VISUAL_SHAPE -> block.getVisualShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+        };
+    }
+
     @Override
-    public boolean isFullCube() {
-        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
+    protected boolean isFullCubeUncached(ShapeType shapeType) {
+        return Block.isShapeFullBlock(getShape(shapeType));
     }
 
     @Override

--- a/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcBlockRegistry.java
+++ b/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcBlockRegistry.java
@@ -52,10 +52,9 @@ public final class CoreMcBlockRegistry implements BlockRegistry {
     }
 
     @Override
-    public BlockMaterial getMaterial(BlockType blockType) {
-        Block block = platform.getAdapter().toNativeBlock(blockType);
+    public BlockMaterial getMaterial(BlockState blockState) {
         return materialMap.computeIfAbsent(
-            block.defaultBlockState(),
+            platform.getAdapter().toNativeBlockState(blockState),
             CoreMcBlockMaterial::new
         );
     }

--- a/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcBlockRegistry.java
+++ b/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcBlockRegistry.java
@@ -56,10 +56,9 @@ public final class CoreMcBlockRegistry implements BlockRegistry {
     }
 
     @Override
-    public BlockMaterial getMaterial(BlockType blockType) {
-        Block block = platform.getAdapter().toNativeBlock(blockType);
+    public BlockMaterial getMaterial(BlockState blockState) {
         return materialMap.computeIfAbsent(
-            block.defaultBlockState(),
+            platform.getAdapter().toNativeBlockState(blockState),
             CoreMcBlockMaterial::new
         );
     }

--- a/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcTransmogrifier.java
+++ b/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcTransmogrifier.java
@@ -71,6 +71,17 @@ public final class CoreMcTransmogrifier {
         this.platform = platform;
     }
 
+    public static net.minecraft.core.Direction transmogToMinecraft(Direction face) {
+        return switch (face) {
+            case NORTH -> net.minecraft.core.Direction.NORTH;
+            case SOUTH -> net.minecraft.core.Direction.SOUTH;
+            case WEST -> net.minecraft.core.Direction.WEST;
+            case EAST -> net.minecraft.core.Direction.EAST;
+            case DOWN -> net.minecraft.core.Direction.DOWN;
+            default -> net.minecraft.core.Direction.UP;
+        };
+    }
+
     public Property<?> transmogToWorldEditProperty(net.minecraft.world.level.block.state.properties.Property<?> property) {
         return propertyCache.getUnchecked(property);
     }
@@ -104,7 +115,7 @@ public final class CoreMcTransmogrifier {
             if (property instanceof net.minecraft.world.level.block.state.properties.EnumProperty) {
                 if (property.getValueClass() == net.minecraft.core.Direction.class) {
                     Direction dir = (Direction) value;
-                    value = platform.getAdapter().adapt(dir);
+                    value = transmogToMinecraft(dir);
                 } else {
                     String enumName = (String) value;
                     value = ((net.minecraft.world.level.block.state.properties.EnumProperty<?>) property).getValue((String) value).orElseThrow(() ->

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -2668,8 +2668,10 @@ public class EditSession implements Extent, AutoCloseable {
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */
     public int hollowOutRegion(Region region, int thickness, Pattern pattern) throws MaxChangedBlocksException {
+        // Number of affected blocks, based on what setBlock returns
         int affected = 0;
 
+        // The set of blocks that were seen
         final Set<BlockVector3> visible = new HashSet<>();
 
         // Initialize BFS with selection bounding box
@@ -2720,14 +2722,17 @@ public class EditSession implements Extent, AutoCloseable {
             for (BlockVector3 recurseDirection : CARDINAL_UPRIGHT_OFFSETS) {
                 final BlockVector3 neighbor = current.add(recurseDirection);
 
+                // Abort if we're outside the region
                 if (!region.contains(neighbor)) {
                     continue;
                 }
 
+                // Mark the block as visible, abort if it already was
                 if (!visible.add(neighbor)) {
                     continue;
                 }
 
+                // And queue it
                 queue.add(neighbor);
             }
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -2770,6 +2770,9 @@ public class EditSession implements Extent, AutoCloseable {
         // The set of blocks that were seen
         final Set<BlockVector3> visible = new HashSet<>(startingPositions);
 
+        // The set of blocks that were not only seen, but entered
+        final Set<BlockVector3> entered = new HashSet<>(startingPositions);
+
         // Do BFS to find more visible blocks
         final Queue<BlockVector3> queue = new ArrayDeque<>(startingPositions);
         while (!queue.isEmpty()) {
@@ -2811,9 +2814,30 @@ public class EditSession implements Extent, AutoCloseable {
                     continue;
                 }
 
-                // Mark the block as visible, abort if it already was
-                if (!visible.add(neighbor)) {
-                    continue;
+                if (useBlockGeometry) {
+                    // Mark neighbor as visible
+                    visible.add(neighbor);
+
+                    // If the neighbor was already entered, we can skip the expensive blocked calculation
+                    if (entered.contains(neighbor)) {
+                        continue;
+                    }
+
+                    // Check if we can actually enter the block from here
+                    Direction oppositeDirection = Direction.findClosest(direction.toVector().multiply(-1), Direction.Flag.ALL);
+                    for (Direction blockedDirection : getBlockedDirections(neighbor)) {
+                        if (blockedDirection == oppositeDirection) {
+                            continue outer; // skip this direction
+                        }
+                    }
+
+                    // Mark neighbor as entered
+                    entered.add(neighbor);
+                } else {
+                    // Mark the block as visible, abort if it already was
+                    if (!visible.add(neighbor)) {
+                        continue;
+                    }
                 }
 
                 // And queue it

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -134,6 +134,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -2716,7 +2717,7 @@ public class EditSession implements Extent, AutoCloseable {
                 continue;
             }
 
-            for (BlockVector3 recurseDirection : recurseDirections) {
+            for (BlockVector3 recurseDirection : CARDINAL_UPRIGHT_OFFSETS) {
                 final BlockVector3 neighbor = current.add(recurseDirection);
 
                 if (!region.contains(neighbor)) {
@@ -2735,7 +2736,7 @@ public class EditSession implements Extent, AutoCloseable {
         final Set<BlockVector3> newVisible = new HashSet<>();
         for (int i = 1; i < thickness; ++i) {
             outer: for (BlockVector3 position : region) {
-                for (BlockVector3 recurseDirection : recurseDirections) {
+                for (BlockVector3 recurseDirection : CARDINAL_UPRIGHT_OFFSETS) {
                     BlockVector3 neighbor = position.add(recurseDirection);
 
                     if (visible.contains(neighbor)) {
@@ -3074,7 +3075,7 @@ public class EditSession implements Extent, AutoCloseable {
                         totalFaces = 0;
                         highestFreq = 0;
                         highestState = blockState;
-                        for (BlockVector3 vec3 : recurseDirections) {
+                        for (BlockVector3 vec3 : CARDINAL_UPRIGHT_OFFSETS) {
                             BlockState adj = currentBuffer[x + 1 + vec3.x()][y + 1 + vec3.y()][z + 1 + vec3.z()];
 
                             if (!adj.getBlockType().getMaterial().isLiquid() && !adj.getBlockType().getMaterial().isAir()) {
@@ -3127,7 +3128,7 @@ public class EditSession implements Extent, AutoCloseable {
                         totalFaces = 0;
                         highestFreq = 0;
                         highestState = blockState;
-                        for (BlockVector3 vec3 : recurseDirections) {
+                        for (BlockVector3 vec3 : CARDINAL_UPRIGHT_OFFSETS) {
                             BlockState adj = currentBuffer[x + 1 + vec3.x()][y + 1 + vec3.y()][z + 1 + vec3.z()];
                             if (adj.getBlockType().getMaterial().isLiquid() || adj.getBlockType().getMaterial().isAir()) {
                                 continue;
@@ -3170,14 +3171,18 @@ public class EditSession implements Extent, AutoCloseable {
         return changed;
     }
 
-    private static final BlockVector3[] recurseDirections = {
-            Direction.NORTH.toBlockVector(),
-            Direction.EAST.toBlockVector(),
-            Direction.SOUTH.toBlockVector(),
-            Direction.WEST.toBlockVector(),
-            Direction.UP.toBlockVector(),
-            Direction.DOWN.toBlockVector(),
-    };
+    /**
+     * Contains all cardinal and upright directions.
+     */
+    private static final Direction[] CARDINAL_UPRIGHT_DIRECTIONS = Arrays.stream(Direction.values())
+        .filter(direction -> direction.isCardinal() || direction.isUpright())
+        .toArray(Direction[]::new);
+    /**
+     * Contains the offset vectors for all cardinal and upright directions.
+     */
+    private static final BlockVector3[] CARDINAL_UPRIGHT_OFFSETS = Arrays.stream(CARDINAL_UPRIGHT_DIRECTIONS)
+        .map(Direction::toBlockVector)
+        .toArray(BlockVector3[]::new);
 
     private static double lengthSq(double x, double y, double z) {
         return (x * x) + (y * y) + (z * z);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -2703,12 +2703,12 @@ public class EditSession implements Extent, AutoCloseable {
      *
      * @return number of blocks affected
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
-     * @deprecated Use {@link EditSession#hollowOutRegion(Region, int, Pattern, boolean, Collection, boolean)} instead.
+     * @deprecated Use {@link EditSession#hollowOutRegion(Region, int, Pattern, boolean, Collection, boolean, Mask)} instead.
      */
-    @InlineMe(replacement = "this.hollowOutRegion(region, thickness, pattern, true, null, false)")
+    @InlineMe(replacement = "this.hollowOutRegion(region, thickness, pattern, true, null, false, Masks.alwaysTrue())", imports = "com.sk89q.worldedit.function.mask.Masks")
     @Deprecated
     public final int hollowOutRegion(Region region, int thickness, Pattern pattern) throws MaxChangedBlocksException {
-        return hollowOutRegion(region, thickness, pattern, true, null, false);
+        return hollowOutRegion(region, thickness, pattern, true, null, false, Masks.alwaysTrue());
     }
 
     /**
@@ -2721,10 +2721,11 @@ public class EditSession implements Extent, AutoCloseable {
      * @param openSides         Open up faces touching the bounding box. This matches the legacy behaviour.
      * @param startingPositions Positions to consider as 'outside'. If null, use the selection bounding box
      * @param useBlockGeometry  Consider block geometry for visibility calculation
+     * @param includeMask       Mask of blocks eligible for shell detection
      * @return number of blocks affected
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */
-    public int hollowOutRegion(Region region, int thickness, Pattern pattern, boolean openSides, Collection<BlockVector3> startingPositions, boolean useBlockGeometry) throws MaxChangedBlocksException {
+    public int hollowOutRegion(Region region, int thickness, Pattern pattern, boolean openSides, Collection<BlockVector3> startingPositions, boolean useBlockGeometry, Mask includeMask) throws MaxChangedBlocksException {
         if (startingPositions == null) {
             // If no startingPositions are specified, use the selection bounding box
             startingPositions = new ArrayList<>();
@@ -2779,7 +2780,9 @@ public class EditSession implements Extent, AutoCloseable {
             final BlockVector3 current = queue.poll();
 
             Direction[] blockedDirections;
-            if (useBlockGeometry) {
+            if (!includeMask.test(current)) {
+                blockedDirections = NO_DIRECTIONS;
+            } else if (useBlockGeometry) {
                 // Get blocked directions for this block
                 blockedDirections = getBlockedDirections(current);
 
@@ -2823,11 +2826,13 @@ public class EditSession implements Extent, AutoCloseable {
                         continue;
                     }
 
-                    // Check if we can actually enter the block from here
-                    Direction oppositeDirection = Direction.findClosest(direction.toVector().multiply(-1), Direction.Flag.ALL);
-                    for (Direction blockedDirection : getBlockedDirections(neighbor)) {
-                        if (blockedDirection == oppositeDirection) {
-                            continue outer; // skip this direction
+                    if (includeMask.test(neighbor)) {
+                        // Check if we can actually enter the block from here
+                        Direction oppositeDirection = Direction.findClosest(direction.toVector().multiply(-1), Direction.Flag.ALL);
+                        for (Direction blockedDirection : getBlockedDirections(neighbor)) {
+                            if (blockedDirection == oppositeDirection) {
+                                continue outer; // skip this direction
+                            }
                         }
                     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -2668,6 +2668,8 @@ public class EditSession implements Extent, AutoCloseable {
     public int hollowOutRegion(Region region, int thickness, Pattern pattern) throws MaxChangedBlocksException {
         int affected = 0;
 
+        // Initialize BFS with selection bounding box
+        var queue = new ArrayDeque<BlockVector3>();
         final Set<BlockVector3> outside = new HashSet<>();
 
         final BlockVector3 min = region.getMinimumPoint();
@@ -2682,25 +2684,47 @@ public class EditSession implements Extent, AutoCloseable {
 
         for (int x = minX; x <= maxX; ++x) {
             for (int y = minY; y <= maxY; ++y) {
-                recurseHollow(region, BlockVector3.at(x, y, minZ), outside);
-                recurseHollow(region, BlockVector3.at(x, y, maxZ), outside);
+                queue.addLast(BlockVector3.at(x, y, minZ));
+                queue.addLast(BlockVector3.at(x, y, maxZ));
             }
         }
 
         for (int y = minY; y <= maxY; ++y) {
             for (int z = minZ; z <= maxZ; ++z) {
-                recurseHollow(region, BlockVector3.at(minX, y, z), outside);
-                recurseHollow(region, BlockVector3.at(maxX, y, z), outside);
+                queue.addLast(BlockVector3.at(minX, y, z));
+                queue.addLast(BlockVector3.at(maxX, y, z));
             }
         }
 
         for (int z = minZ; z <= maxZ; ++z) {
             for (int x = minX; x <= maxX; ++x) {
-                recurseHollow(region, BlockVector3.at(x, minY, z), outside);
-                recurseHollow(region, BlockVector3.at(x, maxY, z), outside);
+                queue.addLast(BlockVector3.at(x, minY, z));
+                queue.addLast(BlockVector3.at(x, maxY, z));
             }
         }
 
+        // Do BFS to find visible blocks
+        while (!queue.isEmpty()) {
+            final BlockVector3 current = queue.poll();
+            final BlockState block = getBlock(current);
+            if (block.getBlockType().getMaterial().isMovementBlocker()) {
+                continue;
+            }
+
+            if (!outside.add(current)) {
+                continue;
+            }
+
+            if (!region.contains(current)) {
+                continue;
+            }
+
+            for (BlockVector3 recurseDirection : recurseDirections) {
+                queue.add(current.add(recurseDirection));
+            }
+        }
+
+        // Expand by $thickness blocks
         final Set<BlockVector3> newOutside = new HashSet<>();
         for (int i = 1; i < thickness; ++i) {
             outer: for (BlockVector3 position : region) {
@@ -2718,6 +2742,7 @@ public class EditSession implements Extent, AutoCloseable {
             newOutside.clear();
         }
 
+        // Remove everything else in the selection
         outer: for (BlockVector3 position : region) {
             for (BlockVector3 recurseDirection : recurseDirections) {
                 BlockVector3 neighbor = position.add(recurseDirection);
@@ -2913,31 +2938,6 @@ public class EditSession implements Extent, AutoCloseable {
             }
         }
         return returnset;
-    }
-
-    private void recurseHollow(Region region, BlockVector3 origin, Set<BlockVector3> outside) {
-        var queue = new ArrayDeque<BlockVector3>();
-        queue.addLast(origin);
-
-        while (!queue.isEmpty()) {
-            final BlockVector3 current = queue.removeFirst();
-            final BlockState block = getBlock(current);
-            if (block.getBlockType().getMaterial().isMovementBlocker()) {
-                continue;
-            }
-
-            if (!outside.add(current)) {
-                continue;
-            }
-
-            if (!region.contains(current)) {
-                continue;
-            }
-
-            for (BlockVector3 recurseDirection : recurseDirections) {
-                queue.addLast(current.add(recurseDirection));
-            }
-        }
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -135,6 +135,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -2668,11 +2669,8 @@ public class EditSession implements Extent, AutoCloseable {
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */
     public int hollowOutRegion(Region region, int thickness, Pattern pattern) throws MaxChangedBlocksException {
-        // Number of affected blocks, based on what setBlock returns
-        int affected = 0;
-
-        // The set of blocks that were seen
-        final Set<BlockVector3> visible = new HashSet<>();
+        // Positions to consider as 'outside'
+        Collection<BlockVector3> startingPositions = new ArrayList<>();
 
         // Initialize BFS with selection bounding box
         final BlockVector3 min = region.getMinimumPoint();
@@ -2687,30 +2685,33 @@ public class EditSession implements Extent, AutoCloseable {
 
         for (int x = minX; x <= maxX; ++x) {
             for (int y = minY; y <= maxY; ++y) {
-                visible.add(BlockVector3.at(x, y, minZ));
-                visible.add(BlockVector3.at(x, y, maxZ));
+                startingPositions.add(BlockVector3.at(x, y, minZ));
+                startingPositions.add(BlockVector3.at(x, y, maxZ));
             }
         }
 
         for (int y = minY; y <= maxY; ++y) {
             for (int z = minZ; z <= maxZ; ++z) {
-                visible.add(BlockVector3.at(minX, y, z));
-                visible.add(BlockVector3.at(maxX, y, z));
+                startingPositions.add(BlockVector3.at(minX, y, z));
+                startingPositions.add(BlockVector3.at(maxX, y, z));
             }
         }
 
         for (int z = minZ; z <= maxZ; ++z) {
             for (int x = minX; x <= maxX; ++x) {
-                visible.add(BlockVector3.at(x, minY, z));
-                visible.add(BlockVector3.at(x, maxY, z));
+                startingPositions.add(BlockVector3.at(x, minY, z));
+                startingPositions.add(BlockVector3.at(x, maxY, z));
             }
         }
 
         // Remove movement blockers from visible list
-        visible.removeIf(blockVector3 -> getBlock(blockVector3).getBlockType().getMaterial().isMovementBlocker());
+        startingPositions.removeIf(blockVector3 -> getBlock(blockVector3).getBlockType().getMaterial().isMovementBlocker());
+
+        // The set of blocks that were seen
+        final Set<BlockVector3> visible = new HashSet<>(startingPositions);
 
         // Do BFS to find more visible blocks
-        final Queue<BlockVector3> queue = new ArrayDeque<>(visible);
+        final Queue<BlockVector3> queue = new ArrayDeque<>(startingPositions);
         while (!queue.isEmpty()) {
             final BlockVector3 current = queue.poll();
 
@@ -2754,6 +2755,9 @@ public class EditSession implements Extent, AutoCloseable {
             visible.addAll(newVisible);
             newVisible.clear();
         }
+
+        // Number of affected blocks, based on what setBlock returns
+        int affected = 0;
 
         // Remove everything else in the selection
         for (BlockVector3 position : region) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -2669,10 +2669,9 @@ public class EditSession implements Extent, AutoCloseable {
     public int hollowOutRegion(Region region, int thickness, Pattern pattern) throws MaxChangedBlocksException {
         int affected = 0;
 
-        // Initialize BFS with selection bounding box
-        final Queue<BlockVector3> queue = new ArrayDeque<>();
-        final Set<BlockVector3> outside = new HashSet<>();
+        final Set<BlockVector3> visible = new HashSet<>();
 
+        // Initialize BFS with selection bounding box
         final BlockVector3 min = region.getMinimumPoint();
         final BlockVector3 max = region.getMaximumPoint();
 
@@ -2685,72 +2684,75 @@ public class EditSession implements Extent, AutoCloseable {
 
         for (int x = minX; x <= maxX; ++x) {
             for (int y = minY; y <= maxY; ++y) {
-                queue.add(BlockVector3.at(x, y, minZ));
-                queue.add(BlockVector3.at(x, y, maxZ));
+                visible.add(BlockVector3.at(x, y, minZ));
+                visible.add(BlockVector3.at(x, y, maxZ));
             }
         }
 
         for (int y = minY; y <= maxY; ++y) {
             for (int z = minZ; z <= maxZ; ++z) {
-                queue.add(BlockVector3.at(minX, y, z));
-                queue.add(BlockVector3.at(maxX, y, z));
+                visible.add(BlockVector3.at(minX, y, z));
+                visible.add(BlockVector3.at(maxX, y, z));
             }
         }
 
         for (int z = minZ; z <= maxZ; ++z) {
             for (int x = minX; x <= maxX; ++x) {
-                queue.add(BlockVector3.at(x, minY, z));
-                queue.add(BlockVector3.at(x, maxY, z));
+                visible.add(BlockVector3.at(x, minY, z));
+                visible.add(BlockVector3.at(x, maxY, z));
             }
         }
 
-        // Do BFS to find visible blocks
+        // Remove movement blockers from visible list
+        visible.removeIf(blockVector3 -> getBlock(blockVector3).getBlockType().getMaterial().isMovementBlocker());
+
+        // Do BFS to find more visible blocks
+        final Queue<BlockVector3> queue = new ArrayDeque<>(visible);
         while (!queue.isEmpty()) {
             final BlockVector3 current = queue.poll();
+
             final BlockState block = getBlock(current);
             if (block.getBlockType().getMaterial().isMovementBlocker()) {
                 continue;
             }
 
-            if (!outside.add(current)) {
-                continue;
-            }
-
-            if (!region.contains(current)) {
-                continue;
-            }
-
             for (BlockVector3 recurseDirection : recurseDirections) {
-                queue.add(current.add(recurseDirection));
+                final BlockVector3 neighbor = current.add(recurseDirection);
+
+                if (!region.contains(neighbor)) {
+                    continue;
+                }
+
+                if (!visible.add(neighbor)) {
+                    continue;
+                }
+
+                queue.add(neighbor);
             }
         }
 
         // Expand by $thickness blocks
-        final Set<BlockVector3> newOutside = new HashSet<>();
+        final Set<BlockVector3> newVisible = new HashSet<>();
         for (int i = 1; i < thickness; ++i) {
             outer: for (BlockVector3 position : region) {
                 for (BlockVector3 recurseDirection : recurseDirections) {
                     BlockVector3 neighbor = position.add(recurseDirection);
 
-                    if (outside.contains(neighbor)) {
-                        newOutside.add(position);
+                    if (visible.contains(neighbor)) {
+                        newVisible.add(position);
                         continue outer;
                     }
                 }
             }
 
-            outside.addAll(newOutside);
-            newOutside.clear();
+            visible.addAll(newVisible);
+            newVisible.clear();
         }
 
         // Remove everything else in the selection
-        outer: for (BlockVector3 position : region) {
-            for (BlockVector3 recurseDirection : recurseDirections) {
-                BlockVector3 neighbor = position.add(recurseDirection);
-
-                if (outside.contains(neighbor)) {
-                    continue outer;
-                }
+        for (BlockVector3 position : region) {
+            if (visible.contains(position)) {
+                continue;
             }
 
             if (setBlock(position, pattern.applyBlock(position))) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.InlineMe;
+import com.sk89q.worldedit.blocks.ShapeType;
 import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.entity.Entity;
 import com.sk89q.worldedit.event.extent.EditSessionEvent;
@@ -129,6 +130,7 @@ import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
 import com.sk89q.worldedit.world.generation.TreeType;
+import com.sk89q.worldedit.world.registry.BlockMaterial;
 import com.sk89q.worldedit.world.registry.LegacyMapper;
 import org.apache.logging.log4j.Logger;
 
@@ -2658,6 +2660,46 @@ public class EditSession implements Extent, AutoCloseable {
         return affected;
     }
 
+    private Direction[] getBlockedDirections(BlockVector3 position) {
+        BlockState blockState = getBlock(position);
+        BlockType blockType = blockState.getBlockType();
+        BlockMaterial material = blockState.getMaterial();
+
+        if (material.isAir()) {
+            return NO_DIRECTIONS;
+        }
+
+        if (material.isLiquid()) {
+            return NO_DIRECTIONS;
+        }
+
+        Direction[] blockedDirections = BLOCKED_DIRECTIONS_OVERRIDE.get(blockType);
+        if (blockedDirections != null) {
+            return blockedDirections;
+        }
+
+        if (material.isFullCube(ShapeType.VISUAL_SHAPE)) {
+            return CARDINAL_UPRIGHT_DIRECTIONS;
+        }
+
+        Direction[] result = new Direction[CARDINAL_UPRIGHT_DIRECTIONS.length];
+        int count = 0;
+
+        for (Direction direction : CARDINAL_UPRIGHT_DIRECTIONS) {
+            if (material.isFullFace(ShapeType.VISUAL_SHAPE, direction)) {
+                result[count++] = direction;
+            }
+        }
+
+        // Short-cut for blocks that are blocked in all directions but for some reason not isFullCube
+        // This enables == comparison later
+        if (count == 6) {
+            return CARDINAL_UPRIGHT_DIRECTIONS;
+        }
+
+        return Arrays.copyOf(result, count);
+    }
+
     /**
      * Hollows out the region (Semi-well-defined for non-cuboid selections).
      *
@@ -2667,45 +2709,69 @@ public class EditSession implements Extent, AutoCloseable {
      *
      * @return number of blocks affected
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
+     * @deprecated Use {@link EditSession#hollowOutRegion(Region, int, Pattern, boolean, Collection, boolean)} instead.
      */
-    public int hollowOutRegion(Region region, int thickness, Pattern pattern) throws MaxChangedBlocksException {
-        // Positions to consider as 'outside'
-        Collection<BlockVector3> startingPositions = new ArrayList<>();
+    @InlineMe(replacement = "this.hollowOutRegion(region, thickness, pattern, true, null, false)")
+    @Deprecated
+    public final int hollowOutRegion(Region region, int thickness, Pattern pattern) throws MaxChangedBlocksException {
+        return hollowOutRegion(region, thickness, pattern, true, null, false);
+    }
 
-        // Initialize BFS with selection bounding box
-        final BlockVector3 min = region.getMinimumPoint();
-        final BlockVector3 max = region.getMaximumPoint();
+    /**
+     * Hollows out the region (bounding-box mode is semi-well-defined for non-cuboid selections).
+     * The startingPositions parameter takes precedence over usePlacementPosition.
+     *
+     * @param region            the region to hollow out.
+     * @param thickness         the thickness of the shell to leave (manhattan distance)
+     * @param pattern           The block pattern to use
+     * @param openSides         Open up faces touching the bounding box. This matches the legacy behaviour.
+     * @param startingPositions Positions to consider as 'outside'. If null, use the selection bounding box
+     * @param useBlockGeometry  Consider block geometry for visibility calculation
+     * @return number of blocks affected
+     * @throws MaxChangedBlocksException thrown if too many blocks are changed
+     */
+    public int hollowOutRegion(Region region, int thickness, Pattern pattern, boolean openSides, Collection<BlockVector3> startingPositions, boolean useBlockGeometry) throws MaxChangedBlocksException {
+        if (startingPositions == null) {
+            // If no startingPositions are specified, use the selection bounding box
+            startingPositions = new ArrayList<>();
 
-        final int minX = min.x();
-        final int minY = min.y();
-        final int minZ = min.z();
-        final int maxX = max.x();
-        final int maxY = max.y();
-        final int maxZ = max.z();
+            // Initialize BFS with selection bounding box
+            final BlockVector3 min = region.getMinimumPoint();
+            final BlockVector3 max = region.getMaximumPoint();
 
-        for (int x = minX; x <= maxX; ++x) {
-            for (int y = minY; y <= maxY; ++y) {
-                startingPositions.add(BlockVector3.at(x, y, minZ));
-                startingPositions.add(BlockVector3.at(x, y, maxZ));
-            }
-        }
+            final int minX = min.x();
+            final int minY = min.y();
+            final int minZ = min.z();
+            final int maxX = max.x();
+            final int maxY = max.y();
+            final int maxZ = max.z();
 
-        for (int y = minY; y <= maxY; ++y) {
-            for (int z = minZ; z <= maxZ; ++z) {
-                startingPositions.add(BlockVector3.at(minX, y, z));
-                startingPositions.add(BlockVector3.at(maxX, y, z));
-            }
-        }
-
-        for (int z = minZ; z <= maxZ; ++z) {
             for (int x = minX; x <= maxX; ++x) {
-                startingPositions.add(BlockVector3.at(x, minY, z));
-                startingPositions.add(BlockVector3.at(x, maxY, z));
+                for (int y = minY; y <= maxY; ++y) {
+                    startingPositions.add(BlockVector3.at(x, y, minZ));
+                    startingPositions.add(BlockVector3.at(x, y, maxZ));
+                }
+            }
+
+            for (int y = minY; y <= maxY; ++y) {
+                for (int z = minZ; z <= maxZ; ++z) {
+                    startingPositions.add(BlockVector3.at(minX, y, z));
+                    startingPositions.add(BlockVector3.at(maxX, y, z));
+                }
+            }
+
+            for (int z = minZ; z <= maxZ; ++z) {
+                for (int x = minX; x <= maxX; ++x) {
+                    startingPositions.add(BlockVector3.at(x, minY, z));
+                    startingPositions.add(BlockVector3.at(x, maxY, z));
+                }
+            }
+
+            if (openSides) {
+                // Remove movement blockers from visible list
+                startingPositions.removeIf(blockVector3 -> getBlock(blockVector3).getBlockType().getMaterial().isMovementBlocker());
             }
         }
-
-        // Remove movement blockers from visible list
-        startingPositions.removeIf(blockVector3 -> getBlock(blockVector3).getBlockType().getMaterial().isMovementBlocker());
 
         // The set of blocks that were seen
         final Set<BlockVector3> visible = new HashSet<>(startingPositions);
@@ -2715,13 +2781,36 @@ public class EditSession implements Extent, AutoCloseable {
         while (!queue.isEmpty()) {
             final BlockVector3 current = queue.poll();
 
-            final BlockState block = getBlock(current);
-            if (block.getBlockType().getMaterial().isMovementBlocker()) {
-                continue;
+            Direction[] blockedDirections;
+            if (useBlockGeometry) {
+                // Get blocked directions for this block
+                blockedDirections = getBlockedDirections(current);
+
+                // Short-cut if blocked in all directions
+                if (blockedDirections == CARDINAL_UPRIGHT_DIRECTIONS) {
+                    continue;
+                }
+            } else {
+                final BlockState block = getBlock(current);
+                if (block.getBlockType().getMaterial().isMovementBlocker()) {
+                    // In non-geometry mode, all movement blockers are assumed to be blocked in all directions, so short-cut here
+                    continue;
+                }
+
+                // All other blocks are assumed to have no blocked directions
+                blockedDirections = NO_DIRECTIONS;
             }
 
-            for (BlockVector3 recurseDirection : CARDINAL_UPRIGHT_OFFSETS) {
-                final BlockVector3 neighbor = current.add(recurseDirection);
+            outer:
+            for (Direction direction : CARDINAL_UPRIGHT_DIRECTIONS) {
+                // Check if this direction is blocked
+                for (Direction blockedDirection : blockedDirections) {
+                    if (blockedDirection == direction) {
+                        continue outer; // skip this direction
+                    }
+                }
+
+                final BlockVector3 neighbor = current.add(direction.toBlockVector());
 
                 // Abort if we're outside the region
                 if (!region.contains(neighbor)) {
@@ -3181,6 +3270,10 @@ public class EditSession implements Extent, AutoCloseable {
     }
 
     /**
+     * Contains no directions.
+     */
+    private static final Direction[] NO_DIRECTIONS = {};
+    /**
      * Contains all cardinal and upright directions.
      */
     private static final Direction[] CARDINAL_UPRIGHT_DIRECTIONS = Arrays.stream(Direction.values())
@@ -3192,6 +3285,64 @@ public class EditSession implements Extent, AutoCloseable {
     private static final BlockVector3[] CARDINAL_UPRIGHT_OFFSETS = Arrays.stream(CARDINAL_UPRIGHT_DIRECTIONS)
         .map(Direction::toBlockVector)
         .toArray(BlockVector3[]::new);
+
+    /**
+     * Some blocks need a special case for one reason or another.
+     */
+    private static final Map<BlockType, Direction[]> BLOCKED_DIRECTIONS_OVERRIDE = new HashMap<>();
+
+    static {
+        Arrays.asList(
+            // fullcubes that you can see through on all 6 sides
+            BlockTypes.SPAWNER,
+            BlockTypes.BEACON,
+            BlockTypes.MANGROVE_ROOTS,
+            BlockTypes.ICE,
+
+            // You can see through some of the doors/trapdoors, which is not reflected in their visual shape
+            // Commented lines are opaque and kept for reference
+            BlockTypes.OAK_DOOR,
+            BlockTypes.OAK_TRAPDOOR,
+            // BlockTypes.SPRUCE_DOOR,
+            // BlockTypes.SPRUCE_TRAPDOOR,
+            // BlockTypes.BIRCH_DOOR,
+            // BlockTypes.BIRCH_TRAPDOOR,
+            BlockTypes.JUNGLE_DOOR,
+            BlockTypes.JUNGLE_TRAPDOOR,
+            BlockTypes.ACACIA_DOOR,
+            BlockTypes.ACACIA_TRAPDOOR,
+            // BlockTypes.DARK_OAK_DOOR,
+            // BlockTypes.DARK_OAK_TRAPDOOR,
+            // BlockTypes.MANGROVE_DOOR,
+            BlockTypes.MANGROVE_TRAPDOOR,
+            BlockTypes.CHERRY_DOOR,
+            BlockTypes.CHERRY_TRAPDOOR,
+            // BlockTypes.PALE_OAK_DOOR,
+            // BlockTypes.PALE_OAK_TRAPDOOR,
+            BlockTypes.BAMBOO_DOOR,
+            BlockTypes.BAMBOO_TRAPDOOR,
+            BlockTypes.CRIMSON_DOOR,
+            BlockTypes.CRIMSON_TRAPDOOR,
+            BlockTypes.WARPED_DOOR,
+            BlockTypes.WARPED_TRAPDOOR,
+            BlockTypes.IRON_DOOR,
+            BlockTypes.IRON_TRAPDOOR
+        ).forEach(blockType -> {
+            BLOCKED_DIRECTIONS_OVERRIDE.put(blockType, NO_DIRECTIONS);
+        });
+
+        // The copper doors/trapdoors are too many to list individually
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("^.*:(?:.*_)?(?:copper_door|copper_trapdoor)(?:_.*)?$");
+        for (BlockType blockType : BlockType.REGISTRY) {
+            if (pattern.matcher(blockType.id()).matches()) {
+                BLOCKED_DIRECTIONS_OVERRIDE.put(blockType, NO_DIRECTIONS);
+            }
+        }
+
+        // These are visual fullcubes, but they're mostly open:
+        BLOCKED_DIRECTIONS_OVERRIDE.put(BlockTypes.TRIAL_SPAWNER, new Direction[] { Direction.UP });
+        BLOCKED_DIRECTIONS_OVERRIDE.put(BlockTypes.VAULT, new Direction[] { Direction.UP, Direction.DOWN });
+    }
 
     private static double lengthSq(double x, double y, double z) {
         return (x * x) + (y * y) + (z * z);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -2662,7 +2662,6 @@ public class EditSession implements Extent, AutoCloseable {
 
     private Direction[] getBlockedDirections(BlockVector3 position) {
         BlockState blockState = getBlock(position);
-        BlockType blockType = blockState.getBlockType();
         BlockMaterial material = blockState.getMaterial();
 
         if (material.isAir()) {
@@ -2671,11 +2670,6 @@ public class EditSession implements Extent, AutoCloseable {
 
         if (material.isLiquid()) {
             return NO_DIRECTIONS;
-        }
-
-        Direction[] blockedDirections = BLOCKED_DIRECTIONS_OVERRIDE.get(blockType);
-        if (blockedDirections != null) {
-            return blockedDirections;
         }
 
         if (material.isFullCube(ShapeType.VISUAL_SHAPE)) {
@@ -3285,64 +3279,6 @@ public class EditSession implements Extent, AutoCloseable {
     private static final BlockVector3[] CARDINAL_UPRIGHT_OFFSETS = Arrays.stream(CARDINAL_UPRIGHT_DIRECTIONS)
         .map(Direction::toBlockVector)
         .toArray(BlockVector3[]::new);
-
-    /**
-     * Some blocks need a special case for one reason or another.
-     */
-    private static final Map<BlockType, Direction[]> BLOCKED_DIRECTIONS_OVERRIDE = new HashMap<>();
-
-    static {
-        Arrays.asList(
-            // fullcubes that you can see through on all 6 sides
-            BlockTypes.SPAWNER,
-            BlockTypes.BEACON,
-            BlockTypes.MANGROVE_ROOTS,
-            BlockTypes.ICE,
-
-            // You can see through some of the doors/trapdoors, which is not reflected in their visual shape
-            // Commented lines are opaque and kept for reference
-            BlockTypes.OAK_DOOR,
-            BlockTypes.OAK_TRAPDOOR,
-            // BlockTypes.SPRUCE_DOOR,
-            // BlockTypes.SPRUCE_TRAPDOOR,
-            // BlockTypes.BIRCH_DOOR,
-            // BlockTypes.BIRCH_TRAPDOOR,
-            BlockTypes.JUNGLE_DOOR,
-            BlockTypes.JUNGLE_TRAPDOOR,
-            BlockTypes.ACACIA_DOOR,
-            BlockTypes.ACACIA_TRAPDOOR,
-            // BlockTypes.DARK_OAK_DOOR,
-            // BlockTypes.DARK_OAK_TRAPDOOR,
-            // BlockTypes.MANGROVE_DOOR,
-            BlockTypes.MANGROVE_TRAPDOOR,
-            BlockTypes.CHERRY_DOOR,
-            BlockTypes.CHERRY_TRAPDOOR,
-            // BlockTypes.PALE_OAK_DOOR,
-            // BlockTypes.PALE_OAK_TRAPDOOR,
-            BlockTypes.BAMBOO_DOOR,
-            BlockTypes.BAMBOO_TRAPDOOR,
-            BlockTypes.CRIMSON_DOOR,
-            BlockTypes.CRIMSON_TRAPDOOR,
-            BlockTypes.WARPED_DOOR,
-            BlockTypes.WARPED_TRAPDOOR,
-            BlockTypes.IRON_DOOR,
-            BlockTypes.IRON_TRAPDOOR
-        ).forEach(blockType -> {
-            BLOCKED_DIRECTIONS_OVERRIDE.put(blockType, NO_DIRECTIONS);
-        });
-
-        // The copper doors/trapdoors are too many to list individually
-        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("^.*:(?:.*_)?(?:copper_door|copper_trapdoor)(?:_.*)?$");
-        for (BlockType blockType : BlockType.REGISTRY) {
-            if (pattern.matcher(blockType.id()).matches()) {
-                BLOCKED_DIRECTIONS_OVERRIDE.put(blockType, NO_DIRECTIONS);
-            }
-        }
-
-        // These are visual fullcubes, but they're mostly open:
-        BLOCKED_DIRECTIONS_OVERRIDE.put(BlockTypes.TRIAL_SPAWNER, new Direction[] { Direction.UP });
-        BLOCKED_DIRECTIONS_OVERRIDE.put(BlockTypes.VAULT, new Direction[] { Direction.UP, Direction.DOWN });
-    }
 
     private static double lengthSq(double x, double y, double z) {
         return (x * x) + (y * y) + (z * z);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -140,6 +140,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
@@ -2669,7 +2670,7 @@ public class EditSession implements Extent, AutoCloseable {
         int affected = 0;
 
         // Initialize BFS with selection bounding box
-        var queue = new ArrayDeque<BlockVector3>();
+        final Queue<BlockVector3> queue = new ArrayDeque<>();
         final Set<BlockVector3> outside = new HashSet<>();
 
         final BlockVector3 min = region.getMinimumPoint();
@@ -2684,22 +2685,22 @@ public class EditSession implements Extent, AutoCloseable {
 
         for (int x = minX; x <= maxX; ++x) {
             for (int y = minY; y <= maxY; ++y) {
-                queue.addLast(BlockVector3.at(x, y, minZ));
-                queue.addLast(BlockVector3.at(x, y, maxZ));
+                queue.add(BlockVector3.at(x, y, minZ));
+                queue.add(BlockVector3.at(x, y, maxZ));
             }
         }
 
         for (int y = minY; y <= maxY; ++y) {
             for (int z = minZ; z <= maxZ; ++z) {
-                queue.addLast(BlockVector3.at(minX, y, z));
-                queue.addLast(BlockVector3.at(maxX, y, z));
+                queue.add(BlockVector3.at(minX, y, z));
+                queue.add(BlockVector3.at(maxX, y, z));
             }
         }
 
         for (int z = minZ; z <= maxZ; ++z) {
             for (int x = minX; x <= maxX; ++x) {
-                queue.addLast(BlockVector3.at(x, minY, z));
-                queue.addLast(BlockVector3.at(x, maxY, z));
+                queue.add(BlockVector3.at(x, minY, z));
+                queue.add(BlockVector3.at(x, maxY, z));
             }
         }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/blocks/ShapeType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/blocks/ShapeType.java
@@ -17,24 +17,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.sk89q.worldedit.function.mask;
+package com.sk89q.worldedit.blocks;
 
-import com.sk89q.worldedit.blocks.ShapeType;
-import com.sk89q.worldedit.extent.Extent;
-import com.sk89q.worldedit.math.BlockVector3;
-import com.sk89q.worldedit.world.block.BlockState;
-
-public final class FullCubeMask extends AbstractExtentMask {
-
-    public FullCubeMask(Extent extent) {
-        super(extent);
-    }
-
-    @Override
-    public boolean test(BlockVector3 vector) {
-        Extent extent = getExtent();
-        BlockState block = extent.getBlock(vector);
-        return block.getBlockType().getMaterial().isFullCube(ShapeType.SHAPE);
-    }
-
+public enum ShapeType {
+    SHAPE,
+    VISUAL_SHAPE,
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/blocks/ShapeType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/blocks/ShapeType.java
@@ -17,24 +17,16 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.sk89q.worldedit.function.mask;
+package com.sk89q.worldedit.blocks;
 
-import com.sk89q.worldedit.blocks.ShapeType;
-import com.sk89q.worldedit.extent.Extent;
-import com.sk89q.worldedit.math.BlockVector3;
-import com.sk89q.worldedit.world.block.BlockState;
+public enum ShapeType {
+    /**
+     * Block shape that's used internally as a default/fallback for many of the others, mostly in less complex blocks.
+     */
+    SHAPE,
 
-public final class FullCubeMask extends AbstractExtentMask {
-
-    public FullCubeMask(Extent extent) {
-        super(extent);
-    }
-
-    @Override
-    public boolean test(BlockVector3 vector) {
-        Extent extent = getExtent();
-        BlockState block = extent.getBlock(vector);
-        return block.getBlockType().getMaterial().isFullCube(ShapeType.SHAPE);
-    }
-
+    /**
+     * Block shape that most closely corresponds to what's visible or not.
+     */
+    VISUAL_SHAPE,
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -550,11 +550,11 @@ public class RegionCommands {
     @Logging(REGION)
     public int hollow(Actor actor, EditSession editSession,
                       @Selection Region region,
-                      @Arg(desc = "Thickness of the shell to leave", def = "0")
+                      @Arg(desc = "Thickness of the shell to leave", def = "1")
                           int thickness,
                       @Arg(desc = "The pattern of blocks to replace the hollowed area with", def = "air")
                           Pattern pattern) throws WorldEditException {
-        checkCommandArgument(thickness >= 0, "Thickness must be >= 0");
+        checkCommandArgument(thickness >= 1, "Thickness must be >= 1");
 
         int affected = editSession.hollowOutRegion(region, thickness, pattern);
         actor.printInfo(TranslatableComponent.of("worldedit.hollow.changed", TextComponent.of(affected)));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -79,8 +79,11 @@ import org.enginehub.piston.annotation.CommandContainer;
 import org.enginehub.piston.annotation.param.Arg;
 import org.enginehub.piston.annotation.param.ArgFlag;
 import org.enginehub.piston.annotation.param.Switch;
+import org.enginehub.piston.exception.CommandException;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import static com.sk89q.worldedit.command.util.Logging.LogMode.ALL;
@@ -543,20 +546,40 @@ public class RegionCommands {
 
     @Command(
         name = "/hollow",
-        desc = "Hollows out the object contained in this selection",
-        descFooter = "Thickness is measured in manhattan distance."
+        desc = "Hollows out the object contained in this selection"
     )
     @CommandPermissions("worldedit.region.hollow")
     @Logging(REGION)
-    public int hollow(Actor actor, EditSession editSession,
+    public int hollow(Actor actor, EditSession editSession, LocalSession session,
                       @Selection Region region,
-                      @Arg(desc = "Thickness of the shell to leave", def = "1")
+                      @Arg(desc = "Thickness of the shell to leave, measured in manhattan distance", def = "1")
                           int thickness,
                       @Arg(desc = "The pattern of blocks to replace the hollowed area with", def = "air")
-                          Pattern pattern) throws WorldEditException {
+                          Pattern pattern,
+                      @Switch(name = 'o', desc = "Open up faces touching the bounding box. This matches the legacy behaviour.")
+                          boolean openSides,
+                      @Switch(name = 'p', desc = "Consider placement position as 'outside' instead of the selection bounding box. Overrides -o.")
+                          boolean usePlacementPosition,
+                      @Switch(name = 'g', desc = "Consider block geometry for visibility calculation")
+                          boolean useBlockGeometry) throws WorldEditException {
         checkCommandArgument(thickness >= 1, "Thickness must be >= 1");
 
-        int affected = editSession.hollowOutRegion(region, thickness, pattern);
+        final Collection<BlockVector3> startingPositions;
+        if (usePlacementPosition) {
+            BlockVector3 placementPosition = session.getPlacementPosition(actor);
+            if (!region.contains(placementPosition)) {
+                throw new CommandException(
+                    TextComponent.of("Placement position must be inside selection (")
+                        .append(session.getPlacement().getInfo())
+                        .append(TextComponent.of(")")),
+                    ImmutableList.of()
+                );
+            }
+            startingPositions = Collections.singletonList(placementPosition);
+        } else {
+            startingPositions = null;
+        }
+        int affected = editSession.hollowOutRegion(region, thickness, pattern, openSides, startingPositions, useBlockGeometry);
         actor.printInfo(TranslatableComponent.of("worldedit.hollow.changed", TextComponent.of(affected)));
         return affected;
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -43,6 +43,7 @@ import com.sk89q.worldedit.function.generator.FloraGenerator;
 import com.sk89q.worldedit.function.mask.ExistingBlockMask;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.mask.MaskIntersection;
+import com.sk89q.worldedit.function.mask.Masks;
 import com.sk89q.worldedit.function.mask.NoiseFilter2D;
 import com.sk89q.worldedit.function.operation.Operations;
 import com.sk89q.worldedit.function.pattern.Pattern;
@@ -561,7 +562,9 @@ public class RegionCommands {
                       @Switch(name = 'p', desc = "Consider placement position as 'outside' instead of the selection bounding box. Overrides -o.")
                           boolean usePlacementPosition,
                       @Switch(name = 'g', desc = "Consider block geometry for visibility calculation")
-                          boolean useBlockGeometry) throws WorldEditException {
+                          boolean useBlockGeometry,
+                      @ArgFlag(name = 'm', desc = "Set the mask of blocks eligible for shell detection")
+                          Mask includeMask) throws WorldEditException {
         checkCommandArgument(thickness >= 1, "Thickness must be >= 1");
 
         final Collection<BlockVector3> startingPositions;
@@ -579,7 +582,10 @@ public class RegionCommands {
         } else {
             startingPositions = null;
         }
-        int affected = editSession.hollowOutRegion(region, thickness, pattern, openSides, startingPositions, useBlockGeometry);
+        if (includeMask == null) {
+            includeMask = Masks.alwaysTrue();
+        }
+        int affected = editSession.hollowOutRegion(region, thickness, pattern, openSides, startingPositions, useBlockGeometry, includeMask);
         actor.printInfo(TranslatableComponent.of("worldedit.hollow.changed", TextComponent.of(affected)));
         return affected;
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/block/AbstractBlockMaterial.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/block/AbstractBlockMaterial.java
@@ -1,0 +1,49 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.internal.block;
+
+import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.util.concurrency.LazyReference;
+import com.sk89q.worldedit.world.registry.BlockMaterial;
+
+import java.util.EnumSet;
+
+public abstract class AbstractBlockMaterial<VS> implements BlockMaterial {
+    @SuppressWarnings("this-escape")
+    public LazyReference<EnumSet<ShapeType>> isFullCube = LazyReference.from(() -> {
+        EnumSet<ShapeType> enumSet = EnumSet.noneOf(ShapeType.class);
+        for (ShapeType shapeType : ShapeType.values()) {
+            if (isShapeFullBlock(getShape(shapeType))) {
+                enumSet.add(shapeType);
+            }
+        }
+
+        return enumSet;
+    });
+
+    @Override
+    public boolean isFullCube(ShapeType shapeType) {
+        return isFullCube.getValue().contains(shapeType);
+    }
+
+    protected abstract VS getShape(ShapeType shapeType);
+
+    protected abstract boolean isShapeFullBlock(VS shape);
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/block/AbstractBlockMaterial.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/block/AbstractBlockMaterial.java
@@ -20,9 +20,11 @@
 package com.sk89q.worldedit.internal.block;
 
 import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.concurrency.LazyReference;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 
+import java.util.EnumMap;
 import java.util.EnumSet;
 
 public abstract class AbstractBlockMaterial<VS> implements BlockMaterial {
@@ -38,12 +40,38 @@ public abstract class AbstractBlockMaterial<VS> implements BlockMaterial {
         return enumSet;
     });
 
+    @SuppressWarnings("this-escape")
+    public LazyReference<EnumMap<Direction, EnumSet<ShapeType>>> isFullFace = LazyReference.from(() -> {
+        EnumMap<Direction, EnumSet<ShapeType>> enumMap = new EnumMap<>(Direction.class);
+        for (Direction face : Direction.values()) {
+            if (!face.isUpright() && !face.isCardinal()) {
+                continue;
+            }
+
+            EnumSet<ShapeType> enumSet = EnumSet.noneOf(ShapeType.class);
+            for (ShapeType shapeType : ShapeType.values()) {
+                if (isFaceFull(getShape(shapeType), face)) {
+                    enumSet.add(shapeType);
+                }
+            }
+            enumMap.put(face, enumSet);
+        }
+        return enumMap;
+    });
+
     @Override
     public boolean isFullCube(ShapeType shapeType) {
         return isFullCube.getValue().contains(shapeType);
     }
 
+    @Override
+    public boolean isFullFace(ShapeType shapeType, Direction face) {
+        return isFullFace.getValue().get(face).contains(shapeType);
+    }
+
     protected abstract VS getShape(ShapeType shapeType);
 
     protected abstract boolean isShapeFullBlock(VS shape);
+
+    protected abstract boolean isFaceFull(VS shape, Direction face);
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/block/AbstractBlockMaterial.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/block/AbstractBlockMaterial.java
@@ -17,24 +17,31 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.sk89q.worldedit.function.mask;
+package com.sk89q.worldedit.internal.block;
 
 import com.sk89q.worldedit.blocks.ShapeType;
-import com.sk89q.worldedit.extent.Extent;
-import com.sk89q.worldedit.math.BlockVector3;
-import com.sk89q.worldedit.world.block.BlockState;
+import com.sk89q.worldedit.util.concurrency.LazyReference;
+import com.sk89q.worldedit.world.registry.BlockMaterial;
 
-public final class FullCubeMask extends AbstractExtentMask {
+import java.util.EnumSet;
 
-    public FullCubeMask(Extent extent) {
-        super(extent);
-    }
+public abstract class AbstractBlockMaterial<VS> implements BlockMaterial {
+    @SuppressWarnings("this-escape")
+    public LazyReference<EnumSet<ShapeType>> isFullCube = LazyReference.from(() -> {
+        EnumSet<ShapeType> enumSet = EnumSet.noneOf(ShapeType.class);
+        for (ShapeType shapeType : ShapeType.values()) {
+            if (isFullCubeUncached(shapeType)) {
+                enumSet.add(shapeType);
+            }
+        }
+
+        return enumSet;
+    });
 
     @Override
-    public boolean test(BlockVector3 vector) {
-        Extent extent = getExtent();
-        BlockState block = extent.getBlock(vector);
-        return block.getBlockType().getMaterial().isFullCube(ShapeType.SHAPE);
+    public boolean isFullCube(ShapeType shapeType) {
+        return isFullCube.getValue().contains(shapeType);
     }
 
+    protected abstract boolean isFullCubeUncached(ShapeType shapeType);
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/block/AbstractBlockMaterial.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/block/AbstractBlockMaterial.java
@@ -20,9 +20,11 @@
 package com.sk89q.worldedit.internal.block;
 
 import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.concurrency.LazyReference;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 
+import java.util.EnumMap;
 import java.util.EnumSet;
 
 public abstract class AbstractBlockMaterial<VS> implements BlockMaterial {
@@ -38,10 +40,36 @@ public abstract class AbstractBlockMaterial<VS> implements BlockMaterial {
         return enumSet;
     });
 
+    @SuppressWarnings("this-escape")
+    public LazyReference<EnumMap<Direction, EnumSet<ShapeType>>> isFullFace = LazyReference.from(() -> {
+        EnumMap<Direction, EnumSet<ShapeType>> enumMap = new EnumMap<>(Direction.class);
+        for (Direction face : Direction.values()) {
+            if (!face.isUpright() && !face.isCardinal()) {
+                continue;
+            }
+
+            EnumSet<ShapeType> enumSet = EnumSet.noneOf(ShapeType.class);
+            for (ShapeType shapeType : ShapeType.values()) {
+                if (isFullFaceUncached(shapeType, face)) {
+                    enumSet.add(shapeType);
+                }
+            }
+            enumMap.put(face, enumSet);
+        }
+        return enumMap;
+    });
+
     @Override
     public boolean isFullCube(ShapeType shapeType) {
         return isFullCube.getValue().contains(shapeType);
     }
 
+    @Override
+    public boolean isFullFace(ShapeType shapeType, Direction face) {
+        return isFullFace.getValue().get(face).contains(shapeType);
+    }
+
     protected abstract boolean isFullCubeUncached(ShapeType shapeType);
+
+    protected abstract boolean isFullFaceUncached(ShapeType shapeType, Direction face);
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockState.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockState.java
@@ -19,9 +19,12 @@
 
 package com.sk89q.worldedit.world.block;
 
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.extension.platform.Capability;
 import com.sk89q.worldedit.internal.block.BlockStateIdAccess;
 import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.util.concurrency.LazyReference;
+import com.sk89q.worldedit.world.registry.BlockMaterial;
 import org.enginehub.linbus.tree.LinCompoundTag;
 
 import java.util.HashSet;
@@ -72,6 +75,11 @@ public class BlockState implements BlockStateHolder<BlockState> {
     @Override
     public BlockType getBlockType() {
         return this.blockType;
+    }
+
+    public BlockMaterial getMaterial() {
+        return WorldEdit.getInstance().getPlatformManager()
+                .queryCapability(Capability.GAME_HOOKS).getRegistries().getBlockRegistry().getMaterial(this);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockState.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockState.java
@@ -25,6 +25,7 @@ import com.sk89q.worldedit.internal.block.BlockStateIdAccess;
 import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.util.concurrency.LazyReference;
 import com.sk89q.worldedit.world.fluid.FluidState;
+import com.sk89q.worldedit.world.registry.BlockMaterial;
 import org.enginehub.linbus.tree.LinCompoundTag;
 
 import java.util.HashSet;
@@ -78,6 +79,11 @@ public class BlockState implements BlockStateHolder<BlockState> {
     @Override
     public BlockType getBlockType() {
         return this.blockType;
+    }
+
+    public BlockMaterial getMaterial() {
+        return WorldEdit.getInstance().getPlatformManager()
+                .queryCapability(Capability.GAME_HOOKS).getRegistries().getBlockRegistry().getMaterial(this);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockType.java
@@ -72,7 +72,7 @@ public class BlockType implements Keyed {
     @SuppressWarnings("this-escape")
     private final LazyReference<BlockMaterial> blockMaterial
         = LazyReference.from(() -> WorldEdit.getInstance().getPlatformManager()
-        .queryCapability(Capability.GAME_HOOKS).getRegistries().getBlockRegistry().getMaterial(this));
+        .queryCapability(Capability.GAME_HOOKS).getRegistries().getBlockRegistry().getMaterial(getDefaultState()));
     @SuppressWarnings("this-escape")
     private final LazyReference<Integer> legacyId = LazyReference.from(() -> computeLegacy(0));
     @SuppressWarnings("this-escape")

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockMaterial.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockMaterial.java
@@ -19,6 +19,8 @@
 
 package com.sk89q.worldedit.world.registry;
 
+import com.sk89q.worldedit.blocks.ShapeType;
+
 /**
  * Describes the material for a block.
  */
@@ -36,7 +38,17 @@ public interface BlockMaterial {
      *
      * @return the value of the test
      */
-    boolean isFullCube();
+    default boolean isFullCube() {
+        return isFullCube(ShapeType.SHAPE);
+    }
+
+    /**
+     * Get whether this block is a full sized cube.
+     *
+     * @param shapeType which shape of the block to test
+     * @return the value of the test
+     */
+    boolean isFullCube(ShapeType shapeType);
 
     /**
      * Get whether this block is opaque.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockMaterial.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockMaterial.java
@@ -20,6 +20,7 @@
 package com.sk89q.worldedit.world.registry;
 
 import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.util.Direction;
 
 /**
  * Describes the material for a block.
@@ -49,6 +50,17 @@ public interface BlockMaterial {
      * @return the value of the test
      */
     boolean isFullCube(ShapeType shapeType);
+
+    /**
+     * Get whether this face is a full sized face.
+     *
+     * @param shapeType which shape of the block to test
+     * @param face      the face to test
+     * @return the value of the test
+     */
+    default boolean isFullFace(ShapeType shapeType, Direction face) {
+        return isFullCube(shapeType);
+    }
 
     /**
      * Get whether this block is opaque.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockMaterial.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockMaterial.java
@@ -20,6 +20,7 @@
 package com.sk89q.worldedit.world.registry;
 
 import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.util.Direction;
 
 /**
  * Describes the material for a block.
@@ -51,6 +52,17 @@ public interface BlockMaterial {
      * @return the value of the test
      */
     boolean isFullCube(ShapeType shapeType);
+
+    /**
+     * Get whether this face is a full sized face.
+     *
+     * @param shapeType which shape of the block to test
+     * @param face      the face to test
+     * @return the value of the test
+     */
+    default boolean isFullFace(ShapeType shapeType, Direction face) {
+        return isFullCube(shapeType);
+    }
 
     /**
      * Get whether this block is opaque.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockMaterial.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockMaterial.java
@@ -19,6 +19,8 @@
 
 package com.sk89q.worldedit.world.registry;
 
+import com.sk89q.worldedit.blocks.ShapeType;
+
 /**
  * Describes the material for a block.
  */
@@ -35,8 +37,20 @@ public interface BlockMaterial {
      * Get whether this block is a full sized cube.
      *
      * @return the value of the test
+     * @deprecated Use {@link BlockMaterial#isFullCube(ShapeType)} instead.
      */
-    boolean isFullCube();
+    @Deprecated
+    default boolean isFullCube() {
+        return isFullCube(ShapeType.SHAPE);
+    }
+
+    /**
+     * Get whether this block is a full sized cube.
+     *
+     * @param shapeType which shape of the block to test
+     * @return the value of the test
+     */
+    boolean isFullCube(ShapeType shapeType);
 
     /**
      * Get whether this block is opaque.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockRegistry.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit.world.registry;
 
+import com.sk89q.worldedit.internal.util.NonAbstractForCompatibility;
 import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -46,9 +47,30 @@ public interface BlockRegistry {
      *
      * @param blockType the block
      * @return the material, or null if the material information is not known
+     * @deprecated Use {@link BlockRegistry#getMaterial(BlockState)} instead.
      */
+    @Deprecated
     @Nullable
-    BlockMaterial getMaterial(BlockType blockType);
+    default BlockMaterial getMaterial(BlockType blockType) {
+        return getMaterial(blockType.getDefaultState());
+    }
+
+    /**
+     * Get the material for the given block state.
+     *
+     * @param blockState the block state
+     * @return the material, or null if the material information is not known
+     * @apiNote This must be overridden by new subclasses. See {@link NonAbstractForCompatibility}
+     *          for details
+     */
+    @NonAbstractForCompatibility(
+        delegateName = "getMaterial",
+        delegateParams = { BlockType.class }
+    )
+    @Nullable
+    default BlockMaterial getMaterial(BlockState blockState) {
+        return getMaterial(blockState.getBlockType());
+    }
 
     /**
      * Get an unmodifiable map of states for this block.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockRegistry.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit.world.registry;
 
+import com.sk89q.worldedit.internal.util.NonAbstractForCompatibility;
 import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -48,9 +49,30 @@ public interface BlockRegistry {
      *
      * @param blockType the block
      * @return the material, or null if the material information is not known
+     * @deprecated Use {@link BlockRegistry#getMaterial(BlockState)} instead.
      */
+    @Deprecated
     @Nullable
-    BlockMaterial getMaterial(BlockType blockType);
+    default BlockMaterial getMaterial(BlockType blockType) {
+        return getMaterial(blockType.getDefaultState());
+    }
+
+    /**
+     * Get the material for the given block state.
+     *
+     * @param blockState the block state
+     * @return the material, or null if the material information is not known
+     * @apiNote This must be overridden by new subclasses. See {@link NonAbstractForCompatibility}
+     *          for details
+     */
+    @NonAbstractForCompatibility(
+        delegateName = "getMaterial",
+        delegateParams = { BlockType.class }
+    )
+    @Nullable
+    default BlockMaterial getMaterial(BlockState blockState) {
+        return getMaterial(blockState.getBlockType());
+    }
 
     /**
      * Get an unmodifiable map of states for this block.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledBlockRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledBlockRegistry.java
@@ -59,8 +59,8 @@ public class BundledBlockRegistry implements BlockRegistry {
 
     @Nullable
     @Override
-    public BlockMaterial getMaterial(BlockType blockType) {
-        return new PassthroughBlockMaterial(BundledBlockData.getInstance().getMaterialById(blockType.id()));
+    public BlockMaterial getMaterial(BlockType blockState) {
+        return new PassthroughBlockMaterial(BundledBlockData.getInstance().getMaterialById(blockState.id()));
     }
 
     @Nullable

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/PassthroughBlockMaterial.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/PassthroughBlockMaterial.java
@@ -20,6 +20,7 @@
 package com.sk89q.worldedit.world.registry;
 
 import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.util.Direction;
 
 import javax.annotation.Nullable;
 
@@ -53,6 +54,11 @@ public class PassthroughBlockMaterial implements BlockMaterial {
     @Override
     public boolean isFullCube(ShapeType shapeType) {
         return blockMaterial.isFullCube(shapeType);
+    }
+
+    @Override
+    public boolean isFullFace(ShapeType shapeType, Direction face) {
+        return blockMaterial.isFullFace(shapeType, face);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/PassthroughBlockMaterial.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/PassthroughBlockMaterial.java
@@ -19,6 +19,8 @@
 
 package com.sk89q.worldedit.world.registry;
 
+import com.sk89q.worldedit.blocks.ShapeType;
+
 import javax.annotation.Nullable;
 
 import static com.sk89q.worldedit.util.GuavaUtil.firstNonNull;
@@ -49,8 +51,8 @@ public class PassthroughBlockMaterial implements BlockMaterial {
     }
 
     @Override
-    public boolean isFullCube() {
-        return blockMaterial.isFullCube();
+    public boolean isFullCube(ShapeType shapeType) {
+        return blockMaterial.isFullCube(shapeType);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/SimpleBlockMaterial.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/SimpleBlockMaterial.java
@@ -19,6 +19,8 @@
 
 package com.sk89q.worldedit.world.registry;
 
+import com.sk89q.worldedit.blocks.ShapeType;
+
 class SimpleBlockMaterial implements BlockMaterial {
 
     private boolean isAir;
@@ -51,7 +53,7 @@ class SimpleBlockMaterial implements BlockMaterial {
     }
 
     @Override
-    public boolean isFullCube() {
+    public boolean isFullCube(ShapeType shapeType) {
         return fullCube;
     }
 

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeAdapter.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeAdapter.java
@@ -235,6 +235,17 @@ public class SpongeAdapter {
         return Direction.valueOf(direction.name());
     }
 
+    public static net.minecraft.core.Direction adapt(Direction face) {
+        return switch (face) {
+            case NORTH -> net.minecraft.core.Direction.NORTH;
+            case SOUTH -> net.minecraft.core.Direction.SOUTH;
+            case WEST -> net.minecraft.core.Direction.WEST;
+            case EAST -> net.minecraft.core.Direction.EAST;
+            case DOWN -> net.minecraft.core.Direction.DOWN;
+            default -> net.minecraft.core.Direction.UP;
+        };
+    }
+
     public static Vector3i adaptVector3i(BlockVector3 bv3) {
         return new Vector3i(bv3.x(), bv3.y(), bv3.z());
     }

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeBlockMaterial.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeBlockMaterial.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.sponge;
 
 import com.sk89q.worldedit.blocks.ShapeType;
 import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
+import com.sk89q.worldedit.util.Direction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -60,6 +61,11 @@ public class SpongeBlockMaterial extends AbstractBlockMaterial<VoxelShape> {
     @Override
     protected boolean isShapeFullBlock(VoxelShape shape) {
         return Block.isShapeFullBlock(shape);
+    }
+
+    @Override
+    protected boolean isFaceFull(VoxelShape shape, Direction face) {
+        return Block.isFaceFull(shape, SpongeAdapter.adapt(face));
     }
 
     @Override

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeBlockMaterial.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeBlockMaterial.java
@@ -19,7 +19,8 @@
 
 package com.sk89q.worldedit.sponge;
 
-import com.sk89q.worldedit.world.registry.BlockMaterial;
+import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -27,13 +28,15 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
 /**
  * Sponge block material that pulls as much info as possible from the Minecraft
  * Material, and passes the rest to another implementation, typically the
  * bundled block info.
  */
-public class SpongeBlockMaterial implements BlockMaterial {
+public class SpongeBlockMaterial extends AbstractBlockMaterial<VoxelShape> {
 
     private final BlockState block;
 
@@ -47,8 +50,16 @@ public class SpongeBlockMaterial implements BlockMaterial {
     }
 
     @Override
-    public boolean isFullCube() {
-        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
+    protected VoxelShape getShape(ShapeType shapeType) {
+        return switch (shapeType) {
+            case SHAPE -> block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+            case VISUAL_SHAPE -> block.getVisualShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+        };
+    }
+
+    @Override
+    protected boolean isShapeFullBlock(VoxelShape shape) {
+        return Block.isShapeFullBlock(shape);
     }
 
     @Override

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeBlockMaterial.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeBlockMaterial.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.sponge;
 
 import com.sk89q.worldedit.blocks.ShapeType;
 import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
+import com.sk89q.worldedit.util.Direction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -59,6 +60,11 @@ public class SpongeBlockMaterial extends AbstractBlockMaterial<VoxelShape> {
     @Override
     protected boolean isFullCubeUncached(ShapeType shapeType) {
         return Block.isShapeFullBlock(getShape(shapeType));
+    }
+
+    @Override
+    protected boolean isFullFaceUncached(ShapeType shapeType, Direction face) {
+        return Block.isFaceFull(getShape(shapeType), SpongeAdapter.adapt(face));
     }
 
     @Override

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeBlockMaterial.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeBlockMaterial.java
@@ -19,7 +19,8 @@
 
 package com.sk89q.worldedit.sponge;
 
-import com.sk89q.worldedit.world.registry.BlockMaterial;
+import com.sk89q.worldedit.blocks.ShapeType;
+import com.sk89q.worldedit.internal.block.AbstractBlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -27,13 +28,15 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
 /**
  * Sponge block material that pulls as much info as possible from the Minecraft
  * Material, and passes the rest to another implementation, typically the
  * bundled block info.
  */
-public class SpongeBlockMaterial implements BlockMaterial {
+public class SpongeBlockMaterial extends AbstractBlockMaterial<VoxelShape> {
 
     private final BlockState block;
 
@@ -46,9 +49,16 @@ public class SpongeBlockMaterial implements BlockMaterial {
         return block.isAir();
     }
 
+    private VoxelShape getShape(ShapeType shapeType) {
+        return switch (shapeType) {
+            case SHAPE -> block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+            case VISUAL_SHAPE -> block.getVisualShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CollisionContext.empty());
+        };
+    }
+
     @Override
-    public boolean isFullCube() {
-        return Block.isShapeFullBlock(block.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
+    protected boolean isFullCubeUncached(ShapeType shapeType) {
+        return Block.isShapeFullBlock(getShape(shapeType));
     }
 
     @Override

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeBlockRegistry.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeBlockRegistry.java
@@ -50,19 +50,16 @@ public class SpongeBlockRegistry implements BlockRegistry {
     }
 
     @Override
-    public BlockMaterial getMaterial(BlockType blockType) {
-        org.spongepowered.api.block.BlockType spongeBlockType =
-            Sponge.game().registry(RegistryTypes.BLOCK_TYPE)
-                .value(ResourceKey.resolve(blockType.id()));
+    public BlockMaterial getMaterial(BlockState blockState) {
         return materialMap.computeIfAbsent(
-            spongeBlockType.defaultState(),
-            m -> {
-                net.minecraft.world.level.block.state.BlockState blockState =
-                    (net.minecraft.world.level.block.state.BlockState) m;
-                return new SpongeBlockMaterial(
-                    blockState
-                );
-            }
+                SpongeAdapter.adapt(blockState),
+                m -> {
+                    net.minecraft.world.level.block.state.BlockState mcBlockState =
+                            (net.minecraft.world.level.block.state.BlockState) m;
+                    return new SpongeBlockMaterial(
+                            mcBlockState
+                    );
+                }
         );
     }
 

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeBlockRegistry.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeBlockRegistry.java
@@ -54,19 +54,16 @@ public class SpongeBlockRegistry implements BlockRegistry {
     }
 
     @Override
-    public BlockMaterial getMaterial(BlockType blockType) {
-        org.spongepowered.api.block.BlockType spongeBlockType =
-            Sponge.game().registry(RegistryTypes.BLOCK_TYPE)
-                .value(ResourceKey.resolve(blockType.id()));
+    public BlockMaterial getMaterial(BlockState blockState) {
         return materialMap.computeIfAbsent(
-            spongeBlockType.defaultState(),
-            m -> {
-                net.minecraft.world.level.block.state.BlockState blockState =
-                    (net.minecraft.world.level.block.state.BlockState) m;
-                return new SpongeBlockMaterial(
-                    blockState
-                );
-            }
+                SpongeAdapter.adapt(blockState),
+                m -> {
+                    net.minecraft.world.level.block.state.BlockState mcBlockState =
+                            (net.minecraft.world.level.block.state.BlockState) m;
+                    return new SpongeBlockMaterial(
+                            mcBlockState
+                    );
+                }
         );
     }
 


### PR DESCRIPTION
- Add -p flag to iterate from placement position instead of the selection boundaries
- Add -g flag to consider geometry in visibility calculations
- Add -m \<mask> flag to set the mask of blocks eligible for shell detection
- By default, //hollow will no longer open up faces that are touching the selection bounding box.
  The old behaviour can be access with the -o flag.

**Note:** This is based on #2997, please don't squash.