### PR TITLE
Remove redundant adapter methods for get/setBiome

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightAdapter.java
@@ -400,40 +400,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return state.toBaseBlock();
     }
 
-    private static final HashMap<BiomeType, Holder<Biome>> biomeTypeToNMSCache = new HashMap<>();
-    private static final HashMap<Holder<Biome>, BiomeType> biomeTypeFromNMSCache = new HashMap<>();
-
-    @Override
-    public BiomeType getBiome(Location location) {
-        checkNotNull(location);
-
-        CraftWorld craftWorld = ((CraftWorld) location.getWorld());
-        int x = location.getBlockX();
-        int y = location.getBlockY();
-        int z = location.getBlockZ();
-
-        final ServerLevel handle = craftWorld.getHandle();
-        LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
-
-        return biomeTypeFromNMSCache.computeIfAbsent(chunk.getNoiseBiome(x >> 2, y >> 2, z >> 2), b -> BiomeType.REGISTRY.get(b.unwrapKey().orElseThrow().identifier().toString()));
-    }
-
-    @Override
-    public void setBiome(Location location, BiomeType biome) {
-        checkNotNull(location);
-        checkNotNull(biome);
-
-        CraftWorld craftWorld = ((CraftWorld) location.getWorld());
-        int x = location.getBlockX();
-        int y = location.getBlockY();
-        int z = location.getBlockZ();
-
-        final ServerLevel handle = craftWorld.getHandle();
-        LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
-        chunk.setBiome(x >> 2, y >> 2, z >> 2, biomeTypeToNMSCache.computeIfAbsent(biome, b -> ((CraftServer) Bukkit.getServer()).getServer().registryAccess().lookupOrThrow(Registries.BIOME).getOrThrow(ResourceKey.create(Registries.BIOME, Identifier.parse(b.id())))));
-        chunk.markUnsaved();
-    }
-
     @Override
     public WorldNativeAccess<?, ?, ?> createWorldNativeAccess(World world) {
         return new PaperweightWorldNativeAccess(this, new WeakReference<>(((CraftWorld) world).getHandle()));

--- a/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
@@ -388,40 +388,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return state.toBaseBlock();
     }
 
-    private static final HashMap<BiomeType, Holder<Biome>> biomeTypeToNMSCache = new HashMap<>();
-    private static final HashMap<Holder<Biome>, BiomeType> biomeTypeFromNMSCache = new HashMap<>();
-
-    @Override
-    public BiomeType getBiome(Location location) {
-        checkNotNull(location);
-
-        CraftWorld craftWorld = ((CraftWorld) location.getWorld());
-        int x = location.getBlockX();
-        int y = location.getBlockY();
-        int z = location.getBlockZ();
-
-        final ServerLevel handle = craftWorld.getHandle();
-        LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
-
-        return biomeTypeFromNMSCache.computeIfAbsent(chunk.getNoiseBiome(x >> 2, y >> 2, z >> 2), b -> BiomeType.REGISTRY.get(b.unwrapKey().orElseThrow().location().toString()));
-    }
-
-    @Override
-    public void setBiome(Location location, BiomeType biome) {
-        checkNotNull(location);
-        checkNotNull(biome);
-
-        CraftWorld craftWorld = ((CraftWorld) location.getWorld());
-        int x = location.getBlockX();
-        int y = location.getBlockY();
-        int z = location.getBlockZ();
-
-        final ServerLevel handle = craftWorld.getHandle();
-        LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
-        chunk.setBiome(x >> 2, y >> 2, z >> 2, biomeTypeToNMSCache.computeIfAbsent(biome, b -> ((CraftServer) Bukkit.getServer()).getServer().registryAccess().lookupOrThrow(Registries.BIOME).getOrThrow(ResourceKey.create(Registries.BIOME, ResourceLocation.parse(b.id())))));
-        chunk.markUnsaved();
-    }
-
     @Override
     public WorldNativeAccess<?, ?, ?> createWorldNativeAccess(World world) {
         return new PaperweightWorldNativeAccess(this, new WeakReference<>(((CraftWorld) world).getHandle()));

--- a/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
@@ -388,40 +388,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return state.toBaseBlock();
     }
 
-    private static final HashMap<BiomeType, Holder<Biome>> biomeTypeToNMSCache = new HashMap<>();
-    private static final HashMap<Holder<Biome>, BiomeType> biomeTypeFromNMSCache = new HashMap<>();
-
-    @Override
-    public BiomeType getBiome(Location location) {
-        checkNotNull(location);
-
-        CraftWorld craftWorld = ((CraftWorld) location.getWorld());
-        int x = location.getBlockX();
-        int y = location.getBlockY();
-        int z = location.getBlockZ();
-
-        final ServerLevel handle = craftWorld.getHandle();
-        LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
-
-        return biomeTypeFromNMSCache.computeIfAbsent(chunk.getNoiseBiome(x >> 2, y >> 2, z >> 2), b -> BiomeType.REGISTRY.get(b.unwrapKey().orElseThrow().location().toString()));
-    }
-
-    @Override
-    public void setBiome(Location location, BiomeType biome) {
-        checkNotNull(location);
-        checkNotNull(biome);
-
-        CraftWorld craftWorld = ((CraftWorld) location.getWorld());
-        int x = location.getBlockX();
-        int y = location.getBlockY();
-        int z = location.getBlockZ();
-
-        final ServerLevel handle = craftWorld.getHandle();
-        LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
-        chunk.setBiome(x >> 2, y >> 2, z >> 2, biomeTypeToNMSCache.computeIfAbsent(biome, b -> ((CraftServer) Bukkit.getServer()).getServer().registryAccess().lookupOrThrow(Registries.BIOME).getOrThrow(ResourceKey.create(Registries.BIOME, ResourceLocation.parse(b.id())))));
-        chunk.markUnsaved();
-    }
-
     @Override
     public WorldNativeAccess<?, ?, ?> createWorldNativeAccess(World world) {
         return new PaperweightWorldNativeAccess(this, new WeakReference<>(((CraftWorld) world).getHandle()));

--- a/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
@@ -401,40 +401,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return state.toBaseBlock();
     }
 
-    private static final HashMap<BiomeType, Holder<Biome>> biomeTypeToNMSCache = new HashMap<>();
-    private static final HashMap<Holder<Biome>, BiomeType> biomeTypeFromNMSCache = new HashMap<>();
-
-    @Override
-    public BiomeType getBiome(Location location) {
-        checkNotNull(location);
-
-        CraftWorld craftWorld = ((CraftWorld) location.getWorld());
-        int x = location.getBlockX();
-        int y = location.getBlockY();
-        int z = location.getBlockZ();
-
-        final ServerLevel handle = craftWorld.getHandle();
-        LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
-
-        return biomeTypeFromNMSCache.computeIfAbsent(chunk.getNoiseBiome(x >> 2, y >> 2, z >> 2), b -> BiomeType.REGISTRY.get(b.unwrapKey().orElseThrow().location().toString()));
-    }
-
-    @Override
-    public void setBiome(Location location, BiomeType biome) {
-        checkNotNull(location);
-        checkNotNull(biome);
-
-        CraftWorld craftWorld = ((CraftWorld) location.getWorld());
-        int x = location.getBlockX();
-        int y = location.getBlockY();
-        int z = location.getBlockZ();
-
-        final ServerLevel handle = craftWorld.getHandle();
-        LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
-        chunk.setBiome(x >> 2, y >> 2, z >> 2, biomeTypeToNMSCache.computeIfAbsent(biome, b -> ((CraftServer) Bukkit.getServer()).getServer().registryAccess().lookupOrThrow(Registries.BIOME).getOrThrow(ResourceKey.create(Registries.BIOME, ResourceLocation.parse(b.id())))));
-        chunk.markUnsaved();
-    }
-
     @Override
     public WorldNativeAccess<?, ?, ?> createWorldNativeAccess(World world) {
         return new PaperweightWorldNativeAccess(this, new WeakReference<>(((CraftWorld) world).getHandle()));

--- a/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightAdapter.java
@@ -400,40 +400,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return state.toBaseBlock();
     }
 
-    private static final HashMap<BiomeType, Holder<Biome>> biomeTypeToNMSCache = new HashMap<>();
-    private static final HashMap<Holder<Biome>, BiomeType> biomeTypeFromNMSCache = new HashMap<>();
-
-    @Override
-    public BiomeType getBiome(Location location) {
-        checkNotNull(location);
-
-        CraftWorld craftWorld = ((CraftWorld) location.getWorld());
-        int x = location.getBlockX();
-        int y = location.getBlockY();
-        int z = location.getBlockZ();
-
-        final ServerLevel handle = craftWorld.getHandle();
-        LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
-
-        return biomeTypeFromNMSCache.computeIfAbsent(chunk.getNoiseBiome(x >> 2, y >> 2, z >> 2), b -> BiomeType.REGISTRY.get(b.unwrapKey().orElseThrow().location().toString()));
-    }
-
-    @Override
-    public void setBiome(Location location, BiomeType biome) {
-        checkNotNull(location);
-        checkNotNull(biome);
-
-        CraftWorld craftWorld = ((CraftWorld) location.getWorld());
-        int x = location.getBlockX();
-        int y = location.getBlockY();
-        int z = location.getBlockZ();
-
-        final ServerLevel handle = craftWorld.getHandle();
-        LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
-        chunk.setBiome(x >> 2, y >> 2, z >> 2, biomeTypeToNMSCache.computeIfAbsent(biome, b -> ((CraftServer) Bukkit.getServer()).getServer().registryAccess().lookupOrThrow(Registries.BIOME).getOrThrow(ResourceKey.create(Registries.BIOME, ResourceLocation.parse(b.id())))));
-        chunk.markUnsaved();
-    }
-
     @Override
     public WorldNativeAccess<?, ?, ?> createWorldNativeAccess(World world) {
         return new PaperweightWorldNativeAccess(this, new WeakReference<>(((CraftWorld) world).getHandle()));

--- a/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
@@ -411,46 +411,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return state.toBaseBlock();
     }
 
-    private static final HashMap<BiomeType, Holder<Biome>> biomeTypeToNMSCache = new HashMap<>();
-    private static final HashMap<Holder<Biome>, BiomeType> biomeTypeFromNMSCache = new HashMap<>();
-
-    @Override
-    public BiomeType getBiome(Location location) {
-        checkNotNull(location);
-
-        CraftWorld craftWorld = ((CraftWorld) location.getWorld());
-        int x = location.getBlockX();
-        int y = location.getBlockY();
-        int z = location.getBlockZ();
-
-        final ServerLevel handle = craftWorld.getHandle();
-        LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
-
-        return biomeTypeFromNMSCache.computeIfAbsent(chunk.getNoiseBiome(x >> 2, y >> 2, z >> 2), b -> BiomeType.REGISTRY.get(b.unwrapKey().orElseThrow().identifier().toString()));
-    }
-
-    @Override
-    public void setBiome(Location location, BiomeType biome) {
-        checkNotNull(location);
-        checkNotNull(biome);
-
-        CraftWorld craftWorld = ((CraftWorld) location.getWorld());
-        int x = location.getBlockX();
-        int y = location.getBlockY();
-        int z = location.getBlockZ();
-
-        final ServerLevel handle = craftWorld.getHandle();
-        LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
-        var biomeArray = (PalettedContainer<Holder<Biome>>) chunk.getSection(chunk.getSectionIndex(y)).getBiomes();
-        biomeArray.getAndSetUnchecked(
-                (x >> 2) & 3, (y >> 2) & 3, (z >> 2) & 3,
-                biomeTypeToNMSCache.computeIfAbsent(biome, b -> craftWorld.getHandle().registryAccess().lookup(Registries.BIOME)
-                        .orElseThrow()
-                        .getOrThrow(ResourceKey.create(Registries.BIOME, Identifier.parse(b.id()))))
-        );
-        chunk.markUnsaved();
-    }
-
     @Override
     public WorldNativeAccess<?, ?, ?> createWorldNativeAccess(World world) {
         return new PaperweightWorldNativeAccess(this, new WeakReference<>(((CraftWorld) world).getHandle()));

--- a/worldedit-bukkit/adapters/adapter-26.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_2/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-26.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_2/PaperweightAdapter.java
@@ -412,46 +412,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return state.toBaseBlock();
     }
 
-    private static final HashMap<BiomeType, Holder<Biome>> biomeTypeToNMSCache = new HashMap<>();
-    private static final HashMap<Holder<Biome>, BiomeType> biomeTypeFromNMSCache = new HashMap<>();
-
-    @Override
-    public BiomeType getBiome(Location location) {
-        checkNotNull(location);
-
-        CraftWorld craftWorld = ((CraftWorld) location.getWorld());
-        int x = location.getBlockX();
-        int y = location.getBlockY();
-        int z = location.getBlockZ();
-
-        final ServerLevel handle = craftWorld.getHandle();
-        LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
-
-        return biomeTypeFromNMSCache.computeIfAbsent(chunk.getNoiseBiome(x >> 2, y >> 2, z >> 2), b -> BiomeType.REGISTRY.get(b.unwrapKey().orElseThrow().identifier().toString()));
-    }
-
-    @Override
-    public void setBiome(Location location, BiomeType biome) {
-        checkNotNull(location);
-        checkNotNull(biome);
-
-        CraftWorld craftWorld = ((CraftWorld) location.getWorld());
-        int x = location.getBlockX();
-        int y = location.getBlockY();
-        int z = location.getBlockZ();
-
-        final ServerLevel handle = craftWorld.getHandle();
-        LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
-        var biomeArray = (PalettedContainer<Holder<Biome>>) chunk.getSection(chunk.getSectionIndex(y)).getBiomes();
-        biomeArray.getAndSetUnchecked(
-                (x >> 2) & 3, (y >> 2) & 3, (z >> 2) & 3,
-                biomeTypeToNMSCache.computeIfAbsent(biome, b -> craftWorld.getHandle().registryAccess().lookup(Registries.BIOME)
-                        .orElseThrow()
-                        .getOrThrow(ResourceKey.create(Registries.BIOME, Identifier.parse(b.id()))))
-        );
-        chunk.markUnsaved();
-    }
-
     @Override
     public WorldNativeAccess<?, ?, ?> createWorldNativeAccess(World world) {
         return new PaperweightWorldNativeAccess(this, new WeakReference<>(((CraftWorld) world).getHandle()));

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
@@ -574,22 +574,12 @@ public class BukkitWorld extends AbstractWorld {
 
     @Override
     public BiomeType getBiome(BlockVector3 position) {
-        BukkitImplAdapter adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
-        if (adapter != null) {
-            return adapter.getBiome(BukkitAdapter.adapt(getWorld(), position));
-        } else {
-            return BukkitAdapter.adapt(getWorld().getBiome(position.x(), position.y(), position.z()));
-        }
+        return BukkitAdapter.adapt(getWorld().getBiome(position.x(), position.y(), position.z()));
     }
 
     @Override
     public boolean setBiome(BlockVector3 position, BiomeType biome) {
-        BukkitImplAdapter adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
-        if (adapter != null) {
-            adapter.setBiome(BukkitAdapter.adapt(getWorld(), position), biome);
-        } else {
-            getWorld().setBiome(position.x(), position.y(), position.z(), BukkitAdapter.adapt(biome));
-        }
+        getWorld().setBiome(position.x(), position.y(), position.z(), BukkitAdapter.adapt(biome));
         return true;
     }
 

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
@@ -270,24 +270,6 @@ public interface BukkitImplAdapter {
     }
 
     /**
-     * Set the biome at a location.
-     * @param location the location
-     * @param biome the new biome
-     */
-    default void setBiome(Location location, BiomeType biome) {
-        throw new UnsupportedOperationException("This adapter does not support custom biomes.");
-    }
-
-    /**
-     * Gets the current biome at a location.
-     * @param location the location
-     * @return the biome
-     */
-    default BiomeType getBiome(Location location) {
-        throw new UnsupportedOperationException("This adapter does not support custom biomes.");
-    }
-
-    /**
      * Generates a Minecraft tree at the given location.
      *
      * @param treeType The tree


### PR DESCRIPTION
Cleanup redundant adapter methods for get/setBiome. These adapter methods were added many years ago, and for now, there is no point to keep use them; we can just use bukkit api instead.