### PR TITLE
Remove strict versions from MC libs

### DIFF
--- a/build-logic/src/main/kotlin/buildlogic.validate-minecraft-library-versions-fabric.gradle.kts
+++ b/build-logic/src/main/kotlin/buildlogic.validate-minecraft-library-versions-fabric.gradle.kts
@@ -1,0 +1,35 @@
+import buildlogic.VerifyMinecraftLibraries
+import buildlogic.getLibrary
+import buildlogic.stringyLibs
+
+val mojangProvidedLibs = listOf("guava", "gson", "fastutil", "log4j-api", "log4j-core")
+    .map { stringyLibs.getLibrary(it) }
+
+val mojangProvided = configurations.dependencyScope("mojangProvided")
+val mojangProvidedClasspath = configurations.resolvable("mojangProvidedClasspath") {
+    extendsFrom(mojangProvided.get())
+}
+
+dependencies {
+    add(mojangProvided.name, platform(stringyLibs.getLibrary("log4j-bom")))
+    for (lib in mojangProvidedLibs) {
+        add(mojangProvided.name, lib)
+    }
+}
+
+val verifyMinecraftLibraries = tasks.register<VerifyMinecraftLibraries>("verifyMinecraftLibraries") {
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    description = "Checks the Mojang-provided library versions we resolve against the ones Minecraft ships"
+
+    declaredLibraries.set(
+        mojangProvidedClasspath.flatMap { it.incoming.resolutionResult.rootComponent }
+    )
+    minecraftLibraries.set(
+        configurations.named("minecraftLibraries").flatMap { it.incoming.resolutionResult.rootComponent }
+    )
+    expectVersions(mojangProvidedLibs)
+}
+
+tasks.named("check") {
+    dependsOn(verifyMinecraftLibraries)
+}

--- a/build-logic/src/main/kotlin/buildlogic/VerifyMinecraftLibraries.kt
+++ b/build-logic/src/main/kotlin/buildlogic/VerifyMinecraftLibraries.kt
@@ -1,0 +1,71 @@
+package buildlogic
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.artifacts.MinimalExternalModuleDependency
+import org.gradle.api.artifacts.result.ResolvedComponentResult
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+
+abstract class VerifyMinecraftLibraries : DefaultTask() {
+    @get:Input
+    abstract val modules: SetProperty<String>
+
+    @get:Input
+    abstract val declaredLibraries: Property<ResolvedComponentResult>
+
+    @get:Input
+    abstract val minecraftLibraries: Property<ResolvedComponentResult>
+
+    fun expectVersions(dependencies: List<Provider<MinimalExternalModuleDependency>>) {
+        for (dependency in dependencies) {
+            modules.add(dependency.map { "${it.module.group}:${it.module.name}" })
+        }
+    }
+
+    @TaskAction
+    fun verify() {
+        val declared = collectVersions(declaredLibraries.get())
+        val minecraft = collectVersions(minecraftLibraries.get())
+
+        val problems = modules.get().sorted().mapNotNull { module ->
+            val ours = declared[module]
+                ?: return@mapNotNull "$module: not resolved, so it cannot be checked against Minecraft"
+            when (val theirs = minecraft[module]) {
+                ours -> null
+                null -> "$module: resolved $ours, but Minecraft does not provide this library"
+                else -> "$module: resolved $ours, but Minecraft provides $theirs"
+            }
+        }
+
+        if (problems.isNotEmpty()) {
+            throw GradleException(
+                problems.joinToString(
+                    separator = "\n",
+                    prefix = "Mojang-provided library versions do not match Minecraft:\n",
+                    postfix = "\n\nUpdate gradle/libs.versions.toml to match.",
+                ) { "  - $it" }
+            )
+        }
+    }
+
+    private fun collectVersions(root: ResolvedComponentResult): Map<String, String> {
+        val versions = mutableMapOf<String, String>()
+        val seen = mutableSetOf<ResolvedComponentResult>()
+        val queue = ArrayDeque(listOf(root))
+        while (queue.isNotEmpty()) {
+            val component = queue.removeFirst()
+            if (!seen.add(component)) {
+                continue
+            }
+            component.moduleVersion?.let { versions["${it.group}:${it.name}"] = it.version }
+            component.dependencies.filterIsInstance<ResolvedDependencyResult>()
+                .mapTo(queue) { it.selected }
+        }
+        return versions
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -108,12 +108,12 @@ fabric-permissions-api = "me.lucko:fabric-permissions-api:0.7.0"
 neoforge = "net.neoforged:neoforge:26.2.0.7-beta"
 
 # Mojang-provided libraries, CHECK AGAINST MINECRAFT for versions
-guava = "com.google.guava:guava:33.6.0-jre!!"
-log4j-bom = "org.apache.logging.log4j:log4j-bom:2.25.2!!"
+guava = "com.google.guava:guava:33.6.0-jre"
+log4j-bom = "org.apache.logging.log4j:log4j-bom:2.25.2"
 log4j-api.module = "org.apache.logging.log4j:log4j-api"
 log4j-core.module = "org.apache.logging.log4j:log4j-core"
-gson = "com.google.code.gson:gson:2.14.0!!"
-fastutil = "it.unimi.dsi:fastutil:8.5.18!!"
+gson = "com.google.code.gson:gson:2.14.0"
+fastutil = "it.unimi.dsi:fastutil:8.5.18"
 
 # Bukkit-provided libraries, CHECK AGAINST SPIGOT for versions
 # Note that we need to balance support for older MC versus working at all on newer ones, so the exact versions here

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -107,9 +107,9 @@ fabric-permissions-api = "me.lucko:fabric-permissions-api:0.7.0"
 
 neoforge = "net.neoforged:neoforge:26.2.0.7-beta"
 
-# Mojang-provided libraries, CHECK AGAINST MINECRAFT for versions
+# Mojang-provided libraries, validated by `:worldedit-fabric:verifyMinecraftLibraries`
 guava = "com.google.guava:guava:33.6.0-jre"
-log4j-bom = "org.apache.logging.log4j:log4j-bom:2.25.2"
+log4j-bom = "org.apache.logging.log4j:log4j-bom:2.26.0"
 log4j-api.module = "org.apache.logging.log4j:log4j-api"
 log4j-core.module = "org.apache.logging.log4j:log4j-core"
 gson = "com.google.code.gson:gson:2.14.0"

--- a/worldedit-fabric/build.gradle.kts
+++ b/worldedit-fabric/build.gradle.kts
@@ -9,6 +9,7 @@ import java.net.URI
 plugins {
     alias(libs.plugins.fabric.loom)
     id("buildlogic.platform")
+    id("buildlogic.validate-minecraft-library-versions-fabric")
 }
 
 platform {


### PR DESCRIPTION
This causes issues in some cases with WG users getting conflicts, plus the original issue this solved (Guava versions mixing) is much less likely to ever be an issue now, since Guava doesn't remove APIs anymore.