### PR TITLE
Remove deprecated getName method from Item/Block APIs

### DIFF
--- a/verification/src/changes/accepted-core-public-api-changes.json
+++ b/verification/src/changes/accepted-core-public-api-changes.json
@@ -108,6 +108,38 @@
                 "METHOD_REMOVED",
                 "ANNOTATION_REMOVED"
             ]
+        },
+        {
+            "type": "com.sk89q.worldedit.world.block.BlockType",
+            "member": "Method com.sk89q.worldedit.world.block.BlockType.getName()",
+            "changes": [
+                "METHOD_REMOVED",
+                "ANNOTATION_REMOVED"
+            ]
+        },
+        {
+            "type": "com.sk89q.worldedit.world.item.ItemType",
+            "member": "Method com.sk89q.worldedit.world.item.ItemType.getName()",
+            "changes": [
+                "METHOD_REMOVED",
+                "ANNOTATION_REMOVED"
+            ]
+        },
+        {
+            "type": "com.sk89q.worldedit.world.registry.BlockRegistry",
+            "member": "Method com.sk89q.worldedit.world.registry.BlockRegistry.getName(com.sk89q.worldedit.world.block.BlockType)",
+            "changes": [
+                "METHOD_REMOVED",
+                "ANNOTATION_REMOVED"
+            ]
+        },
+        {
+            "type": "com.sk89q.worldedit.world.registry.ItemRegistry",
+            "member": "Method com.sk89q.worldedit.world.registry.ItemRegistry.getName(com.sk89q.worldedit.world.item.ItemType)",
+            "changes": [
+                "METHOD_REMOVED",
+                "ANNOTATION_REMOVED"
+            ]
         }
     ]
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockType.java
@@ -74,10 +74,6 @@ public class BlockType implements Keyed {
         = LazyReference.from(() -> WorldEdit.getInstance().getPlatformManager()
         .queryCapability(Capability.GAME_HOOKS).getRegistries().getBlockRegistry().getMaterial(this));
     @SuppressWarnings("this-escape")
-    @Deprecated
-    private final LazyReference<String> name = LazyReference.from(() -> WorldEdit.getInstance().getPlatformManager()
-        .queryCapability(Capability.GAME_HOOKS).getRegistries().getBlockRegistry().getName(this));
-    @SuppressWarnings("this-escape")
     private final LazyReference<Integer> legacyId = LazyReference.from(() -> computeLegacy(0));
     @SuppressWarnings("this-escape")
     private final LazyReference<Integer> legacyData = LazyReference.from(() -> computeLegacy(1));
@@ -121,21 +117,6 @@ public class BlockType implements Keyed {
     public Component getRichName() {
         return WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.GAME_HOOKS)
             .getRegistries().getBlockRegistry().getRichName(this);
-    }
-
-    /**
-     * Gets the name of this block, or the ID if the name cannot be found.
-     *
-     * @return The name, or ID
-     * @deprecated The name is now translatable, use {@link #getRichName()}.
-     */
-    @Deprecated
-    public String getName() {
-        String name = this.name.getValue();
-        if (name == null || name.isEmpty()) {
-            return id();
-        }
-        return name;
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/item/ItemType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/item/ItemType.java
@@ -23,7 +23,6 @@ import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.platform.Capability;
 import com.sk89q.worldedit.registry.Keyed;
 import com.sk89q.worldedit.registry.NamespacedRegistry;
-import com.sk89q.worldedit.util.GuavaUtil;
 import com.sk89q.worldedit.util.concurrency.LazyReference;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.block.BlockType;
@@ -37,15 +36,6 @@ public class ItemType implements Keyed {
     public static final NamespacedRegistry<ItemType> REGISTRY = new NamespacedRegistry<>("item type", "item_type", "minecraft", true);
 
     private final String id;
-    @SuppressWarnings({"deprecation", "this-escape"})
-    private final LazyReference<String> name = LazyReference.from(() -> {
-        String name = GuavaUtil.firstNonNull(
-            WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.GAME_HOOKS)
-                .getRegistries().getItemRegistry().getName(this),
-            ""
-        );
-        return name.isEmpty() ? id() : name;
-    });
     @SuppressWarnings("this-escape")
     private final LazyReference<Component> richName = LazyReference.from(() ->
         WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.GAME_HOOKS)
@@ -73,18 +63,6 @@ public class ItemType implements Keyed {
     public Component getRichName() {
         return richName.getValue();
     }
-
-    /**
-     * Gets the name of this item, or the ID if the name cannot be found.
-     *
-     * @return The name, or ID
-     * @deprecated Names are translatable now, use {@link #getRichName()}.
-     */
-    @Deprecated
-    public String getName() {
-        return name.getValue();
-    }
-
 
     /**
      * Gets whether this item type has a block representation.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockRegistry.java
@@ -42,19 +42,6 @@ public interface BlockRegistry {
     Component getRichName(BlockType blockType);
 
     /**
-     * Gets the name for the given block.
-     *
-     * @param blockType the block
-     * @return The name, or null if it's unknown
-     * @deprecated Names are now translatable, use {@link #getRichName(BlockType)}.
-     */
-    @Deprecated
-    @Nullable
-    default String getName(BlockType blockType) {
-        return getRichName(blockType).toString();
-    }
-
-    /**
      * Get the material for the given block.
      *
      * @param blockType the block

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledBlockRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledBlockRegistry.java
@@ -59,16 +59,6 @@ public class BundledBlockRegistry implements BlockRegistry {
 
     @Nullable
     @Override
-    @Deprecated
-    // dumb_intellij.jpg
-    @SuppressWarnings("deprecation")
-    public String getName(BlockType blockType) {
-        BundledBlockData.BlockEntry blockEntry = BundledBlockData.getInstance().findById(blockType.id());
-        return blockEntry != null ? blockEntry.localizedName : null;
-    }
-
-    @Nullable
-    @Override
     public BlockMaterial getMaterial(BlockType blockType) {
         return new PassthroughBlockMaterial(BundledBlockData.getInstance().getMaterialById(blockType.id()));
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledItemRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledItemRegistry.java
@@ -59,25 +59,6 @@ public class BundledItemRegistry implements ItemRegistry {
 
     @Nullable
     @Override
-    @Deprecated
-    // dumb_intellij.jpg
-    @SuppressWarnings({"deprecation", "removal"})
-    public String getName(ItemType itemType) {
-        BundledItemData.ItemEntry itemEntry = getEntryById(itemType);
-        if (itemEntry != null) {
-            String localized = itemEntry.localizedName;
-            if (localized.equals("Air")) {
-                String id = itemType.id();
-                int c = id.indexOf(':');
-                return c < 0 ? id : id.substring(c + 1);
-            }
-            return localized;
-        }
-        return null;
-    }
-
-    @Nullable
-    @Override
     @Deprecated(forRemoval = true)
     @SuppressWarnings("removal")
     public ItemMaterial getMaterial(ItemType itemType) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/ItemRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/ItemRegistry.java
@@ -46,19 +46,6 @@ public interface ItemRegistry {
     }
 
     /**
-     * Gets the name for the given item.
-     *
-     * @param itemType the item
-     * @return The name, or null if it's unknown
-     * @deprecated Names are now translatable, use {@link #getRichName(ItemType)}.
-     */
-    @Deprecated
-    @Nullable
-    default String getName(ItemType itemType) {
-        return getRichName(itemType).toString();
-    }
-
-    /**
      * Get the material for the given item.
      *
      * @param itemType the item


### PR DESCRIPTION
Stacked on https://github.com/EngineHub/WorldEdit/pull/2986

Removes the getName method from the Item & Block APIs.