### PR TITLE
Print filenames of illegal schematic files. Fixes #2966

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/schematic/backends/PollingSchematicsBackend.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/schematic/backends/PollingSchematicsBackend.java
@@ -73,7 +73,10 @@ public class PollingSchematicsBackend implements SchematicsBackend {
                     pathList.add(path);
                 }
             }
-        } catch (IOException | FilenameException e) {
+        } catch (FilenameException e) {
+            LOGGER.warn("Illegal file detected: {} - {}", e.getMessage(), e.getFilename());
+            LOGGER.debug("Illegal file details", e);
+        } catch (IOException e) {
             LOGGER.error(e);
         }
         return pathList;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/schematic/backends/PollingSchematicsBackend.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/schematic/backends/PollingSchematicsBackend.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.internal.schematic.backends;
 
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
+import com.sk89q.worldedit.internal.util.RecursiveDirectoryWatcher;
 import com.sk89q.worldedit.util.io.file.FilenameException;
 import org.apache.logging.log4j.Logger;
 
@@ -74,8 +75,7 @@ public class PollingSchematicsBackend implements SchematicsBackend {
                 }
             }
         } catch (FilenameException e) {
-            LOGGER.warn("Invalid file name detected: {} - {}", e.getMessage(), e.getFilename());
-            LOGGER.debug("Invalid file name details", e);
+            RecursiveDirectoryWatcher.logInvalidFileName(LOGGER, e);
         } catch (IOException e) {
             LOGGER.error(e);
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/schematic/backends/PollingSchematicsBackend.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/schematic/backends/PollingSchematicsBackend.java
@@ -74,8 +74,8 @@ public class PollingSchematicsBackend implements SchematicsBackend {
                 }
             }
         } catch (FilenameException e) {
-            LOGGER.warn("Illegal file detected: {} - {}", e.getMessage(), e.getFilename());
-            LOGGER.debug("Illegal file details", e);
+            LOGGER.warn("Invalid file name detected: {} - {}", e.getMessage(), e.getFilename());
+            LOGGER.debug("Invalid file name details", e);
         } catch (IOException e) {
             LOGGER.error(e);
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/RecursiveDirectoryWatcher.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/RecursiveDirectoryWatcher.java
@@ -108,6 +108,11 @@ public class RecursiveDirectoryWatcher implements Closeable {
         return new RecursiveDirectoryWatcher(root, watchService);
     }
 
+    public static void logInvalidFileName(Logger logger, FilenameException e) {
+        logger.warn("Invalid file name detected: {} - {}", e.getMessage(), e.getFilename());
+        logger.debug("Invalid file name details", e);
+    }
+
     private void registerFolderWatcher(Path root) throws IOException {
         WatchKey watchKey = root.register(watchService, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY);
         LOGGER.debug("Watch registered: " + root);
@@ -127,8 +132,7 @@ public class RecursiveDirectoryWatcher implements Closeable {
                         eventConsumer.accept(new FileCreatedEvent(path));
                     } catch (FilenameException e) {
                         // Invalid filename, warn but don't fail.
-                        LOGGER.warn("Invalid file name detected: {} - {}", e.getMessage(), e.getFilename());
-                        LOGGER.debug("Invalid file name details", e);
+                        logInvalidFileName(LOGGER, e);
                     }
                 }
             }
@@ -192,8 +196,7 @@ public class RecursiveDirectoryWatcher implements Closeable {
                                 path = WorldEdit.getInstance().getSafeOpenFile(null, schematicRoot.toFile(), schematicRoot.relativize(path).toString(), null).toPath();
                             } catch (FilenameException e) {
                                 // Invalid filename, warn but don't fail.
-                                LOGGER.warn("Invalid file name detected: {} - {}", e.getMessage(), e.getFilename());
-                                LOGGER.debug("Invalid file name details", e);
+                                logInvalidFileName(LOGGER, e);
                                 continue;
                             }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/RecursiveDirectoryWatcher.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/RecursiveDirectoryWatcher.java
@@ -127,7 +127,8 @@ public class RecursiveDirectoryWatcher implements Closeable {
                         eventConsumer.accept(new FileCreatedEvent(path));
                     } catch (FilenameException e) {
                         // Invalid filename, warn but don't fail.
-                        LOGGER.warn("Illegal file detected", e);
+                        LOGGER.warn("Illegal file detected: {} - {}", e.getMessage(), e.getFilename());
+                        LOGGER.debug("Illegal file details", e);
                     }
                 }
             }
@@ -191,7 +192,8 @@ public class RecursiveDirectoryWatcher implements Closeable {
                                 path = WorldEdit.getInstance().getSafeOpenFile(null, schematicRoot.toFile(), schematicRoot.relativize(path).toString(), null).toPath();
                             } catch (FilenameException e) {
                                 // Invalid filename, warn but don't fail.
-                                LOGGER.warn("Illegal file detected", e);
+                                LOGGER.warn("Illegal file detected: {} - {}", e.getMessage(), e.getFilename());
+                                LOGGER.debug("Illegal file details", e);
                                 continue;
                             }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/RecursiveDirectoryWatcher.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/util/RecursiveDirectoryWatcher.java
@@ -127,8 +127,8 @@ public class RecursiveDirectoryWatcher implements Closeable {
                         eventConsumer.accept(new FileCreatedEvent(path));
                     } catch (FilenameException e) {
                         // Invalid filename, warn but don't fail.
-                        LOGGER.warn("Illegal file detected: {} - {}", e.getMessage(), e.getFilename());
-                        LOGGER.debug("Illegal file details", e);
+                        LOGGER.warn("Invalid file name detected: {} - {}", e.getMessage(), e.getFilename());
+                        LOGGER.debug("Invalid file name details", e);
                     }
                 }
             }
@@ -192,8 +192,8 @@ public class RecursiveDirectoryWatcher implements Closeable {
                                 path = WorldEdit.getInstance().getSafeOpenFile(null, schematicRoot.toFile(), schematicRoot.relativize(path).toString(), null).toPath();
                             } catch (FilenameException e) {
                                 // Invalid filename, warn but don't fail.
-                                LOGGER.warn("Illegal file detected: {} - {}", e.getMessage(), e.getFilename());
-                                LOGGER.debug("Illegal file details", e);
+                                LOGGER.warn("Invalid file name detected: {} - {}", e.getMessage(), e.getFilename());
+                                LOGGER.debug("Invalid file name details", e);
                                 continue;
                             }
 


### PR DESCRIPTION
This PR prints out the filenames of the illegal schematic files, fixing #2966.

Also additionally hides the stacktrace outside of debug logs, making this seem less like a problem with the plugin to the average user.