### PR TITLE
feat: fully implement Player#sendFakeBlock

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightAdapter.java
@@ -129,7 +129,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.entity.StructureBlockEntity;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -658,20 +657,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             properties.put(property.name(), property);
         }
         return properties;
-    }
-
-    @SuppressWarnings("deprecation") // -Werror
-    @Override
-    public void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData) {
-        var structureBlock = new StructureBlockEntity(
-                new BlockPos(pos.x(), pos.y(), pos.z()),
-                Blocks.STRUCTURE_BLOCK.defaultBlockState()
-        );
-        structureBlock.setLevel(((CraftPlayer) player).getHandle().level());
-        ((CraftPlayer) player).getHandle().connection.send(ClientboundBlockEntityDataPacket.create(
-                structureBlock,
-                (blockEntity, registryAccess) -> (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
-        ));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightAdapter.java
@@ -151,9 +151,11 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
+import org.bukkit.block.TileState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.CraftWorld;
+import org.bukkit.craftbukkit.block.CraftBlockEntityState;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
@@ -657,6 +659,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return properties;
     }
 
+    @SuppressWarnings("deprecation") // -Werror
     @Override
     public void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData) {
         var structureBlock = new StructureBlockEntity(
@@ -667,6 +670,18 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         ((CraftPlayer) player).getHandle().connection.send(ClientboundBlockEntityDataPacket.create(
                 structureBlock,
                 (blockEntity, registryAccess) -> (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
+        ));
+    }
+
+    @Override
+    public void sendFakeNBT(Player player, BlockVector3 pos, TileState tileState, LinCompoundTag nbtData) {
+        CraftBlockEntityState<?> craftState = (CraftBlockEntityState<?>) tileState;
+        CompoundTag vanillaNBT = (net.minecraft.nbt.CompoundTag) fromNative(nbtData);
+
+        ((CraftPlayer) player).getHandle().connection.send(new ClientboundBlockEntityDataPacket(
+                new BlockPos(pos.x(), pos.y(), pos.z()),
+                craftState.getBlockEntity().getType(),
+                vanillaNBT
         ));
     }
 

--- a/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_11/PaperweightAdapter.java
@@ -33,6 +33,7 @@ import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.blocks.BaseItem;
 import com.sk89q.worldedit.blocks.BaseItemStack;
+import com.sk89q.worldedit.blocks.TileEntityBlock;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.entity.BaseEntity;
@@ -82,6 +83,7 @@ import net.minecraft.core.HolderSet;
 import net.minecraft.core.Registry;
 import net.minecraft.core.SectionPos;
 import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.ByteArrayTag;
 import net.minecraft.nbt.ByteTag;
@@ -126,6 +128,7 @@ import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.entity.StructureBlockEntity;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.chunk.ChunkAccess;
@@ -151,11 +154,9 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
-import org.bukkit.block.TileState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.CraftWorld;
-import org.bukkit.craftbukkit.block.CraftBlockEntityState;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
@@ -674,14 +675,17 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     }
 
     @Override
-    public void sendFakeNBT(Player player, BlockVector3 pos, TileState tileState, LinCompoundTag nbtData) {
-        CraftBlockEntityState<?> craftState = (CraftBlockEntityState<?>) tileState;
-        CompoundTag vanillaNBT = (net.minecraft.nbt.CompoundTag) fromNative(nbtData);
+    public void sendFakeNBT(Player player, BlockVector3 pos, TileEntityBlock tileEntityBlock, LinCompoundTag nbtData) {
+        BlockEntityType<?> nativeBlockEntityType = BuiltInRegistries.BLOCK_ENTITY_TYPE
+            .getValue(Identifier.parse(tileEntityBlock.getNbtId()));
+        if (nativeBlockEntityType == null) {
+            return;
+        }
 
         ((CraftPlayer) player).getHandle().connection.send(new ClientboundBlockEntityDataPacket(
-                new BlockPos(pos.x(), pos.y(), pos.z()),
-                craftState.getBlockEntity().getType(),
-                vanillaNBT
+            new BlockPos(pos.x(), pos.y(), pos.z()),
+            nativeBlockEntityType,
+            (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
         ));
     }
 

--- a/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
@@ -33,6 +33,7 @@ import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.blocks.BaseItem;
 import com.sk89q.worldedit.blocks.BaseItemStack;
+import com.sk89q.worldedit.blocks.TileEntityBlock;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.entity.BaseEntity;
@@ -83,6 +84,7 @@ import net.minecraft.core.HolderSet;
 import net.minecraft.core.Registry;
 import net.minecraft.core.SectionPos;
 import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.ByteArrayTag;
 import net.minecraft.nbt.ByteTag;
@@ -127,6 +129,7 @@ import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.entity.StructureBlockEntity;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.chunk.ChunkAccess;
@@ -149,11 +152,9 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
-import org.bukkit.block.TileState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.CraftWorld;
-import org.bukkit.craftbukkit.block.CraftBlockEntityState;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
@@ -654,14 +655,17 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     }
 
     @Override
-    public void sendFakeNBT(Player player, BlockVector3 pos, TileState tileState, LinCompoundTag nbtData) {
-        CraftBlockEntityState<?> craftState = (CraftBlockEntityState<?>) tileState;
-        CompoundTag vanillaNBT = (net.minecraft.nbt.CompoundTag) fromNative(nbtData);
+    public void sendFakeNBT(Player player, BlockVector3 pos, TileEntityBlock tileEntityBlock, LinCompoundTag nbtData) {
+        BlockEntityType<?> nativeBlockEntityType = BuiltInRegistries.BLOCK_ENTITY_TYPE
+            .getValue(ResourceLocation.parse(tileEntityBlock.getNbtId()));
+        if (nativeBlockEntityType == null) {
+            return;
+        }
 
         ((CraftPlayer) player).getHandle().connection.send(new ClientboundBlockEntityDataPacket(
             new BlockPos(pos.x(), pos.y(), pos.z()),
-            craftState.getTileEntity().getType(),
-            vanillaNBT
+            nativeBlockEntityType,
+            (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
         ));
     }
 

--- a/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
@@ -130,7 +130,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.entity.StructureBlockEntity;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -638,20 +637,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             properties.put(property.name(), property);
         }
         return properties;
-    }
-
-    @SuppressWarnings("deprecation") // -Werror
-    @Override
-    public void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData) {
-        var structureBlock = new StructureBlockEntity(
-            new BlockPos(pos.x(), pos.y(), pos.z()),
-            Blocks.STRUCTURE_BLOCK.defaultBlockState()
-        );
-        structureBlock.setLevel(((CraftPlayer) player).getHandle().level());
-        ((CraftPlayer) player).getHandle().connection.send(ClientboundBlockEntityDataPacket.create(
-            structureBlock,
-            (blockEntity, registryAccess) -> (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
-        ));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_4/PaperweightAdapter.java
@@ -149,9 +149,11 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
+import org.bukkit.block.TileState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.CraftWorld;
+import org.bukkit.craftbukkit.block.CraftBlockEntityState;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
@@ -637,6 +639,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return properties;
     }
 
+    @SuppressWarnings("deprecation") // -Werror
     @Override
     public void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData) {
         var structureBlock = new StructureBlockEntity(
@@ -647,6 +650,18 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         ((CraftPlayer) player).getHandle().connection.send(ClientboundBlockEntityDataPacket.create(
             structureBlock,
             (blockEntity, registryAccess) -> (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
+        ));
+    }
+
+    @Override
+    public void sendFakeNBT(Player player, BlockVector3 pos, TileState tileState, LinCompoundTag nbtData) {
+        CraftBlockEntityState<?> craftState = (CraftBlockEntityState<?>) tileState;
+        CompoundTag vanillaNBT = (net.minecraft.nbt.CompoundTag) fromNative(nbtData);
+
+        ((CraftPlayer) player).getHandle().connection.send(new ClientboundBlockEntityDataPacket(
+            new BlockPos(pos.x(), pos.y(), pos.z()),
+            craftState.getTileEntity().getType(),
+            vanillaNBT
         ));
     }
 

--- a/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
@@ -130,7 +130,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.entity.StructureBlockEntity;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -636,20 +635,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             properties.put(property.name(), property);
         }
         return properties;
-    }
-
-    @SuppressWarnings("deprecation") // -Werror
-    @Override
-    public void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData) {
-        var structureBlock = new StructureBlockEntity(
-            new BlockPos(pos.x(), pos.y(), pos.z()),
-            Blocks.STRUCTURE_BLOCK.defaultBlockState()
-        );
-        structureBlock.setLevel(((CraftPlayer) player).getHandle().level());
-        ((CraftPlayer) player).getHandle().connection.send(ClientboundBlockEntityDataPacket.create(
-            structureBlock,
-            (blockEntity, registryAccess) -> (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
-        ));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
@@ -149,9 +149,11 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
+import org.bukkit.block.TileState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.CraftWorld;
+import org.bukkit.craftbukkit.block.CraftBlockEntityState;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
@@ -635,6 +637,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return properties;
     }
 
+    @SuppressWarnings("deprecation") // -Werror
     @Override
     public void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData) {
         var structureBlock = new StructureBlockEntity(
@@ -645,6 +648,18 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         ((CraftPlayer) player).getHandle().connection.send(ClientboundBlockEntityDataPacket.create(
             structureBlock,
             (blockEntity, registryAccess) -> (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
+        ));
+    }
+
+    @Override
+    public void sendFakeNBT(Player player, BlockVector3 pos, TileState tileState, LinCompoundTag nbtData) {
+        CraftBlockEntityState<?> craftState = (CraftBlockEntityState<?>) tileState;
+        CompoundTag vanillaNBT = (net.minecraft.nbt.CompoundTag) fromNative(nbtData);
+
+        ((CraftPlayer) player).getHandle().connection.send(new ClientboundBlockEntityDataPacket(
+            new BlockPos(pos.x(), pos.y(), pos.z()),
+            craftState.getBlockEntity().getType(),
+            vanillaNBT
         ));
     }
 

--- a/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_5/PaperweightAdapter.java
@@ -33,6 +33,7 @@ import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.blocks.BaseItem;
 import com.sk89q.worldedit.blocks.BaseItemStack;
+import com.sk89q.worldedit.blocks.TileEntityBlock;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.entity.BaseEntity;
@@ -83,6 +84,7 @@ import net.minecraft.core.HolderSet;
 import net.minecraft.core.Registry;
 import net.minecraft.core.SectionPos;
 import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.ByteArrayTag;
 import net.minecraft.nbt.ByteTag;
@@ -127,6 +129,7 @@ import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.entity.StructureBlockEntity;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.chunk.ChunkAccess;
@@ -149,11 +152,9 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
-import org.bukkit.block.TileState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.CraftWorld;
-import org.bukkit.craftbukkit.block.CraftBlockEntityState;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
@@ -652,14 +653,17 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     }
 
     @Override
-    public void sendFakeNBT(Player player, BlockVector3 pos, TileState tileState, LinCompoundTag nbtData) {
-        CraftBlockEntityState<?> craftState = (CraftBlockEntityState<?>) tileState;
-        CompoundTag vanillaNBT = (net.minecraft.nbt.CompoundTag) fromNative(nbtData);
+    public void sendFakeNBT(Player player, BlockVector3 pos, TileEntityBlock tileEntityBlock, LinCompoundTag nbtData) {
+        BlockEntityType<?> nativeBlockEntityType = BuiltInRegistries.BLOCK_ENTITY_TYPE
+            .getValue(ResourceLocation.parse(tileEntityBlock.getNbtId()));
+        if (nativeBlockEntityType == null) {
+            return;
+        }
 
         ((CraftPlayer) player).getHandle().connection.send(new ClientboundBlockEntityDataPacket(
             new BlockPos(pos.x(), pos.y(), pos.z()),
-            craftState.getBlockEntity().getType(),
-            vanillaNBT
+            nativeBlockEntityType,
+            (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
         ));
     }
 

--- a/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
@@ -130,7 +130,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.entity.StructureBlockEntity;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -658,20 +657,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             properties.put(property.name(), property);
         }
         return properties;
-    }
-
-    @SuppressWarnings("deprecation") // -Werror
-    @Override
-    public void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData) {
-        var structureBlock = new StructureBlockEntity(
-            new BlockPos(pos.x(), pos.y(), pos.z()),
-            Blocks.STRUCTURE_BLOCK.defaultBlockState()
-        );
-        structureBlock.setLevel(((CraftPlayer) player).getHandle().level());
-        ((CraftPlayer) player).getHandle().connection.send(ClientboundBlockEntityDataPacket.create(
-            structureBlock,
-            (blockEntity, registryAccess) -> (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
-        ));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
@@ -33,6 +33,7 @@ import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.blocks.BaseItem;
 import com.sk89q.worldedit.blocks.BaseItemStack;
+import com.sk89q.worldedit.blocks.TileEntityBlock;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.entity.BaseEntity;
@@ -83,6 +84,7 @@ import net.minecraft.core.HolderSet;
 import net.minecraft.core.Registry;
 import net.minecraft.core.SectionPos;
 import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.ByteArrayTag;
 import net.minecraft.nbt.ByteTag;
@@ -127,6 +129,7 @@ import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.entity.StructureBlockEntity;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.chunk.ChunkAccess;
@@ -152,11 +155,9 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
-import org.bukkit.block.TileState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.CraftWorld;
-import org.bukkit.craftbukkit.block.CraftBlockEntityState;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
@@ -674,14 +675,17 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     }
 
     @Override
-    public void sendFakeNBT(Player player, BlockVector3 pos, TileState tileState, LinCompoundTag nbtData) {
-        CraftBlockEntityState<?> craftState = (CraftBlockEntityState<?>) tileState;
-        CompoundTag vanillaNBT = (net.minecraft.nbt.CompoundTag) fromNative(nbtData);
+    public void sendFakeNBT(Player player, BlockVector3 pos, TileEntityBlock tileEntityBlock, LinCompoundTag nbtData) {
+        BlockEntityType<?> nativeBlockEntityType = BuiltInRegistries.BLOCK_ENTITY_TYPE
+            .getValue(ResourceLocation.parse(tileEntityBlock.getNbtId()));
+        if (nativeBlockEntityType == null) {
+            return;
+        }
 
         ((CraftPlayer) player).getHandle().connection.send(new ClientboundBlockEntityDataPacket(
             new BlockPos(pos.x(), pos.y(), pos.z()),
-            craftState.getBlockEntity().getType(),
-            vanillaNBT
+            nativeBlockEntityType,
+            (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
         ));
     }
 

--- a/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_6/PaperweightAdapter.java
@@ -152,9 +152,11 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
+import org.bukkit.block.TileState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.CraftWorld;
+import org.bukkit.craftbukkit.block.CraftBlockEntityState;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
@@ -657,6 +659,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return properties;
     }
 
+    @SuppressWarnings("deprecation") // -Werror
     @Override
     public void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData) {
         var structureBlock = new StructureBlockEntity(
@@ -667,6 +670,18 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         ((CraftPlayer) player).getHandle().connection.send(ClientboundBlockEntityDataPacket.create(
             structureBlock,
             (blockEntity, registryAccess) -> (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
+        ));
+    }
+
+    @Override
+    public void sendFakeNBT(Player player, BlockVector3 pos, TileState tileState, LinCompoundTag nbtData) {
+        CraftBlockEntityState<?> craftState = (CraftBlockEntityState<?>) tileState;
+        CompoundTag vanillaNBT = (net.minecraft.nbt.CompoundTag) fromNative(nbtData);
+
+        ((CraftPlayer) player).getHandle().connection.send(new ClientboundBlockEntityDataPacket(
+            new BlockPos(pos.x(), pos.y(), pos.z()),
+            craftState.getBlockEntity().getType(),
+            vanillaNBT
         ));
     }
 

--- a/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightAdapter.java
@@ -129,7 +129,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.entity.StructureBlockEntity;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -657,20 +656,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             properties.put(property.name(), property);
         }
         return properties;
-    }
-
-    @SuppressWarnings("deprecation") // -Werror
-    @Override
-    public void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData) {
-        var structureBlock = new StructureBlockEntity(
-            new BlockPos(pos.x(), pos.y(), pos.z()),
-            Blocks.STRUCTURE_BLOCK.defaultBlockState()
-        );
-        structureBlock.setLevel(((CraftPlayer) player).getHandle().level());
-        ((CraftPlayer) player).getHandle().connection.send(ClientboundBlockEntityDataPacket.create(
-            structureBlock,
-            (blockEntity, registryAccess) -> (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
-        ));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightAdapter.java
@@ -33,6 +33,7 @@ import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.blocks.BaseItem;
 import com.sk89q.worldedit.blocks.BaseItemStack;
+import com.sk89q.worldedit.blocks.TileEntityBlock;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.entity.BaseEntity;
@@ -83,6 +84,7 @@ import net.minecraft.core.HolderSet;
 import net.minecraft.core.Registry;
 import net.minecraft.core.SectionPos;
 import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.ByteArrayTag;
 import net.minecraft.nbt.ByteTag;
@@ -126,6 +128,7 @@ import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.entity.StructureBlockEntity;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.chunk.ChunkAccess;
@@ -151,11 +154,9 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
-import org.bukkit.block.TileState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.CraftWorld;
-import org.bukkit.craftbukkit.block.CraftBlockEntityState;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
@@ -673,14 +674,17 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     }
 
     @Override
-    public void sendFakeNBT(Player player, BlockVector3 pos, TileState tileState, LinCompoundTag nbtData) {
-        CraftBlockEntityState<?> craftState = (CraftBlockEntityState<?>) tileState;
-        CompoundTag vanillaNBT = (net.minecraft.nbt.CompoundTag) fromNative(nbtData);
+    public void sendFakeNBT(Player player, BlockVector3 pos, TileEntityBlock tileEntityBlock, LinCompoundTag nbtData) {
+        BlockEntityType<?> nativeBlockEntityType = BuiltInRegistries.BLOCK_ENTITY_TYPE
+            .getValue(ResourceLocation.parse(tileEntityBlock.getNbtId()));
+        if (nativeBlockEntityType == null) {
+            return;
+        }
 
         ((CraftPlayer) player).getHandle().connection.send(new ClientboundBlockEntityDataPacket(
             new BlockPos(pos.x(), pos.y(), pos.z()),
-            craftState.getBlockEntity().getType(),
-            vanillaNBT
+            nativeBlockEntityType,
+            (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
         ));
     }
 

--- a/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1.21.9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v1_21_9/PaperweightAdapter.java
@@ -151,9 +151,11 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
+import org.bukkit.block.TileState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.CraftWorld;
+import org.bukkit.craftbukkit.block.CraftBlockEntityState;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
@@ -656,6 +658,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return properties;
     }
 
+    @SuppressWarnings("deprecation") // -Werror
     @Override
     public void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData) {
         var structureBlock = new StructureBlockEntity(
@@ -666,6 +669,18 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         ((CraftPlayer) player).getHandle().connection.send(ClientboundBlockEntityDataPacket.create(
             structureBlock,
             (blockEntity, registryAccess) -> (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
+        ));
+    }
+
+    @Override
+    public void sendFakeNBT(Player player, BlockVector3 pos, TileState tileState, LinCompoundTag nbtData) {
+        CraftBlockEntityState<?> craftState = (CraftBlockEntityState<?>) tileState;
+        CompoundTag vanillaNBT = (net.minecraft.nbt.CompoundTag) fromNative(nbtData);
+
+        ((CraftPlayer) player).getHandle().connection.send(new ClientboundBlockEntityDataPacket(
+            new BlockPos(pos.x(), pos.y(), pos.z()),
+            craftState.getBlockEntity().getType(),
+            vanillaNBT
         ));
     }
 

--- a/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
@@ -129,7 +129,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.entity.StructureBlockEntity;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -675,20 +674,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             properties.put(property.name(), property);
         }
         return properties;
-    }
-
-    @SuppressWarnings("deprecation") // -Werror
-    @Override
-    public void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData) {
-        var structureBlock = new StructureBlockEntity(
-                new BlockPos(pos.x(), pos.y(), pos.z()),
-                Blocks.STRUCTURE_BLOCK.defaultBlockState()
-        );
-        structureBlock.setLevel(((CraftPlayer) player).getHandle().level());
-        ((CraftPlayer) player).getHandle().connection.send(ClientboundBlockEntityDataPacket.create(
-                structureBlock,
-                (blockEntity, registryAccess) -> (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
-        ));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
@@ -151,9 +151,11 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
+import org.bukkit.block.TileState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.CraftWorld;
+import org.bukkit.craftbukkit.block.CraftBlockEntityState;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
@@ -674,6 +676,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return properties;
     }
 
+    @SuppressWarnings("deprecation") // -Werror
     @Override
     public void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData) {
         var structureBlock = new StructureBlockEntity(
@@ -684,6 +687,18 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         ((CraftPlayer) player).getHandle().connection.send(ClientboundBlockEntityDataPacket.create(
                 structureBlock,
                 (blockEntity, registryAccess) -> (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
+        ));
+    }
+
+    @Override
+    public void sendFakeNBT(Player player, BlockVector3 pos, TileState tileState, LinCompoundTag nbtData) {
+        CraftBlockEntityState<?> craftState = (CraftBlockEntityState<?>) tileState;
+        CompoundTag vanillaNBT = (net.minecraft.nbt.CompoundTag) fromNative(nbtData);
+
+        ((CraftPlayer) player).getHandle().connection.send(new ClientboundBlockEntityDataPacket(
+            new BlockPos(pos.x(), pos.y(), pos.z()),
+            craftState.getBlockEntity().getType(),
+            vanillaNBT
         ));
     }
 

--- a/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
@@ -32,6 +32,7 @@ import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.blocks.BaseItem;
 import com.sk89q.worldedit.blocks.BaseItemStack;
+import com.sk89q.worldedit.blocks.TileEntityBlock;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.entity.BaseEntity;
@@ -83,6 +84,7 @@ import net.minecraft.core.HolderSet;
 import net.minecraft.core.Registry;
 import net.minecraft.core.SectionPos;
 import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.ByteArrayTag;
 import net.minecraft.nbt.ByteTag;
@@ -126,6 +128,7 @@ import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.entity.StructureBlockEntity;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.chunk.ChunkAccess;
@@ -151,11 +154,9 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
-import org.bukkit.block.TileState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.CraftWorld;
-import org.bukkit.craftbukkit.block.CraftBlockEntityState;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
@@ -691,14 +692,17 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     }
 
     @Override
-    public void sendFakeNBT(Player player, BlockVector3 pos, TileState tileState, LinCompoundTag nbtData) {
-        CraftBlockEntityState<?> craftState = (CraftBlockEntityState<?>) tileState;
-        CompoundTag vanillaNBT = (net.minecraft.nbt.CompoundTag) fromNative(nbtData);
+    public void sendFakeNBT(Player player, BlockVector3 pos, TileEntityBlock tileEntityBlock, LinCompoundTag nbtData) {
+        BlockEntityType<?> nativeBlockEntityType = BuiltInRegistries.BLOCK_ENTITY_TYPE
+            .getValue(Identifier.parse(tileEntityBlock.getNbtId()));
+        if (nativeBlockEntityType == null) {
+            return;
+        }
 
         ((CraftPlayer) player).getHandle().connection.send(new ClientboundBlockEntityDataPacket(
             new BlockPos(pos.x(), pos.y(), pos.z()),
-            craftState.getBlockEntity().getType(),
-            vanillaNBT
+            nativeBlockEntityType,
+            (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
         ));
     }
 

--- a/worldedit-bukkit/adapters/adapter-26.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_2/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-26.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_2/PaperweightAdapter.java
@@ -32,6 +32,7 @@ import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.blocks.BaseItem;
 import com.sk89q.worldedit.blocks.BaseItemStack;
+import com.sk89q.worldedit.blocks.TileEntityBlock;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.entity.BaseEntity;
@@ -83,6 +84,7 @@ import net.minecraft.core.HolderSet;
 import net.minecraft.core.Registry;
 import net.minecraft.core.SectionPos;
 import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.ByteArrayTag;
 import net.minecraft.nbt.ByteTag;
@@ -126,6 +128,7 @@ import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.entity.StructureBlockEntity;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.chunk.ChunkAccess;
@@ -151,11 +154,9 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
-import org.bukkit.block.TileState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.CraftWorld;
-import org.bukkit.craftbukkit.block.CraftBlockEntityState;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
@@ -696,14 +697,17 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
     }
 
     @Override
-    public void sendFakeNBT(Player player, BlockVector3 pos, TileState tileState, LinCompoundTag nbtData) {
-        CraftBlockEntityState<?> craftState = (CraftBlockEntityState<?>) tileState;
-        CompoundTag vanillaNBT = (net.minecraft.nbt.CompoundTag) fromNative(nbtData);
+    public void sendFakeNBT(Player player, BlockVector3 pos, TileEntityBlock tileEntityBlock, LinCompoundTag nbtData) {
+        BlockEntityType<?> nativeBlockEntityType = BuiltInRegistries.BLOCK_ENTITY_TYPE
+            .getValue(Identifier.parse(tileEntityBlock.getNbtId()));
+        if (nativeBlockEntityType == null) {
+            return;
+        }
 
         ((CraftPlayer) player).getHandle().connection.send(new ClientboundBlockEntityDataPacket(
             new BlockPos(pos.x(), pos.y(), pos.z()),
-            craftState.getBlockEntity().getType(),
-            vanillaNBT
+            nativeBlockEntityType,
+            (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
         ));
     }
 

--- a/worldedit-bukkit/adapters/adapter-26.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_2/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-26.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_2/PaperweightAdapter.java
@@ -151,9 +151,11 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
+import org.bukkit.block.TileState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.CraftWorld;
+import org.bukkit.craftbukkit.block.CraftBlockEntityState;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
@@ -679,6 +681,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         return properties;
     }
 
+    @SuppressWarnings("deprecation") // -Werror
     @Override
     public void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData) {
         var structureBlock = new StructureBlockEntity(
@@ -689,6 +692,18 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
         ((CraftPlayer) player).getHandle().connection.send(ClientboundBlockEntityDataPacket.create(
                 structureBlock,
                 (blockEntity, registryAccess) -> (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
+        ));
+    }
+
+    @Override
+    public void sendFakeNBT(Player player, BlockVector3 pos, TileState tileState, LinCompoundTag nbtData) {
+        CraftBlockEntityState<?> craftState = (CraftBlockEntityState<?>) tileState;
+        CompoundTag vanillaNBT = (net.minecraft.nbt.CompoundTag) fromNative(nbtData);
+
+        ((CraftPlayer) player).getHandle().connection.send(new ClientboundBlockEntityDataPacket(
+            new BlockPos(pos.x(), pos.y(), pos.z()),
+            craftState.getBlockEntity().getType(),
+            vanillaNBT
         ));
     }
 

--- a/worldedit-bukkit/adapters/adapter-26.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_2/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-26.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_2/PaperweightAdapter.java
@@ -129,7 +129,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.entity.StructureBlockEntity;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -680,20 +679,6 @@ public final class PaperweightAdapter implements BukkitImplAdapter {
             properties.put(property.name(), property);
         }
         return properties;
-    }
-
-    @SuppressWarnings("deprecation") // -Werror
-    @Override
-    public void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData) {
-        var structureBlock = new StructureBlockEntity(
-                new BlockPos(pos.x(), pos.y(), pos.z()),
-                Blocks.STRUCTURE_BLOCK.defaultBlockState()
-        );
-        structureBlock.setLevel(((CraftPlayer) player).getHandle().level());
-        ((CraftPlayer) player).getHandle().connection.send(ClientboundBlockEntityDataPacket.create(
-                structureBlock,
-                (blockEntity, registryAccess) -> (net.minecraft.nbt.CompoundTag) fromNative(nbtData)
-        ));
     }
 
     @Override

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
@@ -42,6 +42,7 @@ import com.sk89q.worldedit.util.formatting.text.format.TextColor;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BlockTypes;
 import com.sk89q.worldedit.world.gamemode.GameMode;
 import com.sk89q.worldedit.world.gamemode.GameModes;
 import io.papermc.lib.PaperLib;
@@ -329,12 +330,7 @@ public class BukkitPlayer extends AbstractPlayerActor {
             return;
         }
         adapter.sendFakeNBT(player, pos, tileState, nbtData);
-    }
-
-    @Override
-    public void sendFakeOP() {
-        BukkitImplAdapter adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
-        if (adapter != null) {
+        if (block != null && block.getBlockType() == BlockTypes.STRUCTURE_BLOCK) {
             adapter.sendFakeOP(player);
         }
     }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
@@ -48,7 +48,6 @@ import com.sk89q.worldedit.world.gamemode.GameModes;
 import io.papermc.lib.PaperLib;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.block.TileState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -326,10 +325,10 @@ public class BukkitPlayer extends AbstractPlayerActor {
             return;
         }
         LinCompoundTag nbtData = baseBlock.getNbt();
-        if (nbtData == null || !(data.createBlockState() instanceof TileState tileState)) {
+        if (nbtData == null) {
             return;
         }
-        adapter.sendFakeNBT(player, pos, tileState, nbtData);
+        adapter.sendFakeNBT(player, pos, baseBlock, nbtData);
         if (block != null && block.getBlockType() == BlockTypes.STRUCTURE_BLOCK) {
             adapter.sendFakeOP(player);
         }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
@@ -48,7 +48,6 @@ import com.sk89q.worldedit.world.gamemode.GameModes;
 import io.papermc.lib.PaperLib;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.enginehub.linbus.tree.LinCompoundTag;
@@ -316,9 +315,7 @@ public class BukkitPlayer extends AbstractPlayerActor {
             baseBlock = getExtent().getFullBlock(pos);
         }
 
-        BlockData data = BukkitAdapter.adapt(baseBlock);
-
-        player.sendBlockChange(loc, data);
+        player.sendBlockChange(loc, BukkitAdapter.adapt(baseBlock));
 
         BukkitImplAdapter adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
         if (adapter == null) {

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
@@ -42,12 +42,13 @@ import com.sk89q.worldedit.util.formatting.text.format.TextColor;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
-import com.sk89q.worldedit.world.block.BlockTypes;
 import com.sk89q.worldedit.world.gamemode.GameMode;
 import com.sk89q.worldedit.world.gamemode.GameModes;
 import io.papermc.lib.PaperLib;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.block.TileState;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.enginehub.linbus.tree.LinCompoundTag;
@@ -305,22 +306,36 @@ public class BukkitPlayer extends AbstractPlayerActor {
     }
 
     @Override
-    public <B extends BlockStateHolder<B>> void sendFakeBlock(BlockVector3 pos, B block) {
+    public <B extends BlockStateHolder<B>> void sendFakeBlock(BlockVector3 pos, @Nullable B block) {
         Location loc = new Location(player.getWorld(), pos.x(), pos.y(), pos.z());
-        if (block == null) {
-            player.sendBlockChange(loc, player.getWorld().getBlockAt(loc).getBlockData());
+
+        BaseBlock baseBlock;
+        if (block != null) {
+            baseBlock = block.toBaseBlock();
         } else {
-            player.sendBlockChange(loc, BukkitAdapter.adapt(block));
-            BukkitImplAdapter adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
-            if (adapter != null) {
-                if (block.getBlockType() == BlockTypes.STRUCTURE_BLOCK && block instanceof BaseBlock baseBlock) {
-                    LinCompoundTag nbt = baseBlock.getNbt();
-                    if (nbt != null) {
-                        adapter.sendFakeNBT(player, pos, nbt);
-                        adapter.sendFakeOP(player);
-                    }
-                }
-            }
+            baseBlock = getExtent().getFullBlock(pos);
+        }
+
+        BlockData data = BukkitAdapter.adapt(baseBlock);
+
+        player.sendBlockChange(loc, data);
+
+        BukkitImplAdapter adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
+        if (adapter == null) {
+            return;
+        }
+        LinCompoundTag nbtData = baseBlock.getNbt();
+        if (nbtData == null || !(data.createBlockState() instanceof TileState tileState)) {
+            return;
+        }
+        adapter.sendFakeNBT(player, pos, tileState, nbtData);
+    }
+
+    @Override
+    public void sendFakeOP() {
+        BukkitImplAdapter adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
+        if (adapter != null) {
+            adapter.sendFakeOP(player);
         }
     }
 }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
@@ -186,10 +186,10 @@ public interface BukkitImplAdapter {
     /**
      * Send the given NBT data to the player.
      *
-     * @param player          The player
-     * @param pos             The position
+     * @param player The player
+     * @param pos The position
      * @param tileEntityBlock The block-entity block
-     * @param nbtData         The NBT Data
+     * @param nbtData The NBT Data
      */
     void sendFakeNBT(Player player, BlockVector3 pos, TileEntityBlock tileEntityBlock, LinCompoundTag nbtData);
 

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
@@ -203,8 +203,7 @@ public interface BukkitImplAdapter {
      * @param tileEntityBlock The block-entity block
      * @param nbtData         The NBT Data
      */
-    default void sendFakeNBT(Player player, BlockVector3 pos, TileEntityBlock tileEntityBlock, LinCompoundTag nbtData) {
-    }
+    void sendFakeNBT(Player player, BlockVector3 pos, TileEntityBlock tileEntityBlock, LinCompoundTag nbtData);
 
     /**
      * Make the client think it has operator status.

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
@@ -49,6 +49,7 @@ import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.block.TileState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
@@ -188,8 +189,21 @@ public interface BukkitImplAdapter {
      * @param player The player
      * @param pos The position
      * @param nbtData The NBT Data
+     *
+     * @deprecated Only works for structure blocks
      */
+    @Deprecated(since = "2.15.1")
     void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData);
+
+    /**
+     * Send the given NBT data to the player.
+     *
+     * @param player    The player
+     * @param pos       The position
+     * @param tileState The bukkit tile state
+     * @param nbtData   The NBT Data
+     */
+    void sendFakeNBT(Player player, BlockVector3 pos, TileState tileState, LinCompoundTag nbtData);
 
     /**
      * Make the client think it has operator status.

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
@@ -186,18 +186,6 @@ public interface BukkitImplAdapter {
     /**
      * Send the given NBT data to the player.
      *
-     * @param player The player
-     * @param pos The position
-     * @param nbtData The NBT Data
-     *
-     * @deprecated Only works for structure blocks
-     */
-    @Deprecated
-    void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData);
-
-    /**
-     * Send the given NBT data to the player.
-     *
      * @param player          The player
      * @param pos             The position
      * @param tileEntityBlock The block-entity block

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
@@ -23,6 +23,7 @@ import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.blocks.BaseItem;
 import com.sk89q.worldedit.blocks.BaseItemStack;
+import com.sk89q.worldedit.blocks.TileEntityBlock;
 import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.internal.wna.WorldNativeAccess;
@@ -49,7 +50,6 @@ import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 import org.bukkit.Location;
 import org.bukkit.World;
-import org.bukkit.block.TileState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
@@ -198,12 +198,13 @@ public interface BukkitImplAdapter {
     /**
      * Send the given NBT data to the player.
      *
-     * @param player    The player
-     * @param pos       The position
-     * @param tileState The bukkit tile state
-     * @param nbtData   The NBT Data
+     * @param player          The player
+     * @param pos             The position
+     * @param tileEntityBlock The block-entity block
+     * @param nbtData         The NBT Data
      */
-    void sendFakeNBT(Player player, BlockVector3 pos, TileState tileState, LinCompoundTag nbtData);
+    default void sendFakeNBT(Player player, BlockVector3 pos, TileEntityBlock tileEntityBlock, LinCompoundTag nbtData) {
+    }
 
     /**
      * Make the client think it has operator status.

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
@@ -192,7 +192,7 @@ public interface BukkitImplAdapter {
      *
      * @deprecated Only works for structure blocks
      */
-    @Deprecated(since = "2.15.1")
+    @Deprecated
     void sendFakeNBT(Player player, BlockVector3 pos, LinCompoundTag nbtData);
 
     /**

--- a/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcPlayer.java
+++ b/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcPlayer.java
@@ -39,13 +39,14 @@ import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
+import net.minecraft.resources.Identifier;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.EntityBlock;
-import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import org.enginehub.linbus.tree.LinCompoundTag;
 import org.enginehub.worldeditcui.protocol.CUIPacket;
@@ -238,8 +239,8 @@ public class CoreMcPlayer extends AbstractPlayerActor {
         BlockPos loc = platform.getAdapter().toBlockPos(pos);
         if (block == null) {
             player.connection.send(new ClientboundBlockUpdatePacket(
-                    coreMcWorld.getWorld(),
-                    loc
+                coreMcWorld.getWorld(),
+                loc
             ));
         } else {
             final BlockState nativeState = platform.getAdapter().toNativeBlockState(block.toImmutableState());
@@ -250,17 +251,18 @@ public class CoreMcPlayer extends AbstractPlayerActor {
                 return;
             }
             final LinCompoundTag nbtData = tileBlock.getNbt();
-            if (nbtData == null || !(nativeState.getBlock() instanceof final EntityBlock entityBlock)) {
+            if (nbtData == null) {
                 return;
             }
-            final BlockEntity blockEntity = entityBlock.newBlockEntity(loc, nativeState);
-            if (blockEntity == null) {
+            final BlockEntityType<?> nativeBlockEntityType = BuiltInRegistries.BLOCK_ENTITY_TYPE
+                .getValue(Identifier.parse(tileBlock.getNbtId()));
+            if (nativeBlockEntityType == null) {
                 return;
             }
             player.connection.send(AccessorClientboundBlockEntityDataPacket.create(
-                    loc,
-                    blockEntity.getType(),
-                    NBTConverter.toNative(nbtData)
+                loc,
+                nativeBlockEntityType,
+                NBTConverter.toNative(nbtData)
             ));
         }
     }

--- a/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcPlayer.java
+++ b/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcPlayer.java
@@ -20,6 +20,7 @@
 package com.sk89q.worldedit.coremc.internal;
 
 import com.sk89q.worldedit.blocks.BaseItemStack;
+import com.sk89q.worldedit.blocks.TileEntityBlock;
 import com.sk89q.worldedit.coremc.mixin.AccessorClientboundBlockEntityDataPacket;
 import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.extension.platform.AbstractPlayerActor;
@@ -35,9 +36,7 @@ import com.sk89q.worldedit.util.formatting.component.TextUtils;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.serializer.gson.GsonComponentSerializer;
 import com.sk89q.worldedit.world.World;
-import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
-import com.sk89q.worldedit.world.block.BlockTypes;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
@@ -45,7 +44,9 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.entity.BlockEntityTypes;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import org.enginehub.linbus.tree.LinCompoundTag;
 import org.enginehub.worldeditcui.protocol.CUIPacket;
 
@@ -229,33 +230,38 @@ public class CoreMcPlayer extends AbstractPlayerActor {
     }
 
     @Override
-    public <B extends BlockStateHolder<B>> void sendFakeBlock(BlockVector3 pos, B block) {
+    public <B extends BlockStateHolder<B>> void sendFakeBlock(BlockVector3 pos, @Nullable B block) {
         World world = getWorld();
         if (!(world instanceof CoreMcWorld coreMcWorld)) {
             return;
         }
         BlockPos loc = platform.getAdapter().toBlockPos(pos);
         if (block == null) {
-            final ClientboundBlockUpdatePacket packetOut = new ClientboundBlockUpdatePacket(
-                coreMcWorld.getWorld(), loc
-            );
-            player.connection.send(packetOut);
+            player.connection.send(new ClientboundBlockUpdatePacket(
+                    coreMcWorld.getWorld(),
+                    loc
+            ));
         } else {
-            final ClientboundBlockUpdatePacket packetOut = new ClientboundBlockUpdatePacket(
-                loc,
-                platform.getAdapter().toNativeBlockState(block.toImmutableState())
-            );
-            player.connection.send(packetOut);
-            if (block instanceof BaseBlock baseBlock && block.getBlockType().equals(BlockTypes.STRUCTURE_BLOCK)) {
-                final LinCompoundTag nbtData = baseBlock.getNbt();
-                if (nbtData != null) {
-                    player.connection.send(AccessorClientboundBlockEntityDataPacket.create(
-                        new BlockPos(pos.x(), pos.y(), pos.z()),
-                        BlockEntityTypes.STRUCTURE_BLOCK,
-                        NBTConverter.toNative(nbtData)
-                    ));
-                }
+            final BlockState nativeState = platform.getAdapter().toNativeBlockState(block.toImmutableState());
+
+            player.connection.send(new ClientboundBlockUpdatePacket(loc, nativeState));
+
+            if (!(block instanceof final TileEntityBlock tileBlock)) {
+                return;
             }
+            final LinCompoundTag nbtData = tileBlock.getNbt();
+            if (nbtData == null || !(nativeState.getBlock() instanceof final EntityBlock entityBlock)) {
+                return;
+            }
+            final BlockEntity blockEntity = entityBlock.newBlockEntity(loc, nativeState);
+            if (blockEntity == null) {
+                return;
+            }
+            player.connection.send(AccessorClientboundBlockEntityDataPacket.create(
+                    loc,
+                    blockEntity.getType(),
+                    NBTConverter.toNative(nbtData)
+            ));
         }
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -924,7 +924,6 @@ public class LocalSession {
             }
             cuiTemporaryBlock = tempCuiTemporaryBlock;
             player.sendFakeBlock(cuiTemporaryBlock, block);
-            player.sendFakeOP();
         } else if (cuiTemporaryBlock != null) {
             // Remove the old block
             player.sendFakeBlock(cuiTemporaryBlock, null);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -924,6 +924,7 @@ public class LocalSession {
             }
             cuiTemporaryBlock = tempCuiTemporaryBlock;
             player.sendFakeBlock(cuiTemporaryBlock, block);
+            player.sendFakeOP();
         } else if (cuiTemporaryBlock != null) {
             // Remove the old block
             player.sendFakeBlock(cuiTemporaryBlock, null);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/entity/Player.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/entity/Player.java
@@ -322,11 +322,22 @@ public interface Player extends Entity, Actor {
      * Sends a fake block to the client.
      *
      * <p>
-     *     This block isn't real.
+     * This change is client-side only and will not actually change the world in any way.
      * </p>
      *
      * @param pos The position of the block
      * @param block The block to send, null to reset
      */
     <B extends BlockStateHolder<B>> void sendFakeBlock(BlockVector3 pos, @Nullable B block);
+
+    /**
+     * Make the client think it has operator status.
+     *
+     * <p>
+     * This change is client-side only and will not actually grant the player operator status.
+     * </p>
+     *
+     * @since TODO
+     */
+    void sendFakeOP();
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/entity/Player.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/entity/Player.java
@@ -329,15 +329,4 @@ public interface Player extends Entity, Actor {
      * @param block The block to send, null to reset
      */
     <B extends BlockStateHolder<B>> void sendFakeBlock(BlockVector3 pos, @Nullable B block);
-
-    /**
-     * Make the client think it has operator status.
-     *
-     * <p>
-     * This change is client-side only and will not actually grant the player operator status.
-     * </p>
-     *
-     * @since TODO
-     */
-    void sendFakeOP();
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
@@ -565,7 +565,6 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
 
     @Override
     public <B extends BlockStateHolder<B>> void sendFakeBlock(BlockVector3 pos, @Nullable B block) {
-
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
@@ -564,7 +564,12 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
     }
 
     @Override
-    public <B extends BlockStateHolder<B>> void sendFakeBlock(BlockVector3 pos, B block) {
+    public <B extends BlockStateHolder<B>> void sendFakeBlock(BlockVector3 pos, @Nullable B block) {
+
+    }
+
+    @Override
+    public void sendFakeOP() {
 
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
@@ -568,8 +568,4 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
 
     }
 
-    @Override
-    public void sendFakeOP() {
-
-    }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlayerProxy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlayerProxy.java
@@ -185,8 +185,13 @@ class PlayerProxy extends AbstractPlayerActor {
     }
 
     @Override
-    public <B extends BlockStateHolder<B>> void sendFakeBlock(BlockVector3 pos, B block) {
+    public <B extends BlockStateHolder<B>> void sendFakeBlock(BlockVector3 pos, @Nullable B block) {
         basePlayer.sendFakeBlock(pos, block);
+    }
+
+    @Override
+    public void sendFakeOP() {
+        basePlayer.sendFakeOP();
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlayerProxy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlayerProxy.java
@@ -190,11 +190,6 @@ class PlayerProxy extends AbstractPlayerActor {
     }
 
     @Override
-    public void sendFakeOP() {
-        basePlayer.sendFakeOP();
-    }
-
-    @Override
     public void floatAt(int x, int y, int z, boolean alwaysGlass) {
         basePlayer.floatAt(x, y, z, alwaysGlass);
     }

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongePlayer.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongePlayer.java
@@ -264,17 +264,17 @@ public class SpongePlayer extends AbstractPlayerActor {
             CompoundTag nativeNbtData = NbtAdapter.adaptNMSToWorldEdit(nbtData);
 
             SpongeLoggingProblemReporter.with(
-                    () -> "loading block entity for fake player " + player.uniqueId(),
-                    reporter -> {
-                        //noinspection DataFlowIssue
-                        nativeBlockEntity.loadWithComponents(
-                                TagValueInput.create(reporter, nativeBlockEntity.getLevel().registryAccess(), nativeNbtData)
-                        );
-                        return null;
-                    }
+                () -> "loading block entity for fake player " + player.uniqueId(),
+                reporter -> {
+                    //noinspection DataFlowIssue
+                    nativeBlockEntity.loadWithComponents(
+                        TagValueInput.create(reporter, nativeBlockEntity.getLevel().registryAccess(), nativeNbtData)
+                    );
+                    return null;
+                }
             );
             nativePlayer.connection.send(
-                    ClientboundBlockEntityDataPacket.create(nativeBlockEntity, (_, _) -> nativeNbtData)
+                ClientboundBlockEntityDataPacket.create(nativeBlockEntity, (_, _) -> nativeNbtData)
             );
         }
     }

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongePlayer.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongePlayer.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit.sponge;
 import com.sk89q.util.StringUtil;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.blocks.BaseItemStack;
+import com.sk89q.worldedit.blocks.TileEntityBlock;
 import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.extension.platform.AbstractPlayerActor;
 import com.sk89q.worldedit.extent.inventory.BlockBag;
@@ -34,7 +35,6 @@ import com.sk89q.worldedit.sponge.internal.SpongeLoggingProblemReporter;
 import com.sk89q.worldedit.util.HandSide;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.gamemode.GameMode;
 import com.sk89q.worldedit.world.gamemode.GameModes;
@@ -42,8 +42,10 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
-import net.minecraft.world.level.block.entity.StructureBlockEntity;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.storage.TagValueInput;
 import org.enginehub.linbus.tree.LinCompoundTag;
 import org.spongepowered.api.ResourceKey;
@@ -240,29 +242,40 @@ public class SpongePlayer extends AbstractPlayerActor {
         } else {
             BlockState spongeBlock = SpongeAdapter.adapt(block.toImmutableState());
             player.sendBlockChange(pos.x(), pos.y(), pos.z(), spongeBlock);
-            if (block instanceof final BaseBlock baseBlock
-                && block.getBlockType().equals(com.sk89q.worldedit.world.block.BlockTypes.STRUCTURE_BLOCK)) {
-                final LinCompoundTag nbtData = baseBlock.getNbt();
-                if (nbtData != null) {
-                    net.minecraft.world.level.block.state.BlockState nativeBlock =
-                        (net.minecraft.world.level.block.state.BlockState) spongeBlock;
-                    net.minecraft.nbt.CompoundTag nativeNbtData = NbtAdapter.adaptNMSToWorldEdit(nbtData);
-                    net.minecraft.server.level.ServerPlayer nativePlayer =
-                        ((net.minecraft.server.level.ServerPlayer) player);
 
-                    StructureBlockEntity structureBlockEntity =
-                        new StructureBlockEntity(new BlockPos(pos.x(), pos.y(), pos.z()), nativeBlock);
-                    SpongeLoggingProblemReporter.with(
-                        () -> "loading structure block entity for fake player " + player.uniqueId(),
-                        reporter -> {
-                            structureBlockEntity.loadWithComponents(TagValueInput.create(reporter, nativePlayer.level().registryAccess(), nativeNbtData));
-                            return null;
-                        }
-                    );
-                    nativePlayer.connection.send(
-                        ClientboundBlockEntityDataPacket.create(structureBlockEntity, (be, ra) -> nativeNbtData));
-                }
+            if (!(block instanceof TileEntityBlock tileEntityBlock)) {
+                return;
             }
+            final LinCompoundTag nbtData = tileEntityBlock.getNbt();
+            if (nbtData == null) {
+                return;
+            }
+            net.minecraft.world.level.block.state.BlockState nativeBlock =
+                    (net.minecraft.world.level.block.state.BlockState) spongeBlock;
+            if (!(nativeBlock.getBlock() instanceof EntityBlock nativeEntityBlock)) {
+                return;
+            }
+            BlockEntity nativeBlockEntity = nativeEntityBlock.newBlockEntity(new BlockPos(pos.x(), pos.y(), pos.z()), nativeBlock);
+            if (nativeBlockEntity == null) {
+                return;
+            }
+            net.minecraft.server.level.ServerPlayer nativePlayer = (net.minecraft.server.level.ServerPlayer) player;
+            nativeBlockEntity.setLevel(nativePlayer.level());
+            CompoundTag nativeNbtData = NbtAdapter.adaptNMSToWorldEdit(nbtData);
+
+            SpongeLoggingProblemReporter.with(
+                    () -> "loading block entity for fake player " + player.uniqueId(),
+                    reporter -> {
+                        //noinspection DataFlowIssue
+                        nativeBlockEntity.loadWithComponents(
+                                TagValueInput.create(reporter, nativeBlockEntity.getLevel().registryAccess(), nativeNbtData)
+                        );
+                        return null;
+                    }
+            );
+            nativePlayer.connection.send(
+                    ClientboundBlockEntityDataPacket.create(nativeBlockEntity, (_, _) -> nativeNbtData)
+            );
         }
     }
 

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongePlayer.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongePlayer.java
@@ -251,7 +251,7 @@ public class SpongePlayer extends AbstractPlayerActor {
                 return;
             }
             net.minecraft.world.level.block.state.BlockState nativeBlock =
-                    (net.minecraft.world.level.block.state.BlockState) spongeBlock;
+                (net.minecraft.world.level.block.state.BlockState) spongeBlock;
             if (!(nativeBlock.getBlock() instanceof EntityBlock nativeEntityBlock)) {
                 return;
             }


### PR DESCRIPTION
## Overview
This PR aims to improves the `Player#sendFakeBlock` implementation to support non structure-blocks (used by the CUI).

## Description
Replaces the structure block specific implementation with a generic implementation to allow API users to send fake blocks containing NBT such as player heads, banners etc.

## TODO
- [x] implement other platforms
- [x] fix breakage on spigot