### PR TITLE
Add a command version of the apply brush to operate on selections

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ApplyBrushCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ApplyBrushCommands.java
@@ -38,7 +38,6 @@ import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.internal.annotation.Direction;
 import com.sk89q.worldedit.internal.command.CommandRegistrationHandler;
 import com.sk89q.worldedit.regions.factory.RegionFactory;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.formatting.text.format.TextColor;
 import com.sk89q.worldedit.util.formatting.text.format.TextDecoration;
@@ -124,8 +123,12 @@ public class ApplyBrushCommands {
                      @Arg(desc = "The direction in which the item will be applied", def = "up")
                      @Direction(includeDiagonals = true)
                          com.sk89q.worldedit.util.Direction direction) throws WorldEditException {
-        player.print(TextComponent.builder().append("WARNING: ", TextColor.RED, TextDecoration.BOLD)
-                .append(TranslatableComponent.of("worldedit.brush.apply.item.warning")).build());
+        player.print(TranslatableComponent.of(
+            "worldedit.warning",
+            TranslatableComponent.of("worldedit.brush.apply.item.warning")
+                .color(TextColor.WHITE)
+                .decoration(TextDecoration.BOLD, false)
+        ).color(TextColor.RED).decoration(TextDecoration.BOLD, true));
         setApplyBrush(parameters, player, localSession, new ItemUseFactory(item, direction));
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ApplyCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ApplyCommands.java
@@ -1,0 +1,138 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.command;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.sk89q.worldedit.EditSession;
+import com.sk89q.worldedit.LocalSession;
+import com.sk89q.worldedit.WorldEditException;
+import com.sk89q.worldedit.blocks.BaseItem;
+import com.sk89q.worldedit.command.factory.ItemUseFactory;
+import com.sk89q.worldedit.command.util.CommandPermissions;
+import com.sk89q.worldedit.command.util.CommandPermissionsConditionGenerator;
+import com.sk89q.worldedit.command.util.Logging;
+import com.sk89q.worldedit.command.util.PermissionCondition;
+import com.sk89q.worldedit.extension.platform.Actor;
+import com.sk89q.worldedit.function.Contextual;
+import com.sk89q.worldedit.function.EditContext;
+import com.sk89q.worldedit.function.RegionFunction;
+import com.sk89q.worldedit.function.RegionMaskingFilter;
+import com.sk89q.worldedit.function.mask.Mask;
+import com.sk89q.worldedit.function.operation.Operations;
+import com.sk89q.worldedit.function.visitor.RegionVisitor;
+import com.sk89q.worldedit.internal.annotation.Direction;
+import com.sk89q.worldedit.internal.annotation.Selection;
+import com.sk89q.worldedit.internal.command.CommandRegistrationHandler;
+import com.sk89q.worldedit.regions.Region;
+import com.sk89q.worldedit.util.formatting.text.TextComponent;
+import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import com.sk89q.worldedit.util.formatting.text.format.TextDecoration;
+import org.enginehub.piston.CommandManager;
+import org.enginehub.piston.CommandManagerService;
+import org.enginehub.piston.CommandParameters;
+import org.enginehub.piston.annotation.Command;
+import org.enginehub.piston.annotation.CommandContainer;
+import org.enginehub.piston.annotation.param.Arg;
+import org.enginehub.piston.inject.Key;
+import org.enginehub.piston.part.ArgAcceptingCommandFlag;
+import org.enginehub.piston.part.SubCommandPart;
+
+import static com.sk89q.worldedit.command.util.Logging.LogMode.REGION;
+import static org.enginehub.piston.part.CommandParts.flag;
+
+@CommandContainer(superTypes = CommandPermissionsConditionGenerator.Registration.class)
+public class ApplyCommands {
+
+    private static final ArgAcceptingCommandFlag APPLY_MASK = flag(
+            'm', TranslatableComponent.of("worldedit.apply.mask"))
+        .withRequiredArg()
+        .argNamed(TranslatableComponent.of("mask"))
+        .defaultsTo(ImmutableList.of())
+        .ofTypes(ImmutableList.of(Key.of(Mask.class)))
+        .build();
+
+    public static void register(CommandManagerService service, CommandManager commandManager,
+                                CommandRegistrationHandler registration) {
+        commandManager.register("/apply", builder -> {
+            builder.description(TranslatableComponent.of("worldedit.apply.description"));
+            builder.action(org.enginehub.piston.Command.Action.NULL_ACTION);
+
+            CommandManager manager = service.newCommandManager();
+            registration.register(
+                manager,
+                ApplyCommandsRegistration.builder(),
+                new ApplyCommands()
+            );
+
+            builder.condition(new PermissionCondition(ImmutableSet.of("worldedit.region.apply")));
+            builder.addPart(APPLY_MASK);
+            builder.addPart(SubCommandPart.builder(
+                    TranslatableComponent.of("type"),
+                    TranslatableComponent.of("worldedit.apply.type"))
+                .withCommands(manager.getAllCommands().toList())
+                .required()
+                .build());
+        });
+    }
+
+    private int apply(CommandParameters parameters, Actor actor, EditSession editSession,
+                      LocalSession localSession, Region region,
+                      Contextual<? extends RegionFunction> functionFactory) throws WorldEditException {
+        EditContext context = new EditContext();
+        context.setDestination(editSession);
+        context.setRegion(region);
+        context.setSession(localSession);
+
+        RegionFunction function = functionFactory.createFromContext(context);
+        Mask applyMask = APPLY_MASK.value(parameters).asSingle(Mask.class);
+        if (applyMask != null) {
+            function = new RegionMaskingFilter(applyMask, function);
+        }
+
+        RegionVisitor visitor = new RegionVisitor(region, function);
+        Operations.completeLegacy(visitor);
+        actor.printInfo(TranslatableComponent.of("worldedit.apply.done", TextComponent.of(visitor.getAffected())));
+        return visitor.getAffected();
+    }
+
+    @Command(
+        name = "item",
+        desc = "Use an item"
+    )
+    @CommandPermissions("worldedit.brush.item")
+    @Logging(REGION)
+    public int item(CommandParameters parameters, Actor actor, EditSession editSession, LocalSession localSession,
+                    @Selection Region region,
+                    @Arg(desc = "The type of item to use")
+                        BaseItem item,
+                    @Arg(desc = "The direction in which the item will be applied", def = "up")
+                    @Direction(includeDiagonals = true)
+                        com.sk89q.worldedit.util.Direction direction) throws WorldEditException {
+        actor.print(TranslatableComponent.of(
+            "worldedit.warning",
+            TranslatableComponent.of("worldedit.apply.item.warning")
+                .color(TextColor.WHITE)
+                .decoration(TextDecoration.BOLD, false)
+        ).color(TextColor.RED).decoration(TextDecoration.BOLD, true));
+        return apply(parameters, actor, editSession, localSession, region, new ItemUseFactory(item, direction));
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/PaintBrushCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/PaintBrushCommands.java
@@ -38,7 +38,6 @@ import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.internal.annotation.Direction;
 import com.sk89q.worldedit.internal.command.CommandRegistrationHandler;
 import com.sk89q.worldedit.regions.factory.RegionFactory;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.formatting.text.format.TextColor;
 import com.sk89q.worldedit.util.formatting.text.format.TextDecoration;
@@ -130,8 +129,12 @@ public class PaintBrushCommands {
                      @Arg(desc = "The direction in which the item will be applied", def = "up")
                      @Direction(includeDiagonals = true)
                          com.sk89q.worldedit.util.Direction direction) throws WorldEditException {
-        player.print(TextComponent.builder().append("WARNING: ", TextColor.RED, TextDecoration.BOLD)
-                .append(TranslatableComponent.of("worldedit.brush.paint.item.warning")).build());
+        player.print(TranslatableComponent.of(
+            "worldedit.warning",
+            TranslatableComponent.of("worldedit.brush.paint.item.warning")
+                .color(TextColor.WHITE)
+                .decoration(TextDecoration.BOLD, false)
+        ).color(TextColor.RED).decoration(TextDecoration.BOLD, true));
         setPaintBrush(parameters, player, localSession, new ItemUseFactory(item, direction));
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
@@ -29,6 +29,7 @@ import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.MissingWorldException;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.command.ApplyBrushCommands;
+import com.sk89q.worldedit.command.ApplyCommands;
 import com.sk89q.worldedit.command.BiomeCommands;
 import com.sk89q.worldedit.command.BiomeCommandsRegistration;
 import com.sk89q.worldedit.command.BrushCommands;
@@ -359,6 +360,7 @@ public final class PlatformCommandManager {
             WorldEditCommandsRegistration.builder(),
             new WorldEditCommands(worldEdit)
         );
+        ApplyCommands.register(commandManagerService, commandManager, registration);
         this.registration.register(
             commandManager,
             BiomeCommandsRegistration.builder(),

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -1,4 +1,6 @@
 {
+    "worldedit.warning": "WARNING: {0}",
+
     "worldedit.expand.description.vert": "Vertically expand the selection to world limits.",
     "worldedit.expand.expanded": "Region expanded {0} blocks",
     "worldedit.expand.expanded.vert": "Region expanded {0} blocks (top-to-bottom).",
@@ -14,6 +16,11 @@
     "worldedit.brush.apply.shape": "The shape of the region",
     "worldedit.brush.apply.type": "Type of brush to use",
     "worldedit.brush.apply.item.warning": "This brush simulates item usages. Its effects may not work on all platforms, may not be undo-able, and may cause strange interactions with other mods/plugins. Use at your own risk.",
+    "worldedit.apply.description": "Apply a function to every block in the selection",
+    "worldedit.apply.type": "Type of function to apply",
+    "worldedit.apply.mask": "The mask to filter which blocks the function applies to",
+    "worldedit.apply.item.warning": "This command simulates item usages. Its effects may not work on all platforms, may not be undo-able, and may cause strange interactions with other mods/plugins. Use at your own risk.",
+    "worldedit.apply.done": "Applied the function to {0} blocks.",
     "worldedit.brush.paint.description": "Paint brush, apply a function to a surface",
     "worldedit.brush.paint.size": "The size of the brush",
     "worldedit.brush.paint.shape": "The shape of the region",


### PR DESCRIPTION
This PR adds an apply command, which is like the brush but applied via a RegionVisitor. I've removed all but `item` in this version, as neither set nor forest really make sense given the other region commands we already have.

I've also taken the opportunity to generify our "warning" prefix system we use for a few messages, making it more translatable and using an argument to allow better RTL language support (as the argument defines where the actual warning displays)

Adds https://github.com/EngineHub/WorldEdit/issues/1747