### PR TITLE
Fix thread leak hanging shutdown on 26.2

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -307,7 +307,6 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
     @Override
     public void onDisable() {
         WorldEdit worldEdit = WorldEdit.getInstance();
-        worldEdit.getSessionManager().unload();
         if (platform != null) {
             worldEdit.getEventBus().post(new PlatformUnreadyEvent(platform));
             worldEdit.getPlatformManager().unregister(platform);

--- a/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIWorldEdit.java
+++ b/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/CLIWorldEdit.java
@@ -27,6 +27,7 @@ import com.sk89q.worldedit.cli.schematic.ClipboardWorld;
 import com.sk89q.worldedit.event.platform.CommandEvent;
 import com.sk89q.worldedit.event.platform.ConfigurationLoadEvent;
 import com.sk89q.worldedit.event.platform.PlatformReadyEvent;
+import com.sk89q.worldedit.event.platform.PlatformUnreadyEvent;
 import com.sk89q.worldedit.event.platform.PlatformsRegisteredEvent;
 import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.ParserContext;
@@ -212,7 +213,7 @@ public class CLIWorldEdit {
 
     public void onStopped() {
         WorldEdit worldEdit = WorldEdit.getInstance();
-        worldEdit.getSessionManager().unload();
+        worldEdit.getEventBus().post(new PlatformUnreadyEvent(platform));
         worldEdit.getPlatformManager().unregister(platform);
     }
 

--- a/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcMod.java
+++ b/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcMod.java
@@ -245,8 +245,6 @@ public abstract class CoreMcMod {
     }
 
     protected void serverStopping() {
-        WorldEdit worldEdit = WorldEdit.getInstance();
-        worldEdit.getSessionManager().unload();
         WorldEdit.getInstance().getEventBus().post(new PlatformUnreadyEvent(platform));
     }
 

--- a/worldedit-core/doctools/src/main/kotlin/com/sk89q/worldedit/internal/util/DocumentationPrinter.kt
+++ b/worldedit-core/doctools/src/main/kotlin/com/sk89q/worldedit/internal/util/DocumentationPrinter.kt
@@ -37,6 +37,7 @@ import com.sk89q.worldedit.command.ToolUtilCommands
 import com.sk89q.worldedit.command.UtilityCommands
 import com.sk89q.worldedit.command.util.PermissionCondition
 import com.sk89q.worldedit.event.platform.PlatformReadyEvent
+import com.sk89q.worldedit.event.platform.PlatformUnreadyEvent
 import com.sk89q.worldedit.event.platform.PlatformsRegisteredEvent
 import com.sk89q.worldedit.internal.command.CommandUtil
 import com.sk89q.worldedit.util.formatting.text.TextComponent
@@ -337,9 +338,9 @@ Other Permissions
          */
         @JvmStatic
         fun main(args: Array<String>) {
+            val plat = DocumentationPlatform()
+            WorldEdit.getInstance().platformManager.register(plat)
             try {
-                val plat = DocumentationPlatform()
-                WorldEdit.getInstance().platformManager.register(plat)
                 WorldEdit.getInstance().eventBus.post(PlatformReadyEvent(plat))
                 WorldEdit.getInstance().eventBus.post(PlatformsRegisteredEvent())
                 val printer = DocumentationPrinter()
@@ -348,7 +349,7 @@ Other Permissions
                 writeOutput("commands.rst", printer.cmdOutput.toString())
                 writeOutput("permissions.rst", printer.permsOutput.toString())
             } finally {
-                WorldEdit.getInstance().sessionManager.unload()
+                WorldEdit.getInstance().eventBus.post(PlatformUnreadyEvent(plat))
             }
         }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -120,7 +120,6 @@ public final class WorldEdit {
     private final PlatformManager platformManager = new PlatformManager(this);
     @Deprecated
     private final EditSessionFactory editSessionFactory = new EditSessionFactory.EditSessionFactoryImpl();
-    private final SessionManager sessions = new SessionManager(this);
     private final Supervisor supervisor = new SimpleSupervisor();
     private final AssetLoaders assetLoaders = new AssetLoaders(this);
     private final SchematicsManager schematicsManager = new SchematicsManager(this);
@@ -237,7 +236,7 @@ public final class WorldEdit {
      * @return the session manager
      */
     public SessionManager getSessionManager() {
-        return sessions;
+        return platformManager.getSessionManager();
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformManager.java
@@ -41,6 +41,7 @@ import com.sk89q.worldedit.event.platform.PlatformUnreadyEvent;
 import com.sk89q.worldedit.event.platform.PlatformsRegisteredEvent;
 import com.sk89q.worldedit.event.platform.PlayerInputEvent;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
+import com.sk89q.worldedit.session.SessionManager;
 import com.sk89q.worldedit.session.request.Request;
 import com.sk89q.worldedit.util.HandSide;
 import com.sk89q.worldedit.util.Location;
@@ -79,6 +80,7 @@ public class PlatformManager {
     private final WorldEdit worldEdit;
     private final PlatformCommandManager platformCommandManager;
     private final SimpleLifecycled<ListeningExecutorService> executorService;
+    private final SimpleLifecycled<SessionManager> sessionManager;
     private final Map<Platform, Boolean> platforms = Maps.newHashMap();
     private final ImmutableMap<Capability, SimpleLifecycled<Platform>> preferences = Stream.of(Capability.values())
         .collect(Maps.toImmutableEnumMap(
@@ -100,6 +102,7 @@ public class PlatformManager {
         this.worldEdit = worldEdit;
         this.platformCommandManager = new PlatformCommandManager(worldEdit, this);
         this.executorService = SimpleLifecycled.invalid();
+        this.sessionManager = SimpleLifecycled.invalid();
 
         // Register this instance for events
         worldEdit.getEventBus().register(this);
@@ -343,6 +346,19 @@ public class PlatformManager {
     }
 
     /**
+     * Get the session manager.
+     *
+     * @return the session manager
+     */
+    public SessionManager getSessionManager() {
+        return sessionManager.valueOrThrow();
+    }
+
+    private static SessionManager createSessionManager() {
+        return new SessionManager(WorldEdit.getInstance());
+    }
+
+    /**
      * Get the current configuration.
      *
      * <p>If no platform has been registered yet, then a default configuration
@@ -406,6 +422,9 @@ public class PlatformManager {
         if (!executorService.isValid()) {
             executorService.newValue(createExecutor());
         }
+        if (!sessionManager.isValid()) {
+            sessionManager.newValue(createSessionManager());
+        }
     }
 
     /**
@@ -420,6 +439,8 @@ public class PlatformManager {
         if (!platforms.containsValue(true)) {
             executorService.value().ifPresent(ListeningExecutorService::shutdownNow);
             executorService.invalidate();
+            sessionManager.value().ifPresent(SessionManager::unload);
+            sessionManager.invalidate();
         }
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/SessionManager.java
@@ -36,7 +36,6 @@ import com.sk89q.worldedit.session.request.Request;
 import com.sk89q.worldedit.session.storage.JsonFileSessionStore;
 import com.sk89q.worldedit.session.storage.SessionStore;
 import com.sk89q.worldedit.session.storage.VoidStore;
-import com.sk89q.worldedit.util.concurrency.EvenMoreExecutors;
 import com.sk89q.worldedit.util.eventbus.Subscribe;
 import com.sk89q.worldedit.world.gamemode.GameModes;
 import com.sk89q.worldedit.world.item.ItemType;
@@ -50,12 +49,13 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-import java.util.Timer;
 import java.util.TimerTask;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -71,13 +71,13 @@ public class SessionManager {
 
     public static int EXPIRATION_GRACE = 10 * 60 * 1000;
     private static final int FLUSH_PERIOD = 1000 * 30;
-    private static final ExecutorService executorService = EvenMoreExecutors.newBoundedCachedThreadPool(
-        0, 1, 5, "WorldEdit Session Saver - %s"
-    );
     private static final Logger LOGGER = LogManagerCompat.getLogger();
     private static final Set<String> warnedInvalidTool = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
-    private final Timer timer = new Timer("WorldEdit Session Manager");
+    private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(
+            1,
+            Thread.ofVirtual().name("WorldEdit Session Manager").factory()
+    );
     private final WorldEdit worldEdit;
     private final Map<UUID, SessionHolder> sessions = new HashMap<>();
     private SessionStore store = new VoidStore();
@@ -93,7 +93,7 @@ public class SessionManager {
         this.worldEdit = worldEdit;
 
         worldEdit.getEventBus().register(this);
-        timer.schedule(new SessionTracker(), FLUSH_PERIOD, FLUSH_PERIOD);
+        var _ = executorService.scheduleAtFixedRate(new SessionTracker(), FLUSH_PERIOD, FLUSH_PERIOD, TimeUnit.MILLISECONDS);
     }
 
     /**
@@ -307,11 +307,21 @@ public class SessionManager {
     }
 
     /**
-     * Called to unload this session manager.
+     * Called to unload this session manager permanently.
      */
-    public synchronized void unload() {
+    public void unload() {
         clear();
-        timer.cancel();
+        executorService.shutdown();
+        try {
+            if (!executorService.awaitTermination(5, TimeUnit.SECONDS)) {
+                var tasks = executorService.shutdownNow();
+                WorldEdit.logger.error("Session manager is taking too long to exit. List of active tasks: ({})\n{}",
+                        tasks.size(),
+                        tasks.stream().map(run -> run.getClass() + ": " + run + "\n"));
+            }
+        } catch (InterruptedException e) {
+            WorldEdit.logger.error("Interrupted while waiting for session manager to shutdown", e);
+        }
     }
 
     /**

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorldEdit.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorldEdit.java
@@ -253,7 +253,6 @@ public class SpongeWorldEdit {
     @Listener
     public void serverStopping(StoppingEngineEvent<Server> event) {
         WorldEdit worldEdit = WorldEdit.getInstance();
-        worldEdit.getSessionManager().unload();
         WorldEdit.getInstance().getEventBus().post(new PlatformUnreadyEvent(platform));
     }
 


### PR DESCRIPTION
Since 26.2, the client (and possibly server?) waits for threads to exit before closing. Crashing after a short time.
This pull fixes a bug where SessionManager didn't properly shut down.
```
The game crashed: client shutdown from post-main
Error: java.lang.Error: Watchdog (Client shutdown from post-main)
```

Cause:
1. SessionManager is initialized at client start but only shutdown at _server_ shutdown. If the client never opens a world, `SessionManager#unload` is never called.
2. ~`SessionManager#unload` does not shutdown the executor, causing the client to time out and crash when waiting for it to exit anyway.~

Fixes:
- Move SessionManager to PlatformManager and make it use platform ready/unready events.
- Fix `SessionManager#unload` canceling timer and no longer auto-saving after quitting a world.
- Remove timer and use a single ScheduledExecutorService with a single virtual thread.
- Make sure executor shuts down on `SessionManager#unload`

Draft reason:
I'm making this as a draft for now as I'm not entirely sure what consequences of making the session manager dependent on Ready/Unready event are.
I smoketested it on all platforms but that doesn't really say much.
Could someone with some knowledge of when SessionManager is supposed to be available chime in?

The only other thing I want some insight on was the effects of ScheduledExecutorService using an unbounded DelayedWorkQueue and the original used a bounded-queue of 5. Unless I'm missing something I don't think this will cause issues?