### PR TITLE
Add an async teleport API

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitEntity.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitEntity.java
@@ -32,6 +32,7 @@ import com.sk89q.worldedit.world.NullWorld;
 import io.papermc.lib.PaperLib;
 
 import java.lang.ref.WeakReference;
+import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -78,13 +79,27 @@ class BukkitEntity implements Entity {
         org.bukkit.entity.Entity entity = entityRef.get();
         if (entity != null) {
             if (WorldEditPlugin.getInstance().isFolia()) {
-                var _  = PaperLib.teleportAsync(entity, BukkitAdapter.adapt(location));
+                var _ = setLocationAsync(location);
                 return true;
             } else {
                 return entity.teleport(BukkitAdapter.adapt(location));
             }
         } else {
             return false;
+        }
+    }
+
+    @Override
+    public CompletableFuture<Boolean> setLocationAsync(Location location) {
+        org.bukkit.entity.Entity entity = entityRef.get();
+        if (entity != null) {
+            if (PaperLib.isPaper()) {
+                return entity.teleportAsync(BukkitAdapter.adapt(location));
+            } else {
+                return CompletableFuture.completedFuture(entity.teleport(BukkitAdapter.adapt(location)));
+            }
+        } else {
+            return CompletableFuture.completedFuture(false);
         }
     }
 

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
@@ -55,6 +55,7 @@ import org.enginehub.linbus.tree.LinCompoundTag;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 
 public class BukkitPlayer extends AbstractPlayerActor {
@@ -150,10 +151,20 @@ public class BukkitPlayer extends AbstractPlayerActor {
         Location location = new Location(player.getWorld(), pos.x(), pos.y(),
                 pos.z(), yaw, pitch);
         if (WorldEditPlugin.getInstance().isFolia()) {
-            var _  = PaperLib.teleportAsync(player, location);
+            var _ = trySetPositionAsync(pos, pitch, yaw);
             return true;
         } else {
             return player.teleport(location);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Boolean> trySetPositionAsync(Vector3 pos, float pitch, float yaw) {
+        Location location = new Location(player.getWorld(), pos.x(), pos.y(), pos.z(), yaw, pitch);
+        if (PaperLib.isPaper()) {
+            return player.teleportAsync(location);
+        } else {
+            return CompletableFuture.completedFuture(player.teleport(location));
         }
     }
 
@@ -232,10 +243,19 @@ public class BukkitPlayer extends AbstractPlayerActor {
     @Override
     public boolean setLocation(com.sk89q.worldedit.util.Location location) {
         if (WorldEditPlugin.getInstance().isFolia()) {
-            var _  = PaperLib.teleportAsync(player, BukkitAdapter.adapt(location));
+            var _ = setLocationAsync(location);
             return true;
         } else {
             return player.teleport(BukkitAdapter.adapt(location));
+        }
+    }
+
+    @Override
+    public CompletableFuture<Boolean> setLocationAsync(com.sk89q.worldedit.util.Location location) {
+        if (PaperLib.isPaper()) {
+            return player.teleportAsync(BukkitAdapter.adapt(location));
+        } else {
+            return CompletableFuture.completedFuture(player.teleport(BukkitAdapter.adapt(location)));
         }
     }
 

--- a/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcPlayer.java
+++ b/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcPlayer.java
@@ -43,8 +43,10 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.level.TicketType;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.entity.BlockEntityTypes;
 import org.enginehub.linbus.tree.LinCompoundTag;
 import org.enginehub.worldeditcui.protocol.CUIPacket;
@@ -52,6 +54,7 @@ import org.enginehub.worldeditcui.protocol.CUIPacket;
 import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 
 /**
@@ -108,15 +111,48 @@ public class CoreMcPlayer extends AbstractPlayerActor {
     @Override
     public boolean setLocation(Location location) {
         ServerLevel level = platform.getAdapter().toNativeWorld((World) location.getExtent());
-        this.player.teleportTo(
+        return this.player.teleportTo(
             level,
             location.getX(), location.getY(), location.getZ(),
             Set.of(),
             location.getYaw(), location.getPitch(),
             true
         );
-        // This may be false if the teleport was cancelled by a mod
-        return this.player.level() == level;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> setLocationAsync(Location location) {
+        ServerLevel level = platform.getAdapter().toNativeWorld((World) location.getExtent());
+        ChunkPos chunkPosition = new ChunkPos(location.getBlockX() >> 4, location.getBlockZ() >> 4);
+        CompletableFuture<Void> chunkLoaded = new CompletableFuture<>();
+
+        return level.getServer()
+            .submit(() -> {
+                var _ = level.getChunkSource().addTicketAndLoadWithRadius(
+                    TicketType.PORTAL,
+                    chunkPosition,
+                    0
+                ).whenComplete((ignored, throwable) -> {
+                    if (throwable == null) {
+                        chunkLoaded.complete(null);
+                    } else {
+                        chunkLoaded.completeExceptionally(throwable);
+                    }
+                });
+            })
+            .thenCompose(ignored -> chunkLoaded)
+            .thenCompose(ignored -> level.getServer().submit(() -> this.player.teleportTo(
+                level,
+                location.getX(), location.getY(), location.getZ(),
+                Set.of(),
+                location.getYaw(), location.getPitch(),
+                true
+            )));
+    }
+
+    @Override
+    public CompletableFuture<Boolean> trySetPositionAsync(Vector3 pos, float pitch, float yaw) {
+        return setLocationAsync(new Location(getWorld(), pos, yaw, pitch));
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/entity/Player.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/entity/Player.java
@@ -36,6 +36,7 @@ import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.gamemode.GameMode;
 
+import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 
 /**
@@ -316,6 +317,25 @@ public interface Player extends Entity, Actor {
         setPosition(pos, pitch, yaw);
 
         return true;
+    }
+
+    /**
+     * Attempt to move the player, asynchronously when supported.
+     *
+     * <p>
+     * This action may fail, due to other mods cancelling the move.
+     * If so, the returned future will complete with {@code false}.
+     * Platforms without asynchronous teleport support may perform the move
+     * synchronously and return an already-completed future.
+     * </p>
+     *
+     * @param pos where to move them
+     * @param pitch the pitch (up/down) of the player's view in degrees
+     * @param yaw the yaw (left/right) of the player's view in degrees
+     * @return a future that completes with whether the move was able to occur
+     */
+    default CompletableFuture<Boolean> trySetPositionAsync(Vector3 pos, float pitch, float yaw) {
+        return CompletableFuture.completedFuture(trySetPosition(pos, pitch, yaw));
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
@@ -49,6 +49,7 @@ import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.item.ItemTypes;
 
 import java.io.File;
+import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 
 /**
@@ -495,6 +496,12 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
     public boolean trySetPosition(Vector3 pos) {
         final Location location = getLocation();
         return trySetPosition(pos, location.getPitch(), location.getYaw());
+    }
+
+    @Override
+    public CompletableFuture<Boolean> trySetPositionAsync(Vector3 pos) {
+        final Location location = getLocation();
+        return trySetPositionAsync(pos, location.getPitch(), location.getYaw());
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/Locatable.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/Locatable.java
@@ -23,6 +23,8 @@ import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.util.Location;
 
+import java.util.concurrent.CompletableFuture;
+
 public interface Locatable {
 
     /**
@@ -51,6 +53,22 @@ public interface Locatable {
     boolean setLocation(Location location);
 
     /**
+     * Sets the location of this actor, asynchronously when supported.
+     *
+     * <p>
+     * The returned future completes with whether the teleport succeeded.
+     * Platforms without asynchronous teleport support may perform the
+     * teleport synchronously and return an already-completed future.
+     * </p>
+     *
+     * @param location the new location of the actor
+     * @return a future that completes with whether the teleport succeeded
+     */
+    default CompletableFuture<Boolean> setLocationAsync(Location location) {
+        return CompletableFuture.completedFuture(setLocation(location));
+    }
+
+    /**
      * Sets the position of this actor.
      *
      * @param pos where to move them
@@ -75,6 +93,21 @@ public interface Locatable {
      */
     default boolean trySetPosition(Vector3 pos) {
         return setLocation(new Location(getExtent(), pos));
+    }
+
+    /**
+     * Attempts to set the position of this actor, asynchronously when supported.
+     *
+     * <p>
+     * This action may fail, due to other mods cancelling the move.
+     * If so, the returned future will complete with {@code false}.
+     * </p>
+     *
+     * @param pos the position to set
+     * @return a future that completes with whether the position was able to be set
+     */
+    default CompletableFuture<Boolean> trySetPositionAsync(Vector3 pos) {
+        return setLocationAsync(new Location(getExtent(), pos));
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlayerProxy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlayerProxy.java
@@ -37,6 +37,7 @@ import com.sk89q.worldedit.world.gamemode.GameMode;
 
 import java.util.Locale;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -105,8 +106,18 @@ class PlayerProxy extends AbstractPlayerActor {
     }
 
     @Override
+    public CompletableFuture<Boolean> setLocationAsync(Location location) {
+        return basePlayer.setLocationAsync(location);
+    }
+
+    @Override
     public boolean trySetPosition(Vector3 pos, float pitch, float yaw) {
         return basePlayer.trySetPosition(pos, pitch, yaw);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> trySetPositionAsync(Vector3 pos, float pitch, float yaw) {
+        return basePlayer.trySetPositionAsync(pos, pitch, yaw);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/ChangeSetExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/ChangeSetExtent.java
@@ -36,6 +36,7 @@ import com.sk89q.worldedit.world.block.BlockStateHolder;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -161,6 +162,12 @@ public class ChangeSetExtent extends AbstractDelegateExtent {
         public boolean setLocation(Location location) {
             // TODO Add a changeset for this.
             return entity.setLocation(location);
+        }
+
+        @Override
+        public CompletableFuture<Boolean> setLocationAsync(Location location) {
+            // TODO Add a changeset for this.
+            return entity.setLocationAsync(location);
         }
 
         @Override


### PR DESCRIPTION
This adds a basic async teleport API. Tbh I am confused why we have both a setPosition and setLocation API, I feel we can drop the position one honestly. We have an oddly large number of teleport-related functions on the player, this PR ignores most from an async perspective when maybe it shouldn't. This likely needs more work

Adds https://github.com/EngineHub/WorldEdit/issues/2921