### PR TITLE
Remove unnecessary blank issue link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: EngineHub Discord
     url: https://discord.gg/EngineHub
     about: Please ask and answer questions here.
-  - name: '[MAINTAINERS ONLY] Create blank issue'
-    url: https://github.com/EngineHub/WorldEdit/issues/new?template=blank
-    about: For maintainers to create blank issues. Others should use the provided templates.


### PR DESCRIPTION
With `blank_issues_enabled: false` GitHub will still show the option to maintainers now.