### PR TITLE
Fix pistons breaking when head is replaced 

### DIFF
--- a/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcWorldNativeAccess.java
+++ b/worldedit-core-mc/src/main/java/com/sk89q/worldedit/coremc/internal/CoreMcWorldNativeAccess.java
@@ -166,7 +166,10 @@ public final class CoreMcWorldNativeAccess implements WorldNativeAccess<LevelChu
     @Override
     public void updateNeighbors(BlockPos pos, BlockState oldState, BlockState newState, int recursionLimit) {
         ServerLevel world = getWorld();
-        oldState.affectNeighborsAfterRemoval(world, pos, false);
+        boolean blockChanged = !oldState.is(newState.getBlock());
+        if (blockChanged) {
+            oldState.affectNeighborsAfterRemoval(world, pos, false);
+        }
         oldState.updateIndirectNeighbourShapes(world, pos, Block.UPDATE_CLIENTS, recursionLimit);
         newState.updateNeighbourShapes(world, pos, Block.UPDATE_CLIENTS, recursionLimit);
         newState.updateIndirectNeighbourShapes(world, pos, Block.UPDATE_CLIENTS, recursionLimit);


### PR DESCRIPTION
Fixes #2956 by adding a check for if the block was changed before calling `affectNeighborsAfterRemoval`