### PR TITLE
Add a clipboard apply function to apply command & brush

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ApplyBrushCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ApplyBrushCommands.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableSet;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.blocks.BaseItem;
+import com.sk89q.worldedit.command.factory.ClipboardPasteFactory;
 import com.sk89q.worldedit.command.factory.ItemUseFactory;
 import com.sk89q.worldedit.command.factory.ReplaceFactory;
 import com.sk89q.worldedit.command.factory.TreeGeneratorFactory;
@@ -34,10 +35,13 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.function.Contextual;
 import com.sk89q.worldedit.function.RegionFunction;
 import com.sk89q.worldedit.function.factory.ApplyRegion;
+import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.pattern.Pattern;
+import com.sk89q.worldedit.internal.annotation.ClipboardMask;
 import com.sk89q.worldedit.internal.annotation.Direction;
 import com.sk89q.worldedit.internal.command.CommandRegistrationHandler;
 import com.sk89q.worldedit.regions.factory.RegionFactory;
+import com.sk89q.worldedit.session.ClipboardHolder;
 import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.util.formatting.text.format.TextColor;
 import com.sk89q.worldedit.util.formatting.text.format.TextDecoration;
@@ -48,6 +52,8 @@ import org.enginehub.piston.CommandParameters;
 import org.enginehub.piston.annotation.Command;
 import org.enginehub.piston.annotation.CommandContainer;
 import org.enginehub.piston.annotation.param.Arg;
+import org.enginehub.piston.annotation.param.ArgFlag;
+import org.enginehub.piston.annotation.param.Switch;
 import org.enginehub.piston.inject.Key;
 import org.enginehub.piston.part.CommandArgument;
 import org.enginehub.piston.part.SubCommandPart;
@@ -98,6 +104,38 @@ public class ApplyBrushCommands {
         RegionFactory regionFactory = REGION_FACTORY.value(parameters).asSingle(RegionFactory.class);
         BrushCommands.setOperationBasedBrush(player, localSession, radius,
             new ApplyRegion(generatorFactory), regionFactory, "worldedit.brush.apply");
+    }
+
+    @Command(
+        name = "clipboard",
+        desc = "Paste the clipboard at every block"
+    )
+    @CommandPermissions("worldedit.brush.clipboard")
+    public void clipboard(CommandParameters parameters, Player player, LocalSession localSession,
+                          @Switch(name = 'a', desc = "Don't paste air from the clipboard")
+                              boolean ignoreAir,
+                          @Switch(name = 'v', desc = "Include structure void blocks")
+                              boolean pasteStructureVoid,
+                          @Switch(name = 'o', desc = "Paste starting at each block, instead of centering on it")
+                              boolean usingOrigin,
+                          @Switch(name = 'e', desc = "Paste entities if available")
+                              boolean pasteEntities,
+                          @Switch(name = 'b', desc = "Paste biomes if available")
+                              boolean pasteBiomes,
+                          @ArgFlag(name = 'm', desc = "Only paste clipboard blocks matching this mask")
+                          @ClipboardMask
+                              Mask sourceMask) throws WorldEditException {
+        ClipboardHolder holder = localSession.getClipboard();
+
+        setApplyBrush(parameters, player, localSession, new ClipboardPasteFactory(
+            holder,
+            ignoreAir,
+            !pasteStructureVoid,
+            usingOrigin,
+            pasteEntities,
+            pasteBiomes,
+            sourceMask
+        ));
     }
 
     @Command(

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ApplyCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ApplyCommands.java
@@ -25,6 +25,7 @@ import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.blocks.BaseItem;
+import com.sk89q.worldedit.command.factory.ClipboardPasteFactory;
 import com.sk89q.worldedit.command.factory.ItemUseFactory;
 import com.sk89q.worldedit.command.util.CommandPermissions;
 import com.sk89q.worldedit.command.util.CommandPermissionsConditionGenerator;
@@ -38,6 +39,7 @@ import com.sk89q.worldedit.function.RegionMaskingFilter;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.function.operation.Operations;
 import com.sk89q.worldedit.function.visitor.RegionVisitor;
+import com.sk89q.worldedit.internal.annotation.ClipboardMask;
 import com.sk89q.worldedit.internal.annotation.Direction;
 import com.sk89q.worldedit.internal.annotation.Selection;
 import com.sk89q.worldedit.internal.command.CommandRegistrationHandler;
@@ -52,6 +54,8 @@ import org.enginehub.piston.CommandParameters;
 import org.enginehub.piston.annotation.Command;
 import org.enginehub.piston.annotation.CommandContainer;
 import org.enginehub.piston.annotation.param.Arg;
+import org.enginehub.piston.annotation.param.ArgFlag;
+import org.enginehub.piston.annotation.param.Switch;
 import org.enginehub.piston.inject.Key;
 import org.enginehub.piston.part.ArgAcceptingCommandFlag;
 import org.enginehub.piston.part.SubCommandPart;
@@ -112,6 +116,38 @@ public class ApplyCommands {
         Operations.completeLegacy(visitor);
         actor.printInfo(TranslatableComponent.of("worldedit.apply.done", TextComponent.of(visitor.getAffected())));
         return visitor.getAffected();
+    }
+
+    @Command(
+        name = "clipboard",
+        desc = "Paste the clipboard at every block"
+    )
+    @CommandPermissions("worldedit.clipboard.paste")
+    @Logging(REGION)
+    public int clipboard(CommandParameters parameters, Actor actor, EditSession editSession,
+                         LocalSession localSession, @Selection Region region,
+                         @Switch(name = 'a', desc = "Don't paste air from the clipboard")
+                             boolean ignoreAir,
+                         @Switch(name = 'v', desc = "Include structure void blocks")
+                             boolean pasteStructureVoid,
+                         @Switch(name = 'o', desc = "Paste starting at each block, instead of centering on it")
+                             boolean usingOrigin,
+                         @Switch(name = 'e', desc = "Paste entities if available")
+                             boolean pasteEntities,
+                         @Switch(name = 'b', desc = "Paste biomes if available")
+                             boolean pasteBiomes,
+                         @ArgFlag(name = 'm', desc = "Only paste clipboard blocks matching this mask")
+                         @ClipboardMask
+                             Mask sourceMask) throws WorldEditException {
+        return apply(parameters, actor, editSession, localSession, region, new ClipboardPasteFactory(
+            localSession.getClipboard(),
+            ignoreAir,
+            !pasteStructureVoid,
+            usingOrigin,
+            pasteEntities,
+            pasteBiomes,
+            sourceMask
+        ));
     }
 
     @Command(

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/factory/ClipboardPasteFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/factory/ClipboardPasteFactory.java
@@ -17,18 +17,16 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.sk89q.worldedit.command.tool.brush;
+package com.sk89q.worldedit.command.factory;
 
-import com.google.errorprone.annotations.InlineMe;
-import com.sk89q.worldedit.EditSession;
-import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.function.ClipboardPaste;
+import com.sk89q.worldedit.function.Contextual;
+import com.sk89q.worldedit.function.EditContext;
+import com.sk89q.worldedit.function.RegionFunction;
 import com.sk89q.worldedit.function.mask.Mask;
-import com.sk89q.worldedit.function.pattern.Pattern;
-import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.session.ClipboardHolder;
 
-public class ClipboardBrush implements Brush {
+public final class ClipboardPasteFactory implements Contextual<RegionFunction> {
 
     private final ClipboardHolder holder;
     private final boolean ignoreAirBlocks;
@@ -38,20 +36,11 @@ public class ClipboardBrush implements Brush {
     private final boolean pasteBiomes;
     private final Mask sourceMask;
 
-    public ClipboardBrush(ClipboardHolder holder, boolean ignoreAirBlocks, boolean usingOrigin) {
-        this(holder, ignoreAirBlocks, false, usingOrigin, false, false, null);
-    }
-
-    @InlineMe(replacement = "this(holder, ignoreAirBlocks, false, usingOrigin, pasteEntities, pasteBiomes, sourceMask)")
-    @Deprecated
-    public ClipboardBrush(ClipboardHolder holder, boolean ignoreAirBlocks, boolean usingOrigin, boolean pasteEntities,
-                          boolean pasteBiomes, Mask sourceMask) {
-        this(holder, ignoreAirBlocks, false, usingOrigin, pasteEntities, pasteBiomes, sourceMask);
-    }
-
-    public ClipboardBrush(ClipboardHolder holder, boolean ignoreAirBlocks, boolean ignoreStructureVoidBlocks,
-                          boolean usingOrigin, boolean pasteEntities, boolean pasteBiomes, Mask sourceMask) {
-        this.holder = holder;
+    public ClipboardPasteFactory(ClipboardHolder holder, boolean ignoreAirBlocks,
+                                 boolean ignoreStructureVoidBlocks, boolean usingOrigin,
+                                 boolean pasteEntities, boolean pasteBiomes, Mask sourceMask) {
+        this.holder = new ClipboardHolder(holder.getClipboard());
+        this.holder.setTransform(holder.getTransform());
         this.ignoreAirBlocks = ignoreAirBlocks;
         this.ignoreStructureVoidBlocks = ignoreStructureVoidBlocks;
         this.usingOrigin = usingOrigin;
@@ -61,9 +50,9 @@ public class ClipboardBrush implements Brush {
     }
 
     @Override
-    public void build(EditSession editSession, BlockVector3 position, Pattern pattern, double size) throws MaxChangedBlocksException {
-        new ClipboardPaste(
-            editSession,
+    public RegionFunction createFromContext(EditContext context) {
+        return new ClipboardPaste(
+            context.getDestination(),
             holder,
             ignoreAirBlocks,
             ignoreStructureVoidBlocks,
@@ -71,7 +60,11 @@ public class ClipboardBrush implements Brush {
             pasteEntities,
             pasteBiomes,
             sourceMask
-        ).apply(position);
+        );
     }
 
+    @Override
+    public String toString() {
+        return "paste clipboard";
+    }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/ClipboardPaste.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/ClipboardPaste.java
@@ -17,19 +17,21 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.sk89q.worldedit.command.tool.brush;
+package com.sk89q.worldedit.function;
 
-import com.google.errorprone.annotations.InlineMe;
-import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.MaxChangedBlocksException;
-import com.sk89q.worldedit.function.ClipboardPaste;
+import com.sk89q.worldedit.extent.Extent;
+import com.sk89q.worldedit.extent.clipboard.Clipboard;
 import com.sk89q.worldedit.function.mask.Mask;
-import com.sk89q.worldedit.function.pattern.Pattern;
+import com.sk89q.worldedit.function.operation.ForwardExtentCopy;
+import com.sk89q.worldedit.function.operation.Operations;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.session.ClipboardHolder;
 
-public class ClipboardBrush implements Brush {
+public final class ClipboardPaste implements RegionFunction {
 
+    private final Extent destination;
     private final ClipboardHolder holder;
     private final boolean ignoreAirBlocks;
     private final boolean ignoreStructureVoidBlocks;
@@ -38,19 +40,10 @@ public class ClipboardBrush implements Brush {
     private final boolean pasteBiomes;
     private final Mask sourceMask;
 
-    public ClipboardBrush(ClipboardHolder holder, boolean ignoreAirBlocks, boolean usingOrigin) {
-        this(holder, ignoreAirBlocks, false, usingOrigin, false, false, null);
-    }
-
-    @InlineMe(replacement = "this(holder, ignoreAirBlocks, false, usingOrigin, pasteEntities, pasteBiomes, sourceMask)")
-    @Deprecated
-    public ClipboardBrush(ClipboardHolder holder, boolean ignoreAirBlocks, boolean usingOrigin, boolean pasteEntities,
+    public ClipboardPaste(Extent destination, ClipboardHolder holder, boolean ignoreAirBlocks,
+                          boolean ignoreStructureVoidBlocks, boolean usingOrigin, boolean pasteEntities,
                           boolean pasteBiomes, Mask sourceMask) {
-        this(holder, ignoreAirBlocks, false, usingOrigin, pasteEntities, pasteBiomes, sourceMask);
-    }
-
-    public ClipboardBrush(ClipboardHolder holder, boolean ignoreAirBlocks, boolean ignoreStructureVoidBlocks,
-                          boolean usingOrigin, boolean pasteEntities, boolean pasteBiomes, Mask sourceMask) {
+        this.destination = destination;
         this.holder = holder;
         this.ignoreAirBlocks = ignoreAirBlocks;
         this.ignoreStructureVoidBlocks = ignoreStructureVoidBlocks;
@@ -61,17 +54,23 @@ public class ClipboardBrush implements Brush {
     }
 
     @Override
-    public void build(EditSession editSession, BlockVector3 position, Pattern pattern, double size) throws MaxChangedBlocksException {
-        new ClipboardPaste(
-            editSession,
-            holder,
-            ignoreAirBlocks,
-            ignoreStructureVoidBlocks,
-            usingOrigin,
-            pasteEntities,
-            pasteBiomes,
-            sourceMask
-        ).apply(position);
-    }
+    public boolean apply(BlockVector3 position) throws MaxChangedBlocksException {
+        Clipboard clipboard = holder.getClipboard();
+        Region region = clipboard.getRegion();
+        BlockVector3 centerOffset = region.getCenter().toBlockPoint().subtract(clipboard.getOrigin());
+        BlockVector3 transformedCenterOffset = holder.getTransform().apply(centerOffset.toVector3()).toBlockPoint();
 
+        ForwardExtentCopy operation = (ForwardExtentCopy) holder
+            .createPaste(destination)
+            .to(usingOrigin ? position : position.subtract(transformedCenterOffset))
+            .ignoreAirBlocks(ignoreAirBlocks)
+            .ignoreStructureVoidBlocks(ignoreStructureVoidBlocks)
+            .copyEntities(pasteEntities)
+            .copyBiomes(pasteBiomes)
+            .maskSource(sourceMask)
+            .build();
+
+        Operations.completeLegacy(operation);
+        return operation.getAffected() > 0;
+    }
 }


### PR DESCRIPTION
This PR adds a new function type to `//apply` and `/brush apply` – "clipboard". This lets you apply a clipboard paste to the terrain.

Adds https://github.com/EngineHub/WorldEdit/issues/2003