### PR TITLE
Remove ThreadLocal usage

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -1152,7 +1152,8 @@ public class LocalSession {
             builder.blockBag(getBlockBag(player));
         }
         EditSession editSession = builder.build();
-        Request.request().setEditSession(editSession);
+        // Allow creating EditSessions outside a request if needed.
+        Request.applyIfPresent(r -> r.setEditSession(editSession));
 
         editSession.setMask(mask);
         prepareEditingExtents(editSession, actor);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
@@ -472,18 +472,20 @@ public final class PlatformCommandManager {
 
     @Subscribe
     public void handleCommand(CommandEvent event) {
-        Request.reset();
-
-        Actor actor = platformManager.createProxyActor(event.getActor());
-        String[] split = parseArgs(event.getArguments())
+        String[] splitArgs = parseArgs(event.getArguments())
             .map(Substring::getSubstring)
             .toArray(String[]::new);
 
         // No command found!
-        if (!commandManager.containsCommand(split[0])) {
+        if (!commandManager.containsCommand(splitArgs[0])) {
             return;
         }
 
+        Request.runWithRequest(() -> executeCommand(event, splitArgs));
+    }
+
+    private void executeCommand(CommandEvent event, String[] splitArgs) {
+        Actor actor = platformManager.createProxyActor(event.getActor());
         LocalSession session = worldEdit.getSessionManager().get(actor);
         Request.request().setSession(session);
         if (actor instanceof Entity entity && entity.getExtent() instanceof World world) {
@@ -502,7 +504,7 @@ public final class PlatformCommandManager {
             // exceptions and rethrow their converted form, if their is one.
             try {
                 try {
-                    commandManager.execute(context, ImmutableList.copyOf(split));
+                    commandManager.execute(context, ImmutableList.copyOf(splitArgs));
                 } finally {
                     Optional<EditSession> editSessionOpt =
                         context.snapshotMemory().injectedValue(Key.of(EditSession.class));
@@ -563,8 +565,6 @@ public final class PlatformCommandManager {
             actor.printError(e.getRichMessage());
         } catch (Throwable t) {
             handleUnknownException(actor, t);
-        } finally {
-            Request.reset();
         }
 
         event.setCancelled(true);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformManager.java
@@ -437,11 +437,11 @@ public class PlatformManager {
         }
         LocalSession session = worldEdit.getSessionManager().get(actor);
 
-        Request.reset();
-        Request.request().setSession(session);
-        Request.request().setWorld(player.getWorld());
+        Request.runWithRequest(() -> {
+            Request request = Request.request();
+            request.setSession(session);
+            request.setWorld(player.getWorld());
 
-        try {
             if (event.getType() == Interaction.HIT) {
                 // superpickaxe is special because its primary interaction is a left click, not a right click
                 // in addition, it is implicitly bound to all pickaxe items, not just a single tool item
@@ -473,9 +473,7 @@ public class PlatformManager {
                     }
                 }
             }
-        } finally {
-            Request.reset();
-        }
+        });
     }
 
     @Subscribe
@@ -484,11 +482,11 @@ public class PlatformManager {
         // making changes to the world
         Player player = createProxyActor(event.getPlayer());
         LocalSession session = worldEdit.getSessionManager().get(player);
-        Request.reset();
-        Request.request().setSession(session);
-        Request.request().setWorld(player.getWorld());
+        Request.runWithRequest(() -> {
+            Request request = Request.request();
+            request.setSession(session);
+            request.setWorld(player.getWorld());
 
-        try {
             exhaustive(switch (event.getInputType()) {
                 case PRIMARY -> {
                     Tool tool = session.getTool(player.getItemInHand(HandSide.MAIN_HAND).getType());
@@ -513,9 +511,7 @@ public class PlatformManager {
                     yield dummyValue();
                 }
             });
-        } finally {
-            Request.reset();
-        }
+        });
     }
 
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/expression/Functions.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/expression/Functions.java
@@ -266,12 +266,10 @@ public final class Functions {
         return ThreadLocalRandom.current().nextInt((int) Math.floor(max));
     }
 
-    private static final ThreadLocal<PerlinNoise> localPerlin = ThreadLocal.withInitial(PerlinNoise::new);
-
     @ExpressionFunction
     private static double perlin(double seed, double x, double y, double z,
                                  double frequency, double octaves, double persistence) {
-        PerlinNoise perlin = localPerlin.get();
+        PerlinNoise perlin = new PerlinNoise();
         try {
             perlin.setSeed((int) seed);
             perlin.setFrequency(frequency);
@@ -283,11 +281,9 @@ public final class Functions {
         return perlin.noise(Vector3.at(x, y, z));
     }
 
-    private static final ThreadLocal<VoronoiNoise> localVoronoi = ThreadLocal.withInitial(VoronoiNoise::new);
-
     @ExpressionFunction
     private static double voronoi(double seed, double x, double y, double z, double frequency) {
-        VoronoiNoise voronoi = localVoronoi.get();
+        VoronoiNoise voronoi = new VoronoiNoise();
         try {
             voronoi.setSeed((int) seed);
             voronoi.setFrequency(frequency);
@@ -297,12 +293,10 @@ public final class Functions {
         return voronoi.noise(Vector3.at(x, y, z));
     }
 
-    private static final ThreadLocal<RidgedMultiFractalNoise> localRidgedMulti = ThreadLocal.withInitial(RidgedMultiFractalNoise::new);
-
     @ExpressionFunction
     private static double ridgedmulti(double seed, double x, double y, double z,
                                       double frequency, double octaves) {
-        RidgedMultiFractalNoise ridgedMulti = localRidgedMulti.get();
+        RidgedMultiFractalNoise ridgedMulti = new RidgedMultiFractalNoise();
         try {
             ridgedMulti.setSeed((int) seed);
             ridgedMulti.setFrequency(frequency);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
@@ -169,7 +169,9 @@ public class SessionManager {
                 LOGGER.warn("Failed to load saved session", e);
                 session = new LocalSession();
             }
-            Request.request().setSession(session);
+            // Allow retrieving a session outside a request if needed.
+            LocalSession finalSession = session;
+            Request.applyIfPresent(r -> r.setSession(finalSession));
 
             session.setConfiguration(config);
             session.setBlockChangeLimit(config.defaultChangeLimit);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/request/Request.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/request/Request.java
@@ -23,6 +23,7 @@ import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.world.World;
 
+import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
 /**
@@ -30,7 +31,7 @@ import javax.annotation.Nullable;
  */
 public final class Request {
 
-    private static final ThreadLocal<Request> threadLocal = ThreadLocal.withInitial(Request::new);
+    private static final ScopedValue<Request> CURRENT_REQUEST = ScopedValue.newInstance();
 
     private @Nullable World world;
     private @Nullable LocalSession session;
@@ -100,15 +101,44 @@ public final class Request {
      * @return the current request
      */
     public static Request request() {
-        return threadLocal.get();
+        return CURRENT_REQUEST.get();
+    }
+
+    /**
+     * Apply a function to the current request if it is present.
+     * If no request is present, the function will not be called.
+     *
+     * @param func the function to apply to the current request
+     */
+    public static void applyIfPresent(Consumer<Request> func) {
+        if (CURRENT_REQUEST.isBound()) {
+            func.accept(request());
+        }
+    }
+
+    /**
+     * Run a task with a new request. The request will be automatically invalidated after the task completes.
+     *
+     * @param runnable the task to run
+     */
+    public static void runWithRequest(Runnable runnable) {
+        Request request = new Request();
+        request.valid = true;
+        try {
+            ScopedValue.where(CURRENT_REQUEST, request).run(runnable);
+        } finally {
+            request.invalidate();
+        }
     }
 
     /**
      * Reset the current request and clear all fields.
+     *
+     * @deprecated This class is now scoped, so resetting at arbitrary points is not supported.
      */
+    @Deprecated(forRemoval = true)
     public static void reset() {
         request().invalidate();
-        threadLocal.remove();
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/request/RequestExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/request/RequestExtent.java
@@ -38,12 +38,8 @@ import javax.annotation.Nullable;
 
 public class RequestExtent implements Extent {
 
-    private Request request;
-
     protected Extent getExtent() {
-        if (request == null || !request.isValid()) {
-            request = Request.request();
-        }
+        Request request = Request.request();
         final EditSession editSession = request.getEditSession();
         return editSession == null ? request.getWorld() : editSession;
     }
@@ -102,8 +98,6 @@ public class RequestExtent implements Extent {
     @Override
     @Nullable
     public Operation commit() {
-        Operation commit = getExtent().commit();
-        request = null;
-        return commit;
+        return getExtent().commit();
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/request/RequestSelection.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/request/RequestSelection.java
@@ -49,8 +49,9 @@ public class RequestSelection implements Region {
      * @return the delegate region
      */
     protected Region getRegion() {
-        LocalSession session = Request.request().getSession();
-        World world = Request.request().getWorld();
+        Request request = Request.request();
+        LocalSession session = request.getSession();
+        World world = request.getWorld();
 
         if (session != null && world != null) {
             try {


### PR DESCRIPTION
In some cases, it probably wasn't really saving us anything since creating the object is likely cheaper than doing the lookup. For Request, it perfectly fits `ScopedValue`, so we adjust all usages to work with that instead.