### PR TITLE
Add further Folia checks to catch servers obfuscating that they are Folia

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -525,8 +525,28 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
             if (PaperLib.isPaper()) {
                 // Then we can check against the `papermc:folia` key, as per the `isBrandCompatible` javadoc.
                 // This API is experimental so might randomly break on us (hence the try/catch)
-                // TODO if we drop Spigot support in the future, remove this check and purely use Folia-compatible APIs.
-                return ServerBuildInfo.buildInfo().isBrandCompatible(Key.key("papermc", "folia"));
+                if (ServerBuildInfo.buildInfo().isBrandCompatible(Key.key("papermc", "folia"))) {
+                    return true;
+                }
+
+                boolean hiddenFoliaCheck = false;
+
+                try {
+                    Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+                    hiddenFoliaCheck = true;
+                } catch (ClassNotFoundException ignored) {
+                }
+
+                try {
+                    Bukkit.class.getMethod("getRegionScheduler");
+                    hiddenFoliaCheck = true;
+                } catch (NoSuchMethodException ignored) {
+                }
+
+                if (hiddenFoliaCheck) {
+                    LOGGER.warn("Server platform not marked as Folia-based, but appears to have Folia-specific code. Assuming this server is running Folia.");
+                    return true;
+                }
             }
         } catch (Throwable t) {
             // Ignore, this likely means an outdated version.

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -551,7 +551,7 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
         }
 
         if (hiddenFoliaCheckPassed) {
-            LOGGER.warn("Server platform not marked as Folia-based, but appears to have Folia-specific code. Assuming this server is running Folia.");
+            LOGGER.warn("Server platform not marked as Folia-based, but appears to have Folia-specific code. Assuming this server is running Folia. This check is fragile, please tell the author of your server software to report that it is compatible with the `papermc:folia` brand.");
             return true;
         }
 

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -558,7 +558,12 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
         return false;
     });
 
-    protected boolean isFolia() {
+    /**
+     * Returns if this plugin is enabling Folia-specific code.
+     *
+     * @return whether to enable Folia-specific code
+     */
+    public boolean isFolia() {
         return folia.getValue();
     }
 

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -528,29 +528,31 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
                 if (ServerBuildInfo.buildInfo().isBrandCompatible(Key.key("papermc", "folia"))) {
                     return true;
                 }
-
-                boolean hiddenFoliaCheck = false;
-
-                try {
-                    Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
-                    hiddenFoliaCheck = true;
-                } catch (ClassNotFoundException ignored) {
-                }
-
-                try {
-                    Bukkit.class.getMethod("getRegionScheduler");
-                    hiddenFoliaCheck = true;
-                } catch (NoSuchMethodException ignored) {
-                }
-
-                if (hiddenFoliaCheck) {
-                    LOGGER.warn("Server platform not marked as Folia-based, but appears to have Folia-specific code. Assuming this server is running Folia.");
-                    return true;
-                }
             }
         } catch (Throwable t) {
             // Ignore, this likely means an outdated version.
             LOGGER.warn("Failed to check if server is running Folia", t);
+        }
+
+        boolean hiddenFoliaCheckPassed = false;
+
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            hiddenFoliaCheckPassed = true;
+        } catch (ClassNotFoundException ignored) {
+            // This is a class existence check, it's fine if not present.
+        }
+
+        try {
+            Bukkit.class.getMethod("getRegionScheduler");
+            hiddenFoliaCheckPassed = true;
+        } catch (NoSuchMethodException ignored) {
+            // This is a method existence check, it's fine if not present.
+        }
+
+        if (hiddenFoliaCheckPassed) {
+            LOGGER.warn("Server platform not marked as Folia-based, but appears to have Folia-specific code. Assuming this server is running Folia.");
+            return true;
         }
 
         return false;


### PR DESCRIPTION
If we detect Folia-specific code, print a warning that the server is not marking itself as Folia despite containing this code, and assume that it _is_ Folia.